### PR TITLE
fix: include all Linux network actions in k8s spec regardless of build platform

### DIFF
--- a/exec/model/osexp.go
+++ b/exec/model/osexp.go
@@ -22,6 +22,7 @@ import (
 	"github.com/chaosblade-io/chaosblade-exec-os/exec/file"
 	"github.com/chaosblade-io/chaosblade-exec-os/exec/mem"
 	"github.com/chaosblade-io/chaosblade-exec-os/exec/network"
+	"github.com/chaosblade-io/chaosblade-exec-os/exec/network/tc"
 	"github.com/chaosblade-io/chaosblade-exec-os/exec/process"
 	"github.com/chaosblade-io/chaosblade-exec-os/exec/script"
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
@@ -31,12 +32,33 @@ type OSSubResourceModelSpec struct {
 	BaseSubResourceExpModelSpec
 }
 
+// newK8sNetworkCommandSpec returns all Linux-compatible network actions
+// regardless of the build platform, since k8s pods always run on Linux.
+func newK8sNetworkCommandSpec() spec.ExpModelCommandSpec {
+	return &network.NetworkCommandSpec{
+		BaseExpModelCommandSpec: spec.BaseExpModelCommandSpec{
+			ExpActions: []spec.ExpActionCommandSpec{
+				tc.NewDelayActionSpec(),
+				network.NewDropActionSpec(),
+				network.NewDnsActionSpec(),
+				network.NewDnsDownActionSpec(),
+				tc.NewLossActionSpec(),
+				tc.NewDuplicateActionSpec(),
+				tc.NewCorruptActionSpec(),
+				tc.NewReorderActionSpec(),
+				network.NewOccupyActionSpec(),
+			},
+			ExpFlags: []spec.ExpFlagSpec{},
+		},
+	}
+}
+
 func NewOSSubResourceModelSpec() SubResourceExpModelSpec {
 	modelSpec := &OSSubResourceModelSpec{
 		BaseSubResourceExpModelSpec{
 			ExpModelSpecs: []spec.ExpModelCommandSpec{
 				cpu.NewCpuCommandModelSpec(),
-				network.NewNetworkCommandSpec(),
+				newK8sNetworkCommandSpec(),
 				process.NewProcessCommandModelSpec(),
 				disk.NewDiskCommandSpec(),
 				mem.NewMemCommandModelSpec(),


### PR DESCRIPTION
## Summary

- Fix missing k8s pod-network commands (delay, loss, duplicate, corrupt, reorder, dnsdown) on darwin release builds
- Replace platform-dependent `network.NewNetworkCommandSpec()` with explicit construction of all Linux-compatible network actions
- Since k8s pods always run on Linux, the spec should always include all Linux network actions regardless of the build host OS

## Root Cause

The k8s spec YAML is generated by compiling and running `build/spec.go`, which calls `network.NewNetworkCommandSpec()`. This function has platform-specific implementations:

- **`network_linux.go`**: Returns all 9 actions (delay, drop, dns, dnsdown, loss, duplicate, corrupt, reorder, occupy)
- **`network_darwin.go`**: Returns only 3 actions (drop, dns, occupy)

When the spec generator is built on macOS (via `GOOS=$(CURRENT_OS)` in the Makefile `yaml` target), Go's build tags select `network_darwin.go`, resulting in a k8s spec YAML missing tc-based commands.

## Fix

Introduced `newK8sNetworkCommandSpec()` in `exec/model/osexp.go` that explicitly constructs the full network command spec with all Linux-compatible actions using platform-independent imports (`network/tc` package has no build tags).

## Test Plan

- [ ] Build spec generator on macOS and verify generated YAML includes delay, loss, duplicate, corrupt, reorder actions
- [ ] Build spec generator on Linux and verify no regression
- [ ] Verify `blade create k8s pod-network` shows all expected subcommands

Fixes chaosblade-io/chaosblade#1275

Made with [Cursor](https://cursor.com)