### PR TITLE
fix issue 902: chaosblade operator match containerId

### DIFF
--- a/exec/container/controller.go
+++ b/exec/container/controller.go
@@ -26,7 +26,7 @@ import (
 	"github.com/chaosblade-io/chaosblade-exec-cri/exec/container"
 	"github.com/chaosblade-io/chaosblade-spec-go/util"
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
 
@@ -161,7 +161,7 @@ func getMatchedContainerMetaList(pods []v1.Pod, containerIdsValue, containerName
 					if expectedContainerId == "" {
 						continue
 					}
-					if strings.HasPrefix(containerId, expectedContainerId) {
+					if strings.HasPrefix(expectedContainerId, containerId) {
 						if containerStatusErr != nil {
 							return containerObjectMetaList, spec.ResponseFailWithFlags(spec.ParameterInvalid,
 								model.ContainerIdsFlag.Name, expectedContainerId,

--- a/exec/model/executor_copy.go
+++ b/exec/model/executor_copy.go
@@ -19,6 +19,9 @@ package model
 import (
 	"context"
 	"fmt"
+	"path"
+	"sync"
+
 	"github.com/chaosblade-io/chaosblade-exec-cri/exec/container"
 	"github.com/chaosblade-io/chaosblade-operator/channel"
 	"github.com/chaosblade-io/chaosblade-operator/pkg/apis/chaosblade/v1alpha1"
@@ -30,8 +33,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"path"
-	"sync"
 )
 
 type ExperimentIdentifierInPod struct {


### PR DESCRIPTION
Remove unnessesary docker container id truncation, if user input a long container id, we can correctly match them.

Fix issue: https://github.com/chaosblade-io/chaosblade/issues/902