### PR TITLE
feat(pod): Added a pod termination state experiment to simulate a pod…

### DIFF
--- a/examples/pod-terminating-by-finalizer.yaml
+++ b/examples/pod-terminating-by-finalizer.yaml
@@ -15,7 +15,7 @@
 apiVersion: chaosblade.io/v1alpha1
 kind: ChaosBlade
 metadata:
-  name: pod-terminating-by-names
+  name: pod-terminating-by-finalizer
 spec:
   experiments:
   - scope: pod
@@ -28,4 +28,4 @@ spec:
       - "nginx-140862721796080896-0"
     - name: namespace
       value:
-      - "default"
+      - "nginx"

--- a/examples/pod-terminating-by-names.yaml
+++ b/examples/pod-terminating-by-names.yaml
@@ -1,0 +1,31 @@
+# Copyright 2025 The ChaosBlade Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: chaosblade.io/v1alpha1
+kind: ChaosBlade
+metadata:
+  name: pod-terminating-by-names
+spec:
+  experiments:
+  - scope: pod
+    target: pod
+    action: terminating
+    desc: "Make pod stuck in Terminating state by adding a finalizer that blocks deletion"
+    matchers:
+    - name: names
+      value:
+      - "nginx-140862721796080896-0"
+    - name: namespace
+      value:
+      - "nginx"

--- a/examples/pod-terminating-by-names.yaml
+++ b/examples/pod-terminating-by-names.yaml
@@ -28,4 +28,4 @@ spec:
       - "nginx-140862721796080896-0"
     - name: namespace
       value:
-      - "nginx"
+      - "default"

--- a/exec/pod/pod.go
+++ b/exec/pod/pod.go
@@ -260,6 +260,7 @@ func NewSelfExpModelCommandSpec(client *channel.Client) spec.ExpModelCommandSpec
 				NewDeletePodActionSpec(client),
 				NewPodIOActionSpec(client),
 				NewFailPodActionSpec(client),
+				NewPodTerminatingActionSpec(client),
 			},
 		},
 	}

