### PR TITLE
feature: support download mode for deploying chaosblade tool to targe…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ endif
 
 build: build_yaml build_fuse
 
-build_all: build pre_chaosblade build_image
+build_all: pre_build pre_chaosblade build build_image
 
 build_image:
 	operator-sdk build --go-build-args="$(GO_FLAGS)" chaosblade-operator:${BLADE_VERSION}

--- a/channel/client.go
+++ b/channel/client.go
@@ -33,8 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-
-	"github.com/chaosblade-io/chaosblade-spec-go/spec"
 )
 
 // Client contains the kubernetes client, operator client and kubeconfig
@@ -131,7 +129,7 @@ func (c *Client) Exec(options *ExecOptions) interface{} {
 	}
 	if err != nil {
 		execLog.WithError(err).Errorln("Invoke exec command error")
-		return spec.ResponseFailWithFlags(spec.K8sExecFailed, "pods/exec", err)
+		return options.ErrDecoder([]byte(err.Error()))
 	}
 	if outMsg != "" {
 		execLog.Infof("get output message")
@@ -140,9 +138,8 @@ func (c *Client) Exec(options *ExecOptions) interface{} {
 	if options.IgnoreOutput {
 		return nil
 	}
-	return spec.ResponseFailWithFlags(spec.K8sExecFailed, "pods/exec",
-		fmt.Sprintf("cannot get output of pods/%s/exec, maybe kubelet cannot be accessed or container not found",
-			options.PodName))
+	return options.ErrDecoder([]byte(fmt.Sprintf("cannot get output of pods/%s/exec, maybe kubelet cannot be accessed or container not found",
+		options.PodName)))
 }
 
 // "172.21.1.11:8080/api/v1/namespaces/default/pods/my-nginx-3855515330-l1uqk/exec

--- a/deploy/helm/chaosblade-operator-for-v2/templates/deployment.yaml
+++ b/deploy/helm/chaosblade-operator-for-v2/templates/deployment.yaml
@@ -44,6 +44,9 @@ spec:
           {{- if .Values.remove.blade.interval }}
           - '--remove-blade-interval={{ .Values.remove.blade.interval }}'
           {{- end }}
+          {{- if .Values.blade.downloadUrl }}
+          - '--chaosblade-download-url={{ .Values.blade.downloadUrl }}'
+          {{- end }}
           imagePullPolicy: {{ .Values.operator.pullPolicy }}
           env:
             - name: WATCH_NAMESPACE

--- a/deploy/helm/chaosblade-operator-for-v2/values.yaml
+++ b/deploy/helm/chaosblade-operator-for-v2/values.yaml
@@ -13,6 +13,7 @@ blade:
   repository: chaosbladeio/chaosblade-tool
   version: 1.2.0
   pullPolicy: IfNotPresent
+  downloadUrl: ""
 
 env:
   logLevel: info

--- a/deploy/helm/chaosblade-operator-for-v3/templates/deployment.yaml
+++ b/deploy/helm/chaosblade-operator-for-v3/templates/deployment.yaml
@@ -44,6 +44,9 @@ spec:
           {{- if .Values.remove.blade.interval }}
           - '--remove-blade-interval={{ .Values.remove.blade.interval }}'
           {{- end }}
+          {{- if .Values.blade.downloadUrl }}
+          - '--chaosblade-download-url={{ .Values.blade.downloadUrl }}'
+          {{- end }}
           imagePullPolicy: {{ .Values.operator.pullPolicy }}
           env:
             - name: WATCH_NAMESPACE

--- a/deploy/helm/chaosblade-operator-for-v3/values.yaml
+++ b/deploy/helm/chaosblade-operator-for-v3/values.yaml
@@ -14,6 +14,7 @@ blade:
   repository: chaosbladeio/chaosblade-tool
   version: 1.2.0
   pullPolicy: IfNotPresent
+  downloadUrl: ""
 
 env:
   logLevel: info

--- a/exec/container/controller.go
+++ b/exec/container/controller.go
@@ -189,5 +189,5 @@ func getMatchedContainerMetaList(pods []v1.Pod, containerIdsValue, containerName
 			})
 		}
 	}
