### PR TITLE
fix: kill k8s pod with multi labels not work

### DIFF
--- a/exec/model/filter_pod.go
+++ b/exec/model/filter_pod.go
@@ -111,7 +111,7 @@ func (b *BaseExperimentController) filterByOtherFlags(pods []v1.Pod, flags map[s
 var resourceFunc = func(ctx context.Context, client2 *channel.Client, flags map[string]string) ([]v1.Pod, *spec.Response) {
 	namespace := flags[ResourceNamespaceFlag.Name]
 	labels := flags[ResourceLabelsFlag.Name]
-	labelsMap := ParseLabels(labels)
+	requirements := ParseLabels(labels)
 	logrusField := logrus.WithField("experiment", GetExperimentIdFromContext(ctx))
 	pods := make([]v1.Pod, 0)
 	names := flags[ResourceNamesFlag.Name]
@@ -124,7 +124,7 @@ var resourceFunc = func(ctx context.Context, client2 *channel.Client, flags map[
 				logrusField.Warningf("can not find the pod by %s name in %s namespace, %v", name, namespace, err)
 				continue
 			}
-			if MapContains(pod.Labels, labelsMap) {
+			if MapContains(pod.Labels, requirements) {
 				pods = append(pods, pod)
 			}
 		}
@@ -134,14 +134,15 @@ var resourceFunc = func(ctx context.Context, client2 *channel.Client, flags map[
 		}
 		return pods, spec.Success()
 	}
-	if labels != "" && len(labelsMap) == 0 {
+	if labels != "" && len(requirements) == 0 {
 		msg := spec.ParameterIllegal.Sprintf(ResourceLabelsFlag.Name, labels, "data format error")
 		logrusField.Warningln(msg)
 		return pods, spec.ResponseFailWithFlags(spec.ParameterLess, ResourceLabelsFlag.Name, labels, "data format error, example: key=value")
 	}
-	if len(labelsMap) > 0 {
+	if len(requirements) > 0 {
 		podList := v1.PodList{}
-		opts := client.ListOptions{Namespace: namespace, LabelSelector: pkglabels.SelectorFromSet(labelsMap)}
+		selector := pkglabels.NewSelector().Add(requirements...)
+		opts := client.ListOptions{Namespace: namespace, LabelSelector: selector}
 		err := client2.List(context.TODO(), &podList, &opts)
 		if err != nil {
 			return pods, spec.ResponseFailWithFlags(spec.K8sExecFailed, "PodList", err)


### PR DESCRIPTION
Signed-off-by: Icesource <gonghuajian.ghj@alibaba-inc.com>

### Describe what this PR does / why we need it

Fix https://github.com/chaosblade-io/chaosblade/issues/770

### Does this pull request fix one issue?

Fixes https://github.com/chaosblade-io/chaosblade/issues/770

### Describe how you did it

之前，匹配用的 标签都保存在一个Map中，这会导致如果指定了同key的多个标签，后来的value会覆盖原来的value。
例如，指定 app=a , app=b ，那么只有app=b会 生效

修改为直接使用 labels.Requirement 保存标签可以做到不覆盖，且可调用Selector.In来实现多个value值的或匹配


### Describe how to verify it

修改代码后使用以下pod进行验证
```
default       my-nginx-deployment-586df48455-c5str                       1/1     Running                  0          7m50s   app=mynginx,pod-template-hash=586df48455
default       my-nginx-deployment-586df48455-jlkmn                       1/1     Running                  0          14m     app=mynginx,pod-template-hash=586df48455
default       my2-nginx-deployment-6c67c949d9-kmzgw                      1/1     Running                  0          3d17h   app=mynginx2,pod-template-hash=6c67c949d9
default       my2-nginx-deployment-6c67c949d9-w66hf                      1/1     Running                  0          3d18h   app=mynginx2,pod-template-hash=6c67c949d9
default       nginx-deployment-66b6c48dd5-4khhx                          0/1     ContainerStatusUnknown   1          15d     app=nginx,pod-template-hash=66b6c48dd5
default       nginx-deployment-66b6c48dd5-8jvvr                          1/1     Running                  0          14m     app=nginx,pod-template-hash=66b6c48dd5
default       nginx-deployment-66b6c48dd5-q92jr                          1/1     Running                  0          14m     app=nginx,pod-template-hash=66b6c48dd5
```

以delete_pod为例
指定标签
```
- name: labels
      value:
      - "app=nginx"
      - "app=mynginx"
```
可以删除标签nginx和mynginx下的所有的pod

同时指定name和标签，如果name能匹配上任意一个标签，那么删除该name的pod，如果所有标签都没匹配上，则不删除
***

例如指定的pod没有匹配上任意对应的标签
```
    - name: names
      value:
      - "my-nginx-deployment-586df48455-c5str"
    - name: labels
      value:
      - "app=nginx2"
      - "app=mynginx2"
```
该pod不会被删除

***

例如，指定的pod匹配上了标签中的app=nginx标签
```
    - name: names
      value:
      - "my-nginx-deployment-586df48455-c5str"
    - name: labels
      value:
      - "app=nginx"
      - "app=mynginx2"
```
该pod会被删除

