### PR TITLE
fix:avoid duplicate deletion of experiment

### DIFF
--- a/exec/model/executor.go
+++ b/exec/model/executor.go
@@ -30,6 +30,7 @@ import (
 	"github.com/chaosblade-io/chaosblade-exec-cri/exec/container"
 	"github.com/chaosblade-io/chaosblade-spec-go/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
 	"github.com/sirupsen/logrus"
@@ -114,8 +115,24 @@ func checkExperimentStatus(ctx context.Context, expModel *spec.ExpModel, statuse
 
 					if isDestroyed {
 						logrus.Info("The experiment was destroyed, ExperimentId: ", experimentId)
+						cb := &v1alpha1.ChaosBlade{}
+						err := client.Client.Get(context.TODO(), types.NamespacedName{Name: experimentId}, cb)
+						if err != nil {
+							logrus.Warn(err.Error())
+							continue
+						}
+
+						if cb.Status.Phase != v1alpha1.ClusterPhaseDestroyed {
+							cb.Status.Phase = v1alpha1.ClusterPhaseDestroyed
+							err = client.Client.Status().Update(context.TODO(), cb)
+							if err != nil {
+								logrus.Warn(err.Error())
+							}
+							continue
+						}
+
 						objectMeta := metav1.ObjectMeta{Name: experimentId}
-						err :=  client.Client.Delete(context.TODO(), &v1alpha1.ChaosBlade{
+						err = client.Client.Delete(context.TODO(), &v1alpha1.ChaosBlade{
 							TypeMeta: metav1.TypeMeta{
 								APIVersion: "chaosbladio/v1alpha1",
 								Kind:       "ChaosBlade",


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Change status.phase of chaosblade to 'Destroyed' when the experiment was destroyed,and therefore operator will not only delete CR of chaoblade,but avoid actually destroying experiment for the second time as well.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #203 
### Describe how you did it


### Describe how to verify it


### Special notes for reviews