-	return containerObjectMetaList, nil
+	return containerObjectMetaList, spec.Success()
 }

--- a/exec/model/deploy.go
+++ b/exec/model/deploy.go
@@ -1,0 +1,66 @@
+package model
+
+import (
+	"fmt"
+
+	"github.com/chaosblade-io/chaosblade-operator/channel"
+)
+
+type DeployMode interface {
+	DeployToPod(experimentId, src, dest string) error
+}
+
+type DeployOptions struct {
+	Container string
+	Namespace string
+	PodName   string
+	client    *channel.Client
+}
+
+// CheckFileExists return nil if dest file exists
+func (o *DeployOptions) CheckFileExists(dest string) error {
+	options := &channel.ExecOptions{
+		StreamOptions: channel.StreamOptions{
+			ErrDecoder: func(bytes []byte) interface{} {
+				return fmt.Errorf(string(bytes))
+			},
+			OutDecoder: func(bytes []byte) interface{} {
+				return nil
+			},
+		},
+		PodNamespace:  o.Namespace,
+		PodName:       o.PodName,
+		ContainerName: o.Container,
+		Command:       []string{"test", "-e", dest},
+		IgnoreOutput:  true,
+	}
+	if err := o.client.Exec(options); err != nil {
+		return err.(error)
+	}
+	return nil
+}
+
+func (o *DeployOptions) CreateDir(dir string) error {
+	if len(dir) == 0 {
+		return fmt.Errorf("illegal directory name")
+	}
+	options := &channel.ExecOptions{
+		StreamOptions: channel.StreamOptions{
+			ErrDecoder: func(bytes []byte) interface{} {
+				return fmt.Errorf(string(bytes))
+			},
+			OutDecoder: func(bytes []byte) interface{} {
+				return nil
+			},
+		},
+		PodName:       o.PodName,
+		PodNamespace:  o.Namespace,
+		ContainerName: o.Container,
+		Command:       []string{"mkdir", "-p", dir},
+		IgnoreOutput:  true,
+	}
+	if err := o.client.Exec(options); err != nil {
+		return err.(error)
+	}
+	return nil
+}

