### PR TITLE
fix: wrong docker image tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,23 +37,23 @@ build_all: pre_build build docker-build
 
 docker-build:
 	GOOS="linux" GOARCH="amd64" go build $(GO_FLAGS) -o build/_output/bin/chaosblade-operator cmd/manager/main.go
-	docker build -f build/image/amd/Dockerfile -t ghcr.io/chaosbladeio/chaosblade-operator:${BLADE_VERSION} .
+	docker buildx build -f build/image/amd/Dockerfile --platform=linux/amd64 -t ghcr.io/chaosblade-io/chaosblade-operator:${BLADE_VERSION} .
 
 docker-build-arm64:
 	GOOS="linux" GOARCH="arm64" go build $(GO_FLAGS) -o build/_output/bin/chaosblade-operator cmd/manager/main.go
-	docker buildx  build -f build/image/arm/Dockerfile  --platform=linux/arm64  -t ghcr.io/chaosbladeio/chaosblade-operator-arm64:${BLADE_VERSION} .
+	docker buildx build -f build/image/arm/Dockerfile  --platform=linux/arm64  -t ghcr.io/chaosblade-io/chaosblade-operator-arm64:${BLADE_VERSION} .
 
 push_image:
-	docker push ghcr.io/chaosbladeio/chaosblade-operator:${BLADE_VERSION}
-	docker push ghcr.io/chaosbladeio/chaosblade-operator-arm64:${BLADE_VERSION}
+	docker push ghcr.io/chaosblade-io/chaosblade-operator:${BLADE_VERSION}
+	docker push ghcr.io/chaosblade-io/chaosblade-operator-arm64:${BLADE_VERSION}
 
 #operator-sdk 0.19.0 build
 build_all_operator: pre_build build build_image
 build_image:
-	operator-sdk build --go-build-args="$(GO_FLAGS)" ghcr.io/chaosbladeio/chaosblade-operator:${BLADE_VERSION}
+	operator-sdk build --go-build-args="$(GO_FLAGS)" ghcr.io/chaosblade-io/chaosblade-operator:${BLADE_VERSION}
 
 build_image_arm64:
-	GOOS="linux" GOARCH="arm64" operator-sdk build --go-build-args="$(GO_FLAGS)" ghcr.io/chaosbladeio/chaosblade-operator-arm64:${BLADE_VERSION}
+	GOOS="linux" GOARCH="arm64" operator-sdk build --go-build-args="$(GO_FLAGS)" ghcr.io/chaosblade-io/chaosblade-operator-arm64:${BLADE_VERSION}
 
 # only build_fuse and yaml
 build_linux:
@@ -70,7 +70,7 @@ build_arm64:
 		-v $(shell echo -n ${GOPATH}):/go \
 		-v $(shell pwd):/go/src/github.com/chaosblade-io/chaosblade-operator \
 		-w /go/src/github.com/chaosblade-io/chaosblade-operator \
-		chaosbladeio/chaosblade-build-arm:latest
+		chaosblade-io/chaosblade-build-arm:latest
 
 pre_build:
 	mkdir -p $(BUILD_TARGET_BIN) $(BUILD_TARGET_YAML)


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Image tags in makefile are wrong. 

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

NONE.

### Describe how you did it

![image](https://github.com/chaosblade-io/chaosblade-operator/assets/29922079/ed6223c8-ec03-47f6-8f60-13c806656cd4)

![image](https://github.com/chaosblade-io/chaosblade-operator/assets/29922079/d0d6f769-ab62-4893-b236-0832271e01cb)


Replace all `chaosbladeio` with `chaosblade-io` of image tags.

### Describe how to verify it


### Special notes for reviews
