### PR TITLE
fix: unify biz to destroy network exp

### DIFF
--- a/exec/model/executor_copy.go
+++ b/exec/model/executor_copy.go
@@ -273,14 +273,10 @@ func generateDestroyCriCommands(experimentId string, expModel *spec.ExpModel,
 			return identifiers, err
 		}
 		generatedCommand := command
-		if isNetworkTarget {
-			generatedCommand = fmt.Sprintf("%s --container-id %s --container-runtime %s", generatedCommand, obj.ContainerId, obj.ContainerRuntime)
-		} else {
-			if obj.Id != "" {
-				generatedCommand = fmt.Sprintf("%s --uid %s", command, obj.Id)
-			}
-			generatedCommand = fmt.Sprintf("%s --container-name %s --container-runtime %s", generatedCommand, obj.ContainerName, obj.ContainerRuntime)
+		if obj.Id != "" {
+			generatedCommand = fmt.Sprintf("%s --uid %s", command, obj.Id)
 		}
+		generatedCommand = fmt.Sprintf("%s --container-name %s --container-runtime %s", generatedCommand, obj.ContainerName, obj.ContainerRuntime)
 		identifierInPod := ExperimentIdentifierInPod{
 			ContainerObjectMeta:     containerObjectMetaList[idx],
 			Command:                 generatedCommand,

--- a/exec/model/executor_copy.go
+++ b/exec/model/executor_copy.go
@@ -194,7 +194,7 @@ func getCriExperimentIdentifiers(experimentId string, expModel *spec.ExpModel,
 			matchers, chaosblade.Constant.ImageRepoFunc(), chaosblade.Version)
 	}
 	if destroy {
-		return generateDestroyCriCommands(experimentId, expModel, containerObjectMetaList, matchers, isNetworkTarget, client)
+		return generateDestroyCriCommands(experimentId, expModel, containerObjectMetaList, matchers, client)
 	}
 	return generateCreateCriCommands(experimentId, expModel, containerObjectMetaList, matchers, client)
 }
@@ -261,8 +261,13 @@ func generateCreateDockerCommands(experimentId string, expModel *spec.ExpModel,
 	return identifiers, nil
 }
 
-func generateDestroyCriCommands(experimentId string, expModel *spec.ExpModel,
-	containerObjectMetaList ContainerMatchedList, matchers string, isNetworkTarget bool, client *channel.Client) ([]ExperimentIdentifierInPod, error) {
+func generateDestroyCriCommands(
+	experimentId string,
+	expModel *spec.ExpModel,
+	containerObjectMetaList ContainerMatchedList,
+	matchers string,
+	client *channel.Client,
+) ([]ExperimentIdentifierInPod, error) {
 	command := fmt.Sprintf("%s destroy cri %s %s %s", getTargetChaosBladeBin(expModel), expModel.Target, expModel.ActionName, matchers)
 	identifiers := make([]ExperimentIdentifierInPod, 0)
 	for idx, obj := range containerObjectMetaList {

--- a/exec/model/executor_copy.go
+++ b/exec/model/executor_copy.go
@@ -279,7 +279,7 @@ func generateDestroyCriCommands(
 		}
 		generatedCommand := command
 		if obj.Id != "" {
-			generatedCommand = fmt.Sprintf("%s --uid %s", command, obj.Id)
+			generatedCommand = fmt.Sprintf("%s --uid %s", generatedCommand, obj.Id)
 		}
 		generatedCommand = fmt.Sprintf("%s --container-name %s --container-runtime %s", generatedCommand, obj.ContainerName, obj.ContainerRuntime)
 		identifierInPod := ExperimentIdentifierInPod{


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Go to https://github.com/chaosblade-io/chaosblade/issues/1097 for details.

### Does this pull request fix one issue?

RESOLVE https://github.com/chaosblade-io/chaosblade/issues/1097

### Describe how you did it

Remove redundant and unnecessary condition branch.

### Describe how to verify it

The `chaosblade-operator` currently lacks the conditions to write tests. But I have applied this patch to a internal fork ChaosBlade in the PROD env and served 200+ apps for experiments since 01/2025.
