### PR TITLE
fix: DNS Action Destroy Failed

### DIFF
--- a/exec/model/executor_nsexec.go
+++ b/exec/model/executor_nsexec.go
@@ -171,7 +171,7 @@ func getExperimentIdentifiersWithNsexec(ctx context.Context, expModel *spec.ExpM
 	identifiers := make([]ExperimentIdentifierInPod, 0)
 	for idx, obj := range containerObjectMetaList {
 		var generatedCommand string
-		if expModel.Target == "network" && handle == "destroy" {
+		if expModel.Target == "network" && handle == "destroy" && expModel.ActionName != "dns" {
 			labels := []string{
 				fmt.Sprintf("io.kubernetes.pod.name=%s", obj.PodName),
 				fmt.Sprintf("io.kubernetes.pod.namespace=%s", obj.Namespace),


### PR DESCRIPTION
## Describe what this PR does / why we need it
fix DNS Action Destroy Failed

## Does this pull request fix one issue?
Fixes [#962](https://github.com/chaosblade-io/chaosblade/issues/962)

## Describe how you did it
Filter containers by labels when cri network target is destroyed

## Describe how to verify it
When the CRI network fails and is destroyed, the POD is filtered through the sandbox. This is to prevent the name of the POD from changing after it is restarted. However, the DNS scene will not be restarted, which will cause the DNS scene to fail to be destroyed.
