### PR TITLE
chore: fix package install in image build Dockerfile.

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,7 +12,8 @@ COPY --from=builder ${OPERATOR} /usr/local/bin/
 COPY build/cache/chaosblade ${CHAOSBLADE_HOME}
 COPY build/bin /usr/local/bin
 
-RUN yum install net-tools -y
+# 安装 ps 命令和 netstat 工具
+RUN microdnf install procps net-tools
 RUN /usr/local/bin/user_setup
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
1. runtime image still use redhat ubi7/ubi-minimal so that installing ps and netstat by using microdnf, a package manager in redhat ubi image instead of yum.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