--- a/exec/model/download.go
+++ b/exec/model/download.go
@@ -1,0 +1,132 @@
+package model
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/chaosblade-io/chaosblade-operator/channel"
+	"github.com/chaosblade-io/chaosblade-operator/pkg/runtime/chaosblade"
+)
+
+/*
+.
+├── bin
+├── blade
+├── lib.tar.gz
+└── yaml.tar.gz
+*/
+
+const bin = "bin"
+const blade = "blade"
+const lib = "lib.tar.gz"
+const yaml = "yaml.tar.gz"
+
+type DownloadOptions struct {
+	DeployOptions
+	url string
+}
+
+func (d *DownloadOptions) DeployToPod(experimentId, src, dest string) error {
+	if len(src) == 0 {
+		return errors.New("the chaosblade downloaded address is empty")
+	}
+	url := d.getUrl(src)
+	// code=$( curl -s -L -w %{http_code} -o /opt/yaml.tar.gz https://xxx/temp/yaml.tar.gz ) && [ $code = 200 ] && tar -zxf /opt/yaml.tar.gz -C /opt && echo $code || echo $code
+	var command []string
+	isTarFile := strings.HasSuffix(url, "tar.gz")
+	if isTarFile {
+		dest = fmt.Sprintf("%s.%s", dest, "tar.gz")
+	}
+	command = []string{"curl", "-s", "-L", "-w", "%{http_code}", "-o", dest, url}
+	options := &channel.ExecOptions{
+		StreamOptions: channel.StreamOptions{
+			ErrDecoder: func(bytes []byte) interface{} {
+				return string(bytes)
+			},
+			OutDecoder: func(bytes []byte) interface{} {
+				return string(bytes)
+			},
+		},
+		PodNamespace:  d.Namespace,
+		PodName:       d.PodName,
+		ContainerName: d.Container,
+		Command:       command,
+		IgnoreOutput:  false,
+	}
+	statusCode := d.client.Exec(options).(string)
+	logrus.WithFields(
+		logrus.Fields{
+			"experimentId": experimentId,
+			"pod":          d.PodName,
+			"container":    d.Container,
+			"command":      command,
+			"result":       statusCode,
+		}).Infof("download to the target container")
+	code, err := strconv.Atoi(strings.TrimSpace(statusCode))
+	if err != nil {
+		return errors.New(statusCode)
+	}
+	if code != 200 {
+		return fmt.Errorf("response code is %d", code)
+	}
+	if isTarFile {
+		return d.uncompress(experimentId, dest)
+	}
+	return nil
+}
+
+func (d *DownloadOptions) uncompress(experimentId, file string) error {
+	dir := path.Dir(file)
+	command := []string{"/bin/sh", "-c", fmt.Sprintf("tar -zxf %s -C %s && chmod -R 755 %s", file, dir, dir)}
+	options := &channel.ExecOptions{
+		StreamOptions: channel.StreamOptions{
+			ErrDecoder: func(bytes []byte) interface{} {
+				return string(bytes)
+			},
+			OutDecoder: func(bytes []byte) interface{} {
+				return string(bytes)
+			},
+		},
+		PodNamespace:  d.Namespace,
+		PodName:       d.PodName,
+		ContainerName: d.Container,
+		Command:       command,
+		IgnoreOutput:  true,
+	}
+	error := d.client.Exec(options)
+	logrus.WithFields(
+		logrus.Fields{
+			"experimentId": experimentId,
+			"pod":          d.PodName,
+			"container":    d.Container,
+			"command":      command,
+			"result":       error,
+		}).Infof("uncompress in the target container")
+	if error == nil {
+		return nil
+	}
+	return errors.New(error.(string))
+}
+
+func (d *DownloadOptions) getUrl(srcFile string) string {
+	var obj = srcFile
+	switch srcFile {
+	case chaosblade.OperatorChaosBladeBlade:
+		obj = blade
+		break
+	case chaosblade.OperatorChaosBladeYaml:
+		obj = yaml
+		break
+	case chaosblade.OperatorChaosBladeLib:
+		obj = lib
+		break
+	default:
+		obj = strings.TrimPrefix(srcFile, chaosblade.OperatorChaosBladePath+"/")
+	}
+	return fmt.Sprintf("%s/%s", d.url, obj)
+}

--- a/exec/model/model.go
+++ b/exec/model/model.go
@@ -174,6 +174,19 @@ var ChaosBladePathFlag = &spec.ExpFlag{
 	Desc: "Chaosblade tool deployment path, default value is /opt. Please select a path with write permission",
 }
 
