### PR TITLE
Fix the problem that evict-percent does not take effect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GO=env $(GO_ENV) $(GO_MODULE) go
 UNAME := $(shell uname)
 
 ifeq ($(BLADE_VERSION), )
-	BLADE_VERSION=0.5.1
+	BLADE_VERSION=0.6.0
 endif
 
 BUILD_TARGET=target

--- a/exec/model/controller.go
+++ b/exec/model/controller.go
@@ -117,7 +117,8 @@ func GetResourceCount(resourceCount int, flags map[string]string) (int, error) {
 			return 0, err
 		}
 	}
-	percentCount := resourceCount * percent
+
+	percentCount := int(math.Round(float64(percent) / 100.0 * float64(resourceCount)))
 	if count > percentCount {
 		count = percentCount
 	}

--- a/exec/model/controller_test.go
+++ b/exec/model/controller_test.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package model
+
+import (
+	"testing"
+)
+
+func TestGetResourceCount(t *testing.T) {
+	type args struct {
+		resourceCount int
+		flags         map[string]string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    int
+		wantErr bool
+	}{
+		{name: "evict-percent=0", args: args{10, map[string]string{"evict-count": "", "evict-percent": "0"}}, want: 0, wantErr: false},
+		{name: "evict-percent=10", args: args{10, map[string]string{"evict-count": "", "evict-percent": "10"}}, want: 1, wantErr: false},
+		{name: "evict-percent=55", args: args{10, map[string]string{"evict-count": "", "evict-percent": "55"}}, want: 6, wantErr: false},
+		{name: "evict-percent=100", args: args{10, map[string]string{"evict-count": "", "evict-percent": "100"}}, want: 10, wantErr: false},
+		{name: "evict-count=5,evict-percent==10", args: args{10, map[string]string{"evict-count": "5", "evict-percent": "10"}}, want: 1, wantErr: false},
+		{name: "evict-count=20", args: args{10, map[string]string{"evict-count": "20", "evict-percent": ""}}, want: 10, wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetResourceCount(tt.args.resourceCount, tt.args.flags)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetResourceCount() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetResourceCount() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/exec/node/controller.go
+++ b/exec/node/controller.go
@@ -53,7 +53,7 @@ func (e *ExpController) Create(ctx context.Context, expSpec v1alpha1.ExperimentS
 		return spec.ReturnFailWitResult(spec.Code[spec.IgnoreCode], err.Error(),
 			v1alpha1.CreateFailExperimentStatus(err.Error(), nil))
 	}
-	if len(nodes) == 0 {
+	if nodes == nil || len(nodes) == 0 {
 		return spec.ReturnFailWitResult(spec.Code[spec.IgnoreCode], err.Error(),
 			v1alpha1.CreateFailExperimentStatus("cannot find the target nodes", nil))
 	}

--- a/exec/pod/controller.go
+++ b/exec/pod/controller.go
@@ -52,7 +52,7 @@ func (e *ExpController) Create(ctx context.Context, expSpec v1alpha1.ExperimentS
 		return spec.ReturnFailWitResult(spec.Code[spec.IgnoreCode], err.Error(),
 			v1alpha1.CreateFailExperimentStatus(err.Error(), nil))
 	}
-	if len(pods) == 0 {
+	if pods == nil || len(pods) == 0 {
 		return spec.ReturnFailWitResult(spec.Code[spec.IgnoreCode], err.Error(),
 			v1alpha1.CreateFailExperimentStatus("cannot find the pods", nil))
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,8 @@ module github.com/chaosblade-io/chaosblade-operator
 
 require (
 	github.com/chaosblade-io/chaosblade-exec-docker v0.5.0
-	github.com/chaosblade-io/chaosblade-exec-os v0.5.0
-	github.com/chaosblade-io/chaosblade-spec-go v0.5.0
+	github.com/chaosblade-io/chaosblade-exec-os v0.5.1-0.20200305014825-c91a0ddb186a
+	github.com/chaosblade-io/chaosblade-spec-go v0.5.1-0.20200303014535-956c50c757eb
 	github.com/go-logr/logr v0.1.0
 	github.com/go-openapi/spec v0.19.0
 	github.com/google/martian v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/chaosblade-io/chaosblade-exec-os v0.4.1-0.20200110074748-6dcc3e972904
 github.com/chaosblade-io/chaosblade-exec-os v0.4.1-0.20200110074748-6dcc3e972904/go.mod h1:y1+wo+0IAjyHW6574WdT1Vwh2Jqe9pfdFNCZL14oVPE=
 github.com/chaosblade-io/chaosblade-exec-os v0.5.0 h1:aliw7vn+Au3dFuhz430/DGhZ4hjeGxDFOvw2UFmTuaI=
 github.com/chaosblade-io/chaosblade-exec-os v0.5.0/go.mod h1:0iAqL2POuj4fBp5JLI3ug/tWEpWEL7LSsuff3aQ3rZA=
+github.com/chaosblade-io/chaosblade-exec-os v0.5.1-0.20200305014825-c91a0ddb186a h1:/OgebD8oIkyoaxJTAZy3fVrfO0eoWwTcmCiVf6Vqf4U=
+github.com/chaosblade-io/chaosblade-exec-os v0.5.1-0.20200305014825-c91a0ddb186a/go.mod h1:JNAmMFc5RiMP7L1SwDse9QUaFuIkWwcD5UXeOMul754=
 github.com/chaosblade-io/chaosblade-operator v0.4.0/go.mod h1:FfFGwher7xuvU1yjIZzIViBq5svntfk8BDzy3TGjqI0=
 github.com/chaosblade-io/chaosblade-spec-go v0.0.1 h1:8Nch78qEYJLxW9Xd5pESSnLB1RCV4gMYgDnE7rlVgDs=
 github.com/chaosblade-io/chaosblade-spec-go v0.0.1/go.mod h1:ybcCsIX1wZtPrH0IsI28yDNJ+AVPeDMUZlgw1HE++Ds=
@@ -113,6 +115,8 @@ github.com/chaosblade-io/chaosblade-spec-go v0.4.1-0.20200110072855-4f767ce4e582
 github.com/chaosblade-io/chaosblade-spec-go v0.4.1-0.20200110072855-4f767ce4e582/go.mod h1:pNTL6HH4/ei+dshXnqxoNBUJ6jkDL+/7VYrobFVEyeQ=
 github.com/chaosblade-io/chaosblade-spec-go v0.5.0 h1:IcacKph5X7rgAA0d8d4Myh0ko3blXWKBg4jWnA4mH+E=
 github.com/chaosblade-io/chaosblade-spec-go v0.5.0/go.mod h1:pNTL6HH4/ei+dshXnqxoNBUJ6jkDL+/7VYrobFVEyeQ=
+github.com/chaosblade-io/chaosblade-spec-go v0.5.1-0.20200303014535-956c50c757eb h1:rAeJAuxWeKF6rOVmch7QTNno7FkN8cWhoC+MRZ6qE9I=
+github.com/chaosblade-io/chaosblade-spec-go v0.5.1-0.20200303014535-956c50c757eb/go.mod h1:pNTL6HH4/ei+dshXnqxoNBUJ6jkDL+/7VYrobFVEyeQ=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/containerd/cgroups v0.0.0-20190717030353-c4b9ac5c7601/go.mod h1:X9rLEHIqSf/wfK8NsPqxJmeZgW4pcfzdXITDrUSJ6uI=
 github.com/containerd/cgroups v0.0.0-20191011165608-5fbad35c2a7e/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=


### PR DESCRIPTION
Signed-off-by: xcaspar <x.caspar@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
See chaosblade-io/chaosblade#306

### Describe how you did it
1. Fix percentage calculation logic.
2：Use `math.Round` function to get the percentage count.
```
	percentCount := int(math.Round(float64(percent) / 100.0 * float64(resourceCount)))
	if count > percentCount {
		count = percentCount
	}
	if count > resourceCount {
		return resourceCount, nil
	}
	return count, nil
```

### Describe how to verify it
1. Add unit test.
2. Run the following command to test in kubernetes cluster:

Get the number of nodes.
```
kubectl get node 
NAME                        STATUS   ROLES    AGE    VERSION
cn-hangzhou.192.168.0.100   Ready    <none>   128d   v1.14.8-aliyun.1
cn-hangzhou.192.168.0.98    Ready    <none>   128d   v1.14.8-aliyun.1
cn-hangzhou.192.168.0.99    Ready    <none>   128d   v1.14.8-aliyun.1
```

Execute node CPU full load experiment.
```
blade c k8s node-cpu fullload --cpu-percent 50 --evict-percent 50 --kubeconfig ~/.kube/config
```

Command result:
```
"status": {
        "expStatuses": [
            {
                "action": "fullload",
                "resStatuses": [
                    {
                        "id": "e36e05842be587c3",
                        "kind": "node",
                        "name": "cn-hangzhou.192.168.0.100",
                        "nodeName": "cn-hangzhou.192.168.0.100",
                        "state": "Success",
                        "success": true,
                        "uid": "f3c72e00-f92c-11e9-b177-7e85fdbc41e3"
                    },
                    {
                        "id": "2adc0490c846c0e5",
                        "kind": "node",
                        "name": "cn-hangzhou.192.168.0.98",
                        "nodeName": "cn-hangzhou.192.168.0.98",
                        "state": "Success",
                        "success": true,
                        "uid": "f42d26fd-f92c-11e9-b177-7e85fdbc41e3"
                    }
                ],
                "scope": "node",
                "state": "Success",
                "success": true,
                "target": "cpu"
            }
        ],
        "phase": "Running"
    }
```

### Special notes for reviews
