### PR TITLE
feature: expose chaosblade-tool daemonset yaml configuration

### DIFF
--- a/deploy/helm/chaosblade-operator-for-v2/templates/daemonset.yaml
+++ b/deploy/helm/chaosblade-operator-for-v2/templates/daemonset.yaml
@@ -1,0 +1,84 @@
+{{- if .Values.daemonset.enable }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: chaosblade-tool
+  labels:
+    name: chaosblade-tool
+    app: chaosblade-tool
+spec:
+  selector:
+    matchLabels:
+      name: chaosblade-tool
+      app: chaosblade-tool
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: chaosblade-tool
+        app: chaosblade-tool
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: type
+                    operator: NotIn
+                    values:
+                      - virtual-kubelet
+      containers:
+        - name: chaosblade-tool
+          image: {{ .Values.blade.repository }}:{{ .Values.blade.version }}
+          imagePullPolicy: {{ .Values.blade.pullPolicy }}
+          env:
+            - name: KUBERNETES_NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: DOCKER_API_VERSION
+              value: "1.14.0"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /var/run/docker.sock
+              name: docker-socket
+            - mountPath: /opt/chaosblade/chaosblade.dat
+              name: chaosblade-db-volume
+            - mountPath: /etc/hosts
+              name: hosts
+            - mountPath: /var/log/audit
+              name: audit
+            - mountPath: /var/lib/docker
+              name: docker-lib
+            - mountPath: /etc/docker
+              name: docker-etc
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      hostPID: true
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+      volumes:
+        - hostPath:
+            path: /var/run/docker.sock
+          name: docker-socket
+        - hostPath:
+            path: /var/run/chaosblade.dat
+            type: FileOrCreate
+          name: chaosblade-db-volume
+        - hostPath:
+            path: /etc/hosts
+          name: hosts
+        - hostPath:
+            path: /var/lib/docker
+          name: docker-lib
+        - hostPath:
+            path: /etc/docker
+          name: docker-etc
+        - hostPath:
+            path: /var/log/audit
+          name: audit
+      serviceAccountName: chaosblade
+{{- end }}

--- a/deploy/helm/chaosblade-operator-for-v3/templates/daemonset.yaml
+++ b/deploy/helm/chaosblade-operator-for-v3/templates/daemonset.yaml
@@ -1,0 +1,84 @@
+{{- if .Values.daemonset.enable }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: chaosblade-tool
+  labels:
+    name: chaosblade-tool
+    app: chaosblade-tool
+spec:
+  selector:
+    matchLabels:
+      name: chaosblade-tool
+      app: chaosblade-tool
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: chaosblade-tool
+        app: chaosblade-tool
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: type
+                    operator: NotIn
+                    values:
+                      - virtual-kubelet
+      containers:
+        - name: chaosblade-tool
+          image: {{ .Values.blade.repository }}:{{ .Values.blade.version }}
+          imagePullPolicy: {{ .Values.blade.pullPolicy }}
+          env:
+            - name: KUBERNETES_NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: DOCKER_API_VERSION
+              value: "1.14.0"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /var/run/docker.sock
+              name: docker-socket
+            - mountPath: /opt/chaosblade/chaosblade.dat
+              name: chaosblade-db-volume
+            - mountPath: /etc/hosts
+              name: hosts
+            - mountPath: /var/log/audit
+              name: audit
+            - mountPath: /var/lib/docker
+              name: docker-lib
+            - mountPath: /etc/docker
+              name: docker-etc
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      hostPID: true
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+      volumes:
+        - hostPath:
+            path: /var/run/docker.sock
+          name: docker-socket
+        - hostPath:
+            path: /var/run/chaosblade.dat
+            type: FileOrCreate
+          name: chaosblade-db-volume
+        - hostPath:
+            path: /etc/hosts
+          name: hosts
+        - hostPath:
+            path: /var/lib/docker
+          name: docker-lib
+        - hostPath:
+            path: /etc/docker
+          name: docker-etc
+        - hostPath:
+            path: /var/log/audit
+          name: audit
+      serviceAccountName: chaosblade
+{{- end }}

--- a/pkg/controller/chaosblade/controller.go
+++ b/pkg/controller/chaosblade/controller.go
@@ -20,12 +20,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 
-	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -94,16 +94,18 @@ func add(mgr manager.Manager, rcb *ReconcileChaosBlade) error {
 		return err
 	}
 	if chaosblade.DaemonsetEnable {
-		namespace, err := k8sutil.GetOperatorNamespace()
-		if err != nil {
-			return err
-		}
-		chaosblade.DaemonsetPodNamespace = namespace
-		// deploy chaosblade tool
-		if err := deployChaosBladeTool(rcb); err != nil {
-			logrus.WithField("product", version.Product).WithError(err).Errorln("Failed to deploy chaosblade tool")
-			return err
-		}
+		//namespace, err := k8sutil.GetOperatorNamespace()
+		//if err != nil {
+		//	return err
+		//}
+		//chaosblade.DaemonsetPodNamespace = namespace
+		//// deploy chaosblade tool
+		//if err := deployChaosBladeTool(rcb); err != nil {
+		//	logrus.WithField("product", version.Product).WithError(err).Errorln("Failed to deploy chaosblade tool")
+		//	return err
+		//}
+		logrus.WithField("product", version.Product).WithField("daemonset.enable", chaosblade.DaemonsetEnable).
+			Infoln("enable chaosblade-tool deamonset")
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: xcaspar <changjun.xcj@alibaba-inc.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
chaosblade-io/chaosblade#527


### Does this pull request fix one issue?

chaosblade-io/chaosblade#527

### Describe how you did it
Add chaosblade-tool daemonset yaml file. Use `daemonset.enable` flag to control the daemonset deployment.


### Describe how to verify it
Default deployment:
```
helmv3 install chaosblade-operator deploy/helm/chaosblade-operator-for-v3 --namespace chaosblade --set operator.repository=registry.cn-hangzhou.aliyuncs.com/ahas/chaosblade-operator,operator.version=1.3.0-dev 
```
![image](https://user-images.githubusercontent.com/3992234/124694366-b640ba00-df13-11eb-896f-d09fa1e172f6.png)

Disable daemonset deployment:
```
helmv3 install chaosblade-operator deploy/helm/chaosblade-operator-for-v3 --namespace chaosblade --set operator.repository=registry.cn-hangzhou.aliyuncs.com/ahas/chaosblade-operator,operator.version=1.3.0-dev,daemonset.enable=false
```
![image](https://user-images.githubusercontent.com/3992234/124694421-ceb0d480-df13-11eb-83b4-a2ae0571dbc1.png)


### Special notes for reviews