--- a/exec/pod/terminating.go
+++ b/exec/pod/terminating.go
@@ -24,6 +24,7 @@ import (
 	"github.com/chaosblade-io/chaosblade-spec-go/util"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/chaosblade-io/chaosblade-operator/channel"
@@ -194,10 +195,18 @@ func (d *PodTerminatingActionExecutor) destroy(uid string, ctx context.Context, 
 		pod := &v1.Pod{}
 		err := d.client.Get(context.TODO(), types.NamespacedName{Name: meta.PodName, Namespace: meta.Namespace}, pod)
 		if err != nil {
-			logrusField.Warningf("get pod %s/%s err, %v", meta.Namespace, meta.PodName, err)
-			// Pod may already be fully deleted after finalizer removal, treat as success
-			status = status.CreateSuccessResourceStatus()
-			status.State = v1alpha1.DestroyedState
+			// Distinguish between NotFound and other errors (RBAC, API server unreachable, etc.)
+			if apierrors.IsNotFound(err) {
+				// Pod is already fully deleted, treat as success
+				logrusField.Infof("pod %s/%s already deleted", meta.Namespace, meta.PodName)
+				status = status.CreateSuccessResourceStatus()
+				status.State = v1alpha1.DestroyedState
+			} else {
+				// Other errors mean the finalizer may still be present
+				logrusField.Warningf("get pod %s/%s err, %v", meta.Namespace, meta.PodName, err)
+				status = status.CreateFailResourceStatus(fmt.Sprintf("get pod failed: %v", err), spec.K8sExecFailed.Code)
+				allSuccess = false
+			}
 			statuses = append(statuses, status)
 			continue
 		}

--- a/exec/pod/terminating.go
+++ b/exec/pod/terminating.go
@@ -117,7 +117,7 @@ func (d *PodTerminatingActionExecutor) create(uid string, ctx context.Context, e
 	for _, meta := range containerObjectMetaList {
 		status := v1alpha1.ResourceStatus{
 			Kind:       v1alpha1.PodKind,
-			Identifier: fmt.Sprintf("%s/%s/%s", meta.Namespace, meta.NodeName, meta.PodName),
+			Identifier: meta.GetIdentifier(),
 		}
 
 		pod := &v1.Pod{}
@@ -193,7 +193,7 @@ func (d *PodTerminatingActionExecutor) destroy(uid string, ctx context.Context, 
 	for _, meta := range containerObjectMetaList {
 		status := v1alpha1.ResourceStatus{
 			Kind:       v1alpha1.PodKind,
-			Identifier: fmt.Sprintf("%s/%s/%s", meta.Namespace, meta.NodeName, meta.PodName),
+			Identifier: meta.GetIdentifier(),
 		}
 
 		pod := &v1.Pod{}

--- a/exec/pod/terminating.go
+++ b/exec/pod/terminating.go
@@ -150,6 +150,10 @@ func (d *PodTerminatingActionExecutor) create(uid string, ctx context.Context, e
 		// Step 2: Delete the pod, it will be stuck in Terminating because of the finalizer
 		if err := d.client.Delete(context.TODO(), pod); err != nil {
 			logrusField.Warningf("delete pod %s/%s err, %v", meta.Namespace, meta.PodName, err)
+			// Best-effort rollback: remove the finalizer we just added
+			if rbErr := d.removeFinalizer(ctx, pod); rbErr != nil {
+				logrusField.Warningf("rollback finalizer for pod %s/%s failed: %v", meta.Namespace, meta.PodName, rbErr)
+			}
 			status = status.CreateFailResourceStatus(fmt.Sprintf("delete pod failed: %v", err), spec.K8sExecFailed.Code)
 			statuses = append(statuses, status)
 			continue

--- a/exec/pod/terminating.go
+++ b/exec/pod/terminating.go
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pod
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/chaosblade-io/chaosblade-operator/channel"
+	"github.com/chaosblade-io/chaosblade-operator/exec/model"
+	"github.com/chaosblade-io/chaosblade-operator/pkg/apis/chaosblade/v1alpha1"
+)
+
+const (
+	// PodTerminatingFinalizer is the finalizer added to the target pod to block its deletion
+	PodTerminatingFinalizer = "chaosblade.io/pod-terminating"
+)
+
+type PodTerminatingActionSpec struct {
+	spec.BaseExpActionCommandSpec
+}
+
+func NewPodTerminatingActionSpec(client *channel.Client) spec.ExpActionCommandSpec {
+	return &PodTerminatingActionSpec{
+		spec.BaseExpActionCommandSpec{
+			ActionMatchers: []spec.ExpFlagSpec{},
+			ActionFlags: []spec.ExpFlagSpec{
+				&spec.ExpFlag{
+					Name:   "random",
+					Desc:   "Randomly select pod",
+					NoArgs: true,
+				},
+			},
+			ActionExecutor: &PodTerminatingActionExecutor{client: client},
+			ActionExample: `# Make the pod stuck in Terminating state in the default namespace
+blade create k8s pod-pod terminating --names nginx-app --namespace default --kubeconfig ~/.kube/config
+
+# Make pods stuck in Terminating state by labels
+blade create k8s pod-pod terminating --labels app=guestbook --namespace default --evict-count 2 --kubeconfig ~/.kube/config
+`,
+			ActionCategories: []string{model.CategorySystemContainer},
+		},
+	}
+}
+
+func (*PodTerminatingActionSpec) Name() string {
+	return "terminating"
+}
+
+func (*PodTerminatingActionSpec) Aliases() []string {
+	return []string{}
+}
+
+func (*PodTerminatingActionSpec) ShortDesc() string {
+	return "Make pod stuck in Terminating state by adding a finalizer"
+}
+
+func (*PodTerminatingActionSpec) LongDesc() string {
+	return "Simulate the scenario where a Pod is stuck in Terminating state due to uncleaned finalizers. " +
+		"This fault injects by adding a custom finalizer to the target Pod and then deleting it, " +
+		"which causes the Pod to remain in Terminating state because the finalizer prevents garbage collection. " +
+		"When the experiment is destroyed, the finalizer will be removed so the Pod can be fully deleted."
+}
+
+type PodTerminatingActionExecutor struct {
+	client *channel.Client
+}
+
+func (*PodTerminatingActionExecutor) Name() string {
+	return "terminating"
+}
+
+func (*PodTerminatingActionExecutor) SetChannel(channel spec.Channel) {}
+
+func (d *PodTerminatingActionExecutor) Exec(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	if _, ok := spec.IsDestroy(ctx); ok {
+		return d.destroy(uid, ctx, expModel)
+	}
+	return d.create(uid, ctx, expModel)
+}
+
+func (d *PodTerminatingActionExecutor) create(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	experimentId := model.GetExperimentIdFromContext(ctx)
+	logrusField := logrus.WithField("experiment", experimentId)
+
+	containerObjectMetaList, err := model.GetContainerObjectMetaListFromContext(ctx)
+	if err != nil {
+		util.Errorf(uid, util.GetRunFuncName(), err.Error())
+		return spec.ResponseFailWithResult(spec.ContainerInContextNotFound,
+			v1alpha1.CreateFailExperimentStatus(spec.ContainerInContextNotFound.Msg, []v1alpha1.ResourceStatus{}))
+	}
+
+	statuses := make([]v1alpha1.ResourceStatus, 0)
+	success := false
+
+	for _, meta := range containerObjectMetaList {
+		status := v1alpha1.ResourceStatus{
+			Kind:       v1alpha1.PodKind,
+			Identifier: fmt.Sprintf("%s/%s/%s", meta.Namespace, meta.NodeName, meta.PodName),
+		}
+
+		pod := &v1.Pod{}
+		err := d.client.Get(context.TODO(), types.NamespacedName{Name: meta.PodName, Namespace: meta.Namespace}, pod)
+		if err != nil {
+			logrusField.Warningf("get pod %s/%s err, %v", meta.Namespace, meta.PodName, err)
+			status = status.CreateFailResourceStatus(err.Error(), spec.K8sExecFailed.Code)
+			statuses = append(statuses, status)
+			continue
+		}
+
+		// Skip if pod is already being deleted
+		if pod.DeletionTimestamp != nil {
+			logrusField.Infof("pod %s/%s is already terminating, skip", meta.Namespace, meta.PodName)
+			status = status.CreateSuccessResourceStatus()
+			status.Error = "pod is already in Terminating state"
+			statuses = append(statuses, status)
+			success = true
+			continue
+		}
+
+		// Step 1: Add the finalizer to the pod
+		if err := d.addFinalizer(ctx, pod); err != nil {
+			logrusField.Warningf("add finalizer to pod %s/%s err, %v", meta.Namespace, meta.PodName, err)
+			status = status.CreateFailResourceStatus(fmt.Sprintf("add finalizer failed: %v", err), spec.K8sExecFailed.Code)
+			statuses = append(statuses, status)
+			continue
+		}
+
+		// Step 2: Delete the pod, it will be stuck in Terminating because of the finalizer
+		if err := d.client.Delete(context.TODO(), pod); err != nil {
+			logrusField.Warningf("delete pod %s/%s err, %v", meta.Namespace, meta.PodName, err)
+			status = status.CreateFailResourceStatus(fmt.Sprintf("delete pod failed: %v", err), spec.K8sExecFailed.Code)
+			statuses = append(statuses, status)
+			continue
+		}
+
+		logrusField.Infof("pod %s/%s is now stuck in Terminating state with finalizer %s",
+			meta.Namespace, meta.PodName, PodTerminatingFinalizer)
+
+		status = status.CreateSuccessResourceStatus()
+		statuses = append(statuses, status)
+		success = true
+	}
+
+	var experimentStatus v1alpha1.ExperimentStatus
+	if success {
+		experimentStatus = v1alpha1.CreateSuccessExperimentStatus(statuses)
+	} else {
+		experimentStatus = v1alpha1.CreateFailExperimentStatus("see resStatuses for details", statuses)
+	}
+	return spec.ReturnResultIgnoreCode(experimentStatus)
+}
+
+func (d *PodTerminatingActionExecutor) destroy(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	experimentId := model.GetExperimentIdFromContext(ctx)
+	logrusField := logrus.WithField("experiment", experimentId)
+
+	containerObjectMetaList, err := model.GetContainerObjectMetaListFromContext(ctx)
+	if err != nil {
+		util.Errorf(uid, util.GetRunFuncName(), err.Error())
+		return spec.ResponseFailWithResult(spec.ContainerInContextNotFound,
+			v1alpha1.CreateFailExperimentStatus(spec.ContainerInContextNotFound.Msg, []v1alpha1.ResourceStatus{}))
+	}
+
+	statuses := make([]v1alpha1.ResourceStatus, 0)
+	allSuccess := true
+
+	for _, meta := range containerObjectMetaList {
+		status := v1alpha1.ResourceStatus{
+			Kind:       v1alpha1.PodKind,
+			Identifier: fmt.Sprintf("%s/%s/%s", meta.Namespace, meta.NodeName, meta.PodName),
+		}
+
+		pod := &v1.Pod{}
+		err := d.client.Get(context.TODO(), types.NamespacedName{Name: meta.PodName, Namespace: meta.Namespace}, pod)
+		if err != nil {
+			logrusField.Warningf("get pod %s/%s err, %v", meta.Namespace, meta.PodName, err)
+			// Pod may already be fully deleted after finalizer removal, treat as success
+			status = status.CreateSuccessResourceStatus()
+			status.State = v1alpha1.DestroyedState
+			statuses = append(statuses, status)
+			continue
+		}
+
+		// Remove the finalizer to allow the pod to be fully deleted
+		if err := d.removeFinalizer(ctx, pod); err != nil {
+			logrusField.Warningf("remove finalizer from pod %s/%s err, %v", meta.Namespace, meta.PodName, err)
+			status = status.CreateFailResourceStatus(fmt.Sprintf("remove finalizer failed: %v", err), spec.K8sExecFailed.Code)
+			statuses = append(statuses, status)
+			allSuccess = false
+			continue
+		}
+
+		logrusField.Infof("removed finalizer from pod %s/%s, pod will be fully deleted",
+			meta.Namespace, meta.PodName)
+
+		status = status.CreateSuccessResourceStatus()
+		status.State = v1alpha1.DestroyedState
+		statuses = append(statuses, status)
+	}
+
+	if allSuccess {
+		return spec.ReturnResultIgnoreCode(v1alpha1.CreateDestroyedExperimentStatus(statuses))
+	}
+	return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus("see resStatuses for details", statuses))
+}
+
+// addFinalizer adds the chaosblade pod-terminating finalizer to the pod
+func (d *PodTerminatingActionExecutor) addFinalizer(ctx context.Context, pod *v1.Pod) error {
+	finalizers := pod.GetFinalizers()
+	for _, f := range finalizers {
+		if f == PodTerminatingFinalizer {
+			// Finalizer already exists
+			return nil
+		}
+	}
+	pod.SetFinalizers(append(finalizers, PodTerminatingFinalizer))
+	return d.client.Update(ctx, pod)
+}
+
+// removeFinalizer removes the chaosblade pod-terminating finalizer from the pod
+func (d *PodTerminatingActionExecutor) removeFinalizer(ctx context.Context, pod *v1.Pod) error {
+	finalizers := pod.GetFinalizers()
+	newFinalizers := make([]string, 0, len(finalizers))
+	found := false
+	for _, f := range finalizers {
+		if f == PodTerminatingFinalizer {
+			found = true
+			continue
+		}
+		newFinalizers = append(newFinalizers, f)
+	}
+	if !found {
+		// Finalizer not found, nothing to remove
+		return nil
+	}
+	pod.SetFinalizers(newFinalizers)
+	return d.client.Update(ctx, pod)
+}

--- a/exec/pod/terminating.go
+++ b/exec/pod/terminating.go
@@ -23,6 +23,7 @@ import (
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
 	"github.com/chaosblade-io/chaosblade-spec-go/util"
 	"github.com/sirupsen/logrus"
+	
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"

--- a/exec/pod/terminating.go
+++ b/exec/pod/terminating.go
@@ -121,7 +121,7 @@ func (d *PodTerminatingActionExecutor) create(uid string, ctx context.Context, e
 		}
 
 		pod := &v1.Pod{}
-		err := d.client.Get(context.TODO(), types.NamespacedName{Name: meta.PodName, Namespace: meta.Namespace}, pod)
+		err := d.client.Get(ctx, types.NamespacedName{Name: meta.PodName, Namespace: meta.Namespace}, pod)
 		if err != nil {
 			logrusField.Warningf("get pod %s/%s err, %v", meta.Namespace, meta.PodName, err)
 			status = status.CreateFailResourceStatus(err.Error(), spec.K8sExecFailed.Code)
@@ -147,7 +147,7 @@ func (d *PodTerminatingActionExecutor) create(uid string, ctx context.Context, e
 		}
 
 		// Step 2: Delete the pod, it will be stuck in Terminating because of the finalizer
-		if err := d.client.Delete(context.TODO(), pod); err != nil {
+		if err := d.client.Delete(ctx, pod); err != nil {
 			logrusField.Warningf("delete pod %s/%s err, %v", meta.Namespace, meta.PodName, err)
 			// Best-effort rollback: remove the finalizer we just added
 			if rbErr := d.removeFinalizer(ctx, pod); rbErr != nil {
@@ -196,7 +196,7 @@ func (d *PodTerminatingActionExecutor) destroy(uid string, ctx context.Context, 
 		}
 
 		pod := &v1.Pod{}
-		err := d.client.Get(context.TODO(), types.NamespacedName{Name: meta.PodName, Namespace: meta.Namespace}, pod)
+		err := d.client.Get(ctx, types.NamespacedName{Name: meta.PodName, Namespace: meta.Namespace}, pod)
 		if err != nil {
 			// Distinguish between NotFound and other errors (RBAC, API server unreachable, etc.)
 			if apierrors.IsNotFound(err) {

--- a/exec/pod/terminating.go
+++ b/exec/pod/terminating.go
@@ -133,7 +133,6 @@ func (d *PodTerminatingActionExecutor) create(uid string, ctx context.Context, e
 		if pod.DeletionTimestamp != nil {
 			logrusField.Infof("pod %s/%s is already terminating, skip", meta.Namespace, meta.PodName)
 			status = status.CreateSuccessResourceStatus()
-			status.Error = "pod is already in Terminating state"
 			statuses = append(statuses, status)
 			success = true
 			continue

--- a/exec/pod/terminating.go
+++ b/exec/pod/terminating.go
@@ -23,7 +23,7 @@ import (
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
 	"github.com/chaosblade-io/chaosblade-spec-go/util"
 	"github.com/sirupsen/logrus"
-	
+
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"


### PR DESCRIPTION
… stuck in the Terminating state.

- Added a sample file `pod-terminating-by-names.yaml` to demonstrate termination experiments based on pod names.

- Registered the `PodTerminating` experiment action in the pod experiment model to extend experimental functionality.

- Implemented `PodTerminatingAction`, injecting a finalizer to prevent pod deletion, simulating a scenario stuck in the Terminating state.

- Implemented experiment creation and destruction logic, ensuring that adding a finalizer before deleting the pod and removing the finalizer during destruction restores normal deletion.

- Added detailed experiment descriptions and creation examples to improve the user experience.

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
This PR adds a new chaos experiment action terminating for Pod scope, which simulates the scenario where a Pod is stuck in Terminating state due to uncleaned finalizers.

In production Kubernetes clusters, Pods sometimes get stuck in Terminating state because of:
* Finalizers that are never removed
* Misconfigured controllers that don't handle cleanup
* Unexpected errors during pod deletion

This scenario is a common Kubernetes lifecycle management issue. By simulating this fault, users can:
* Test their monitoring/alerting for stuck pods
* Validate their cleanup automation tools
* Train SRE teams to handle Terminating Pod incidents
* Verify pod deletion timeout configurations


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Injection phase:
1. Add a custom finalizer chaosblade.io/pod-terminating to the target Pod
2. Delete the Pod (which causes it to remain in Terminating state)

Recovery phase:
1. Remove the custom finalizer from the Pod
2. Pod gets fully garbage collected by Kubernetes


### Describe how to verify it
 * Local debugging with go run cmd/manager/main.go
 * Inject fault: Pod enters Terminating state
 * Verify finalizer: chaosblade.io/pod-terminating is added
 * Recovery: Deleting ChaosBlade CR removes finalizer and Pod is fully deleted

### Special notes for reviews