+var ChaosBladeDownloadUrlFlag = &spec.ExpFlag{
+	Name: "chaosblade-download-url",
+	Desc: "The chaosblade downloaded address. If you use download deployment mode, you must specify the value, or config chaosblade-download-url when deploying the operator",
+}
+
+var DownloadMode = "download"
+var CopyMode = "copy"
+
+var ChaosBladeDeployModeFlag = &spec.ExpFlag{
+	Name: "chaosblade-deploy-mode",
+	Desc: "The mode of chaosblade deployment in container, the values are copy and download, the default value is copy which copy tool from the operator to the target container. If you select download mode, the operator will download chaosblade tool from the chaosblade-download-url.",
+}
+
 func GetContainerFlags() []spec.ExpFlagSpec {
 	return []spec.ExpFlagSpec{
 		ContainerIdsFlag,
@@ -195,6 +208,8 @@ func GetChaosBladeFlags() []spec.ExpFlagSpec {
 	return []spec.ExpFlagSpec{
 		ChaosBladePathFlag,
 		exec.ChaosBladeOverrideFlag,
+		ChaosBladeDeployModeFlag,
+		ChaosBladeDownloadUrlFlag,
 	}
 }
 
@@ -210,6 +225,8 @@ func GetResourceFlagNames() map[string]spec.Empty {
 		ContainerIndexFlag.Name,
 		ChaosBladePathFlag.Name,
 		exec.ChaosBladeOverrideFlag.Name,
+		ChaosBladeDeployModeFlag.Name,
+		ChaosBladeDownloadUrlFlag.Name,
 	}
 	names := make(map[string]spec.Empty, 0)
 	for _, name := range flagNames {

--- a/pkg/runtime/chaosblade/chaosblade.go
+++ b/pkg/runtime/chaosblade/chaosblade.go
@@ -28,6 +28,7 @@ var (
 	PullPolicy          string
 	DaemonsetEnable     bool
 	RemoveBladeInterval string
+	DownloadUrl         string
 )
 
 const (
@@ -67,6 +68,7 @@ func init() {
 	f.StringVar(&PullPolicy, "chaosblade-image-pull-policy", "IfNotPresent", "Pulling policy of chaosblade image, default value is IfNotPresent.")
 	f.BoolVar(&DaemonsetEnable, "daemonset-enable", false, "Deploy chaosblade daemonset to resolve chaos experiment environment of network, default value is false.")
 	f.StringVar(&RemoveBladeInterval, "remove-blade-interval", DefaultRemoveBladeInterval, "Periodically clean up blade state is destroying, default value is 24h.")
+	f.StringVar(&DownloadUrl, "chaosblade-download-url", "", "The chaosblade downloaded address which works when the chaosblade is deployed in download mode.")
 }
 
 func FlagSet() *pflag.FlagSet {


### PR DESCRIPTION
…t container

Signed-off-by: xcaspar <changjun.xcj@alibaba-inc.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it


### Does this pull request fix one issue?
chaosblade-io/chaosblade#553
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
1. Add `chaosblade-deploy-mode` flag to specify deployment mode, default value is `copy`, which is copied from the operator container to the target container. Another value is `download`, which is downloaded chaosblade tool from the remote address.
2. Add `chaosblade-download-url` flag to config the chaosblade downloaded url. You can also specify the `blade.downloadUrl` config when installing chaosblade-operator, such as `--set blade.downloadUrl=https://chaosblade.oss-xxxx.aliyuncs.com/agent/github/1.3.0`.  Under this address, the following files must be included:
```
.
├── bin
├── blade
├── lib.tar.gz
└── yaml.tar.gz
```
* bin: The directory where the os experiments file is located.
* blade: Chaoblade CLI.
* lib.tar.gz: lib package file.
* yaml.tar.gz: yaml package file.

### Describe how to verify it
```
blade c k8s pod-cpu fullload --chaosblade-deploy-mode download --chaosblade-download-url https://chaosblade.oss-xxx.aliyuncs.com/agent/github/1.3.0 --names logtail-ds-gzd72 --namespace kube-system -d --kubeconfig ~/.kube/config                     
{"code":200,"success":true,"result":"dcdf0a13814fcacc"}
```
Or using `blade.downloadUrl` to specify the download url when installing the operator.
```
helm install chaosblade-operator deploy/helm/chaosblade-operator-for-v3 --namespace chaosblade --set blade.downloadUrl=https://chaosblade.oss-xxxxx.aliyuncs.com/agent/github/1.3.0 
```

Then you can create experiment without `chaosblade-download-url`, such as:
```
blade c k8s pod-cpu fullload --chaosblade-deploy-mode download --names logtail-ds-gzd72 --namespace kube-system -d --kubeconfig ~/.kube/config  
{"code":200,"success":true,"result":"3be6ebb2625f792e"}
```

You can also add `--chaosblade-override` flag to update chaosblade tool in the target container.

### Special notes for reviews
