### PR TITLE
feat: filter out terminating pods from the pod list to inject exps

### DIFF
--- a/exec/model/filter_pod.go
+++ b/exec/model/filter_pod.go
@@ -155,7 +155,14 @@ var resourceFunc = func(ctx context.Context, client2 *channel.Client, flags map[
 		if len(podList.Items) == 0 {
 			return pods, spec.ResponseFailWithFlags(spec.ParameterInvalidK8sPodQuery, ResourceLabelsFlag.Name)
 		}
-		pods = podList.Items
+		// filter out running but TERMINATING pods
+		for _, p := range podList.Items {
+			if p.ObjectMeta.DeletionTimestamp != nil {
+				logrusField.Debugf("the pod is being deleted: %s", p.Name)
+				continue
+			}
+			pods = append(pods, p)
+		}
 		logrusField.Infof("get pods by labels %s, len is %d", labels, len(pods))
 	}
 	return pods, spec.Success()


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Filter out TERMINATING pods(which have `deletionTimestamp`) before injecting chaos exp.

### Does this pull request fix one issue?

RESOLVE https://github.com/chaosblade-io/chaosblade/issues/1168

### Describe how to verify it

The `chaosblade-operator` currently lacks the conditions to write tests. But I have applied this patch in the PROD env of my team and served 200+ apps for experiments since 03/2025.

