### PR TITLE
feature: add is-docker-network flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GO=env $(GO_ENV) $(GO_MODULE) go
 UNAME := $(shell uname)
 
 ifeq ($(BLADE_VERSION), )
-	BLADE_VERSION=1.3.0
+	BLADE_VERSION=1.4.0
 endif
 ifeq ($(BLADE_VENDOR), )
 	BLADE_VENDOR=community

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.8 as builder
 ENV OPERATOR=/usr/local/bin/chaosblade-operator
 COPY build/_output/bin/chaosblade-operator /usr/local/bin/
 
-FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/chaosblade-operator \
     CHAOSBLADE_HOME=/opt/chaosblade

--- a/exec/container/container.go
+++ b/exec/container/container.go
@@ -276,5 +276,6 @@ func getResourceFlags() []spec.ExpFlagSpec {
 	commonFlags := model.GetResourceCommonFlags()
 	containerFlags := model.GetContainerFlags()
 	chaosbladeFlags := model.GetChaosBladeFlags()
-	return append(append(append(coverageFlags, commonFlags...), containerFlags...), chaosbladeFlags...)
+	networkFlags := model.GetNetworkFlags()
+	return append(append(append(append(coverageFlags, commonFlags...), containerFlags...), chaosbladeFlags...), networkFlags...)
 }

--- a/exec/model/download.go
+++ b/exec/model/download.go
@@ -42,7 +42,7 @@ func (d *DownloadOptions) DeployToPod(experimentId, src, dest string) error {
 	if isTarFile {
 		dest = fmt.Sprintf("%s.%s", dest, "tar.gz")
 	}
-	command = []string{"curl", "-s", "-L", "-w", "%{http_code}", "-o", dest, url}
+	command = []string{"sh", "-c", "curl -s -L -w %{http_code} " + fmt.Sprintf("-o %s %s && chmod 755 %s", dest, url, dest)}
 	options := &channel.ExecOptions{
 		StreamOptions: channel.StreamOptions{
 			ErrDecoder: func(bytes []byte) interface{} {

--- a/exec/model/model.go
+++ b/exec/model/model.go
@@ -187,6 +187,19 @@ var ChaosBladeDeployModeFlag = &spec.ExpFlag{
 	Desc: "The mode of chaosblade deployment in container, the values are copy and download, the default value is copy which copy tool from the operator to the target container. If you select download mode, the operator will download chaosblade tool from the chaosblade-download-url.",
 }
 
+var IsDockerNetworkFlag = &spec.ExpFlag{
+	Name:     "is-docker-network",
+	Desc:     "Used when a docker container is used and there is no tc command in the target container",
+	NoArgs:   true,
+	Required: false,
+}
+
+func GetNetworkFlags() []spec.ExpFlagSpec {
+	return []spec.ExpFlagSpec{
+		IsDockerNetworkFlag,
+	}
+}
+
 func GetContainerFlags() []spec.ExpFlagSpec {
 	return []spec.ExpFlagSpec{
 		ContainerIdsFlag,
@@ -227,6 +240,7 @@ func GetResourceFlagNames() map[string]spec.Empty {
 		exec.ChaosBladeOverrideFlag.Name,
 		ChaosBladeDeployModeFlag.Name,
 		ChaosBladeDownloadUrlFlag.Name,
+		IsDockerNetworkFlag.Name,
 	}
 	names := make(map[string]spec.Empty, 0)
 	for _, name := range flagNames {


### PR DESCRIPTION
Signed-off-by: xcaspar <changjun.xcj@alibaba-inc.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
1. `daemonset.enable` should not control how the container network scenario is implemented.
2. The sidecar implementation currently only supports docker containers.
3. Only used when the tc command does not exist in the target container.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Add `is-docker-network` flag to active sidecar implementation.


### Describe how to verify it


### Special notes for reviews
