### PR TITLE
parallelize exec command in matched pods

### DIFF
--- a/exec/model/parallelizer.go
+++ b/exec/model/parallelizer.go
@@ -1,0 +1,35 @@
+package model
+
+import "sync"
+
+const (
+	maxWorkers = 64 //magic number
+)
+
+type DoWorkFunc func(workID int)
+
+func ParallelizeExec(workCount int, doWork DoWorkFunc) {
+	workers := maxWorkers
+	toExec := make(chan int, workCount)
+
+	for i := 0; i < workCount; i++ {
+		toExec <- i
+	}
+	close(toExec)
+
+	if workCount < workers {
+		workers = workCount
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for workID := range toExec {
+				doWork(workID)
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
The execution in matched pods with low efficiency

### Does this pull request fix one issue?
https://github.com/chaosblade-io/chaosblade-operator/issues/77
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
1. parallelize exec commands in matched pods
2. set max parallel count 64

### Describe how to verify it
```
apiVersion: chaosblade.io/v1alpha1
kind: ChaosBlade
metadata:
  name: loss-pod-by-labels
spec:
  experiments:
  - scope: pod
    target: network
    action: loss
    desc: "node network loss"
    matchers:
    - name: labels
      value: ["app=nginx"]
    - name: namespace
      value: ["default"]
    - name: percent
      value: ["100"]
    - name: interface
      value: ["eth0"]
    - name: local-port
      value: ["80"]
```
![image](https://user-images.githubusercontent.com/5801931/118283428-ed8d7e80-b501-11eb-925f-741d35568e1e.png)
![image](https://user-images.githubusercontent.com/5801931/118283517-07c75c80-b502-11eb-9928-d24c3bde41b3.png)


### Special notes for reviews
