### PR TITLE
feat: add Service resource support for chaos experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ The current experimental scenarios involve resources including Node, Pod, and Co
     * Disk: specify the directory disk occupation, disk IO read and write load, etc.
     * Memory: specify memory usage
     * Container: remove container
-
+* Service:
+    * Service: create, modify service
 
 ## Local Build & Installation
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -24,6 +24,8 @@ Chaosblade Operator 是混沌工程实验工具 ChaosBlade 下的一款面向云
     * 磁盘：指定目录磁盘填充、磁盘 IO 读写负载等
     * 内存：指定内存使用率
     * Container: 杀 Container
+* Service:
+    * Service: 创建、修改Service
 
 ## 本地构建&安装
 

--- a/build/spec.go
+++ b/build/spec.go
@@ -23,6 +23,7 @@ import (
 	"github.com/chaosblade-io/chaosblade-operator/exec/container"
 	"github.com/chaosblade-io/chaosblade-operator/exec/node"
 	"github.com/chaosblade-io/chaosblade-operator/exec/pod"
+	"github.com/chaosblade-io/chaosblade-operator/exec/service"
 
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
 	"github.com/chaosblade-io/chaosblade-spec-go/util"
@@ -57,6 +58,11 @@ func getModels() *spec.Models {
 	containerResourceModelSpec := container.NewResourceModelSpec(nil)
 	for _, modelSpec := range containerResourceModelSpec.ExpModels() {
 		model := util.ConvertSpecToModels(modelSpec, spec.ExpPrepareModel{}, containerResourceModelSpec.Scope())
+		models = append(models, model)
+	}
+	serviceResourceModelSpec := service.NewResourceModelSpec(nil)
+	for _, modelSpec := range serviceResourceModelSpec.ExpModels() {
+		model := util.ConvertSpecToModels(modelSpec, spec.ExpPrepareModel{}, serviceResourceModelSpec.Scope())
 		models = append(models, model)
 	}
 	return util.MergeModels(models...)

--- a/deploy/helm/chaosblade-operator-arm64/templates/rbac.yaml
+++ b/deploy/helm/chaosblade-operator-arm64/templates/rbac.yaml
@@ -34,6 +34,7 @@ rules:
       - pods
       - pods/exec
       - configmaps
+      - services
     verbs:
       - "*"
   - apiGroups:

--- a/deploy/helm/chaosblade-operator/templates/rbac.yaml
+++ b/deploy/helm/chaosblade-operator/templates/rbac.yaml
@@ -34,6 +34,7 @@ rules:
       - pods
       - pods/exec
       - configmaps
+      - services
     verbs:
       - "*"
   - apiGroups:

--- a/exec/controller.go
+++ b/exec/controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/chaosblade-io/chaosblade-operator/exec/model"
 	"github.com/chaosblade-io/chaosblade-operator/exec/node"
 	"github.com/chaosblade-io/chaosblade-operator/exec/pod"
+	"github.com/chaosblade-io/chaosblade-operator/exec/service"
 	"github.com/chaosblade-io/chaosblade-operator/pkg/apis/chaosblade/v1alpha1"
 )
 
@@ -51,6 +52,7 @@ func NewDispatcherExecutor(client *channel.Client) *ResourceDispatchedController
 			node.NewExpController(client),
 			pod.NewExpController(client),
 			container.NewExpController(client),
+			service.NewExpController(client),
 		)
 	})
 	return executor

--- a/exec/service/controller.go
+++ b/exec/service/controller.go
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/sirupsen/logrus"
+
+	"github.com/chaosblade-io/chaosblade-operator/channel"
+	"github.com/chaosblade-io/chaosblade-operator/exec/model"
+	"github.com/chaosblade-io/chaosblade-operator/pkg/apis/chaosblade/v1alpha1"
+)
+
+const ServiceMetaListKey = "ServiceMetaListKey"
+
+type ServiceMeta struct {
+	Id          string
+	ServiceName string
+	Namespace   string
+}
+
+type ServiceMetaList []ServiceMeta
+
+func GetServiceMetaListFromContext(ctx context.Context) (ServiceMetaList, error) {
+	val := ctx.Value(ServiceMetaListKey)
+	if val == nil {
+		return nil, fmt.Errorf("less service meta in context")
+	}
+	return val.(ServiceMetaList), nil
+}
+
+func SetServiceMetaListToContext(ctx context.Context, list ServiceMetaList) context.Context {
+	return context.WithValue(ctx, ServiceMetaListKey, list)
+}
+
+type ExpController struct {
+	model.BaseExperimentController
+}
+
+func NewExpController(client *channel.Client) model.ExperimentController {
+	return &ExpController{
+		model.BaseExperimentController{
+			Client:            client,
+			ResourceModelSpec: NewResourceModelSpec(client),
+		},
+	}
+}
+
+func (*ExpController) Name() string {
+	return "service"
+}
+
+func (e *ExpController) Create(ctx context.Context, expSpec v1alpha1.ExperimentSpec) *spec.Response {
+	expModel := model.ExtractExpModelFromExperimentSpec(expSpec)
+	experimentId := model.GetExperimentIdFromContext(ctx)
+	logrus.WithField("experiment", experimentId).Infof("creating service experiment")
+	return e.Exec(ctx, expModel)
+}
+
+func (e *ExpController) Destroy(ctx context.Context, expSpec v1alpha1.ExperimentSpec, oldExpStatus v1alpha1.ExperimentStatus) *spec.Response {
+	experimentId := model.GetExperimentIdFromContext(ctx)
+	logrus.WithField("experiment", experimentId).Infoln("start to destroy service experiment")
+	expModel := model.ExtractExpModelFromExperimentSpec(expSpec)
+	statuses := oldExpStatus.ResStatuses
+	if statuses == nil {
+		return spec.ReturnSuccess(v1alpha1.CreateSuccessExperimentStatus([]v1alpha1.ResourceStatus{}))
+	}
+	serviceMetaList := ServiceMetaList{}
+	for _, status := range statuses {
+		if !status.Success {
+			continue
+		}
+		meta := parseServiceIdentifier(status.Identifier)
+		meta.Id = status.Id
+		serviceMetaList = append(serviceMetaList, meta)
+	}
+	ctx = SetServiceMetaListToContext(ctx, serviceMetaList)
+	return e.Exec(ctx, expModel)
+}
+
+// parseServiceIdentifier parses identifier in format "Namespace/ServiceName"
+func parseServiceIdentifier(identifier string) ServiceMeta {
+	parts := strings.SplitN(identifier, "/", 2)
+	meta := ServiceMeta{}
+	if len(parts) >= 1 {
+		meta.Namespace = parts[0]
+	}
+	if len(parts) >= 2 {
+		meta.ServiceName = parts[1]
+	}
+	return meta
+}

--- a/exec/service/create.go
+++ b/exec/service/create.go
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/chaosblade-io/chaosblade-operator/channel"
+	"github.com/chaosblade-io/chaosblade-operator/exec/model"
+	"github.com/chaosblade-io/chaosblade-operator/pkg/apis/chaosblade/v1alpha1"
+)
+
+const (
+	NamePrefixFlag = "name-prefix"
+	CountFlag      = "count"
+	PortBaseFlag   = "port-base"
+	PortCountFlag  = "port-count"
+)
+
+type CreateServiceActionSpec struct {
+	spec.BaseExpActionCommandSpec
+}
+
+func NewCreateServiceActionSpec(client *channel.Client) spec.ExpActionCommandSpec {
+	return &CreateServiceActionSpec{
+		spec.BaseExpActionCommandSpec{
+			ActionMatchers: []spec.ExpFlagSpec{},
+			ActionFlags: []spec.ExpFlagSpec{
+				&spec.ExpFlag{
+					Name:     NamePrefixFlag,
+					Desc:     "Name prefix for the created services",
+					NoArgs:   false,
+					Required: true,
+				},
+				&spec.ExpFlag{
+					Name:     CountFlag,
+					Desc:     "Number of services to create",
+					NoArgs:   false,
+					Required: true,
+				},
+				&spec.ExpFlag{
+					Name:   PortBaseFlag,
+					Desc:   "Base port number for service ports, default is 8000",
+					NoArgs: false,
+				},
+				&spec.ExpFlag{
+					Name:   PortCountFlag,
+					Desc:   "Number of ports per service, default is 10",
+					NoArgs: false,
+				},
+			},
+			ActionExecutor: &CreateServiceActionExecutor{client: client},
+			ActionExample: `# Create 1000 services with prefix my-service in default namespace
+blade create k8s service-self create --name-prefix my-service --namespace default --count 1000 --kubeconfig ~/.kube/config`,
+			ActionCategories: []string{model.CategorySystemContainer},
+		},
+	}
+}
+
+func (*CreateServiceActionSpec) Name() string {
+	return "create"
+}
+
+func (*CreateServiceActionSpec) Aliases() []string {
+	return []string{}
+}
+
+func (*CreateServiceActionSpec) ShortDesc() string {
+	return "Create services in batch"
+}
+
+func (*CreateServiceActionSpec) LongDesc() string {
+	return "Create the specified number of Kubernetes services with given name prefix, each containing configurable port mappings and no selector"
+}
+
+type CreateServiceActionExecutor struct {
+	client *channel.Client
+}
+
+func (*CreateServiceActionExecutor) Name() string {
+	return "create"
+}
+
+func (*CreateServiceActionExecutor) SetChannel(channel spec.Channel) {
+}
+
+func (d *CreateServiceActionExecutor) Exec(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	if _, ok := spec.IsDestroy(ctx); ok {
+		return d.destroy(uid, ctx, expModel)
+	}
+	return d.create(uid, ctx, expModel)
+}
+
+func (d *CreateServiceActionExecutor) create(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	logrusField := logrus.WithField("experiment", model.GetExperimentIdFromContext(ctx))
+
+	namePrefix := expModel.ActionFlags[NamePrefixFlag]
+	if namePrefix == "" {
+		util.Errorf(uid, util.GetRunFuncName(), "name-prefix is required")
+		return spec.ResponseFailWithResult(spec.ParameterLess,
+			v1alpha1.CreateFailExperimentStatus("name-prefix is required", []v1alpha1.ResourceStatus{}),
+			NamePrefixFlag)
+	}
+
+	namespace := expModel.ActionFlags["namespace"]
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	countStr := expModel.ActionFlags[CountFlag]
+	if countStr == "" {
+		util.Errorf(uid, util.GetRunFuncName(), "count is required")
+		return spec.ResponseFailWithResult(spec.ParameterLess,
+			v1alpha1.CreateFailExperimentStatus("count is required", []v1alpha1.ResourceStatus{}),
+			CountFlag)
+	}
+	count, err := strconv.Atoi(countStr)
+	if err != nil {
+		return spec.ResponseFailWithResult(spec.ParameterIllegal,
+			v1alpha1.CreateFailExperimentStatus(fmt.Sprintf("count is invalid: %v", err), []v1alpha1.ResourceStatus{}),
+			CountFlag, countStr, err)
+	}
+
+	portBase := 8000
+	if v := expModel.ActionFlags[PortBaseFlag]; v != "" {
+		portBase, err = strconv.Atoi(v)
+		if err != nil {
+			return spec.ResponseFailWithResult(spec.ParameterIllegal,
+				v1alpha1.CreateFailExperimentStatus(fmt.Sprintf("port-base is invalid: %v", err), []v1alpha1.ResourceStatus{}),
+				PortBaseFlag, v, err)
+		}
+	}
+
+	portCount := 10
+	if v := expModel.ActionFlags[PortCountFlag]; v != "" {
+		portCount, err = strconv.Atoi(v)
+		if err != nil {
+			return spec.ResponseFailWithResult(spec.ParameterIllegal,
+				v1alpha1.CreateFailExperimentStatus(fmt.Sprintf("port-count is invalid: %v", err), []v1alpha1.ResourceStatus{}),
+				PortCountFlag, v, err)
+		}
+	}
+
+	logrusField.Infof("creating %d services with prefix %s in namespace %s", count, namePrefix, namespace)
+
+	statuses := make([]v1alpha1.ResourceStatus, 0)
+	success := false
+	for i := 0; i < count; i++ {
+		serviceName := fmt.Sprintf("%s-%d", namePrefix, i)
+		status := v1alpha1.ResourceStatus{
+			Kind:       v1alpha1.ServiceKind,
+			Identifier: fmt.Sprintf("%s/%s", namespace, serviceName),
+		}
+
+		svc := buildService(serviceName, namespace, portBase, portCount)
+		if err := d.client.Create(context.TODO(), svc); err != nil {
+			logrusField.Warningf("create service %s err, %v", serviceName, err)
+			status = status.CreateFailResourceStatus(err.Error(), spec.K8sExecFailed.Code)
+		} else {
+			status = status.CreateSuccessResourceStatus()
+			success = true
+		}
+		statuses = append(statuses, status)
+	}
+
+	var experimentStatus v1alpha1.ExperimentStatus
+	if success {
+		experimentStatus = v1alpha1.CreateSuccessExperimentStatus(statuses)
+	} else {
+		experimentStatus = v1alpha1.CreateFailExperimentStatus("see resStatuses for details", statuses)
+	}
+	return spec.ReturnResultIgnoreCode(experimentStatus)
+}
+
+func (d *CreateServiceActionExecutor) destroy(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	logrusField := logrus.WithField("experiment", model.GetExperimentIdFromContext(ctx))
+
+	serviceMetaList, err := GetServiceMetaListFromContext(ctx)
+	if err != nil {
+		util.Errorf(uid, util.GetRunFuncName(), err.Error())
+		return spec.ResponseFailWithResult(spec.ContainerInContextNotFound,
+			v1alpha1.CreateFailExperimentStatus("cannot get service meta from context", []v1alpha1.ResourceStatus{}))
+	}
+
+	statuses := make([]v1alpha1.ResourceStatus, 0)
+	success := false
+	for _, meta := range serviceMetaList {
+		status := v1alpha1.ResourceStatus{
+			Id:         meta.Id,
+			Kind:       v1alpha1.ServiceKind,
+			Identifier: fmt.Sprintf("%s/%s", meta.Namespace, meta.ServiceName),
+		}
+
+		objectMeta := metav1.ObjectMeta{Name: meta.ServiceName, Namespace: meta.Namespace}
+		if err := d.client.Delete(context.TODO(), &v1.Service{ObjectMeta: objectMeta}); err != nil {
+			logrusField.Warningf("delete service %s err, %v", meta.ServiceName, err)
+			status = status.CreateFailResourceStatus(err.Error(), spec.K8sExecFailed.Code)
+		} else {
+			status.State = v1alpha1.DestroyedState
+			status.Success = true
+			success = true
+		}
+		statuses = append(statuses, status)
+	}
+
+	var experimentStatus v1alpha1.ExperimentStatus
+	if success {
+		experimentStatus = v1alpha1.CreateDestroyedExperimentStatus(statuses)
+	} else {
+		experimentStatus = v1alpha1.CreateFailExperimentStatus("see resStatuses for details", statuses)
+	}
+	return spec.ReturnResultIgnoreCode(experimentStatus)
+}
+
+func buildService(name, namespace string, portBase, portCount int) *v1.Service {
+	ports := make([]v1.ServicePort, 0, portCount)
+	for i := 0; i < portCount; i++ {
+		port := int32(portBase + i)
+		ports = append(ports, v1.ServicePort{
+			Name:       fmt.Sprintf("p%d", port),
+			Port:       port,
+			TargetPort: intstr.FromInt32(port),
+		})
+	}
+
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1.ServiceSpec{
+			Ports: ports,
+		},
+	}
+}

--- a/exec/service/create.go
+++ b/exec/service/create.go
@@ -143,6 +143,11 @@ func (d *CreateServiceActionExecutor) create(uid string, ctx context.Context, ex
 			v1alpha1.CreateFailExperimentStatus(fmt.Sprintf("count is invalid: %v", err), []v1alpha1.ResourceStatus{}),
 			CountFlag, countStr, err)
 	}
+	if count < 1 {
+		return spec.ResponseFailWithResult(spec.ParameterIllegal,
+			v1alpha1.CreateFailExperimentStatus("count is invalid: must be greater than or equal to 1", []v1alpha1.ResourceStatus{}),
+			CountFlag, countStr)
+	}
 
 	portBase := 8000
 	if v := expModel.ActionFlags[PortBaseFlag]; v != "" {

--- a/exec/service/modify.go
+++ b/exec/service/modify.go
@@ -171,16 +171,20 @@ func (d *ModifyServiceActionExecutor) create(uid string, ctx context.Context, ex
 
 	if externalPolicy != "" {
 		annotationKey := fmt.Sprintf(OriginalPolicyAnnotationFn, ExternalTrafficPolicyFlag)
-		svc.Annotations[annotationKey] = string(svc.Spec.ExternalTrafficPolicy)
+		if _, exists := svc.Annotations[annotationKey]; !exists {
+			svc.Annotations[annotationKey] = string(svc.Spec.ExternalTrafficPolicy)
+		}
 		svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicy(externalPolicy)
 	}
 
 	if internalPolicy != "" {
 		annotationKey := fmt.Sprintf(OriginalPolicyAnnotationFn, InternalTrafficPolicyFlag)
-		if svc.Spec.InternalTrafficPolicy != nil {
-			svc.Annotations[annotationKey] = string(*svc.Spec.InternalTrafficPolicy)
-		} else {
-			svc.Annotations[annotationKey] = ""
+		if _, exists := svc.Annotations[annotationKey]; !exists {
+			if svc.Spec.InternalTrafficPolicy != nil {
+				svc.Annotations[annotationKey] = string(*svc.Spec.InternalTrafficPolicy)
+			} else {
+				svc.Annotations[annotationKey] = ""
+			}
 		}
 		policy := v1.ServiceInternalTrafficPolicyType(internalPolicy)
 		svc.Spec.InternalTrafficPolicy = &policy

--- a/exec/service/modify.go
+++ b/exec/service/modify.go
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/chaosblade-io/chaosblade-operator/channel"
+	"github.com/chaosblade-io/chaosblade-operator/exec/model"
+	"github.com/chaosblade-io/chaosblade-operator/pkg/apis/chaosblade/v1alpha1"
+)
+
+const (
+	ServiceNameFlag            = "name"
+	ExternalTrafficPolicyFlag  = "externalTrafficPolicy"
+	InternalTrafficPolicyFlag  = "internalTrafficPolicy"
+	OriginalPolicyAnnotationFn = "chaosblade.io/original-%s"
+)
+
+type ModifyServiceActionSpec struct {
+	spec.BaseExpActionCommandSpec
+}
+
+func NewModifyServiceActionSpec(client *channel.Client) spec.ExpActionCommandSpec {
+	return &ModifyServiceActionSpec{
+		spec.BaseExpActionCommandSpec{
+			ActionMatchers: []spec.ExpFlagSpec{},
+			ActionFlags: []spec.ExpFlagSpec{
+				&spec.ExpFlag{
+					Name:     ServiceNameFlag,
+					Desc:     "Service name to modify",
+					NoArgs:   false,
+					Required: true,
+				},
+				&spec.ExpFlag{
+					Name:   ExternalTrafficPolicyFlag,
+					Desc:   "Set externalTrafficPolicy, values: Local or Cluster",
+					NoArgs: false,
+				},
+				&spec.ExpFlag{
+					Name:   InternalTrafficPolicyFlag,
+					Desc:   "Set internalTrafficPolicy, values: Local or Cluster",
+					NoArgs: false,
+				},
+			},
+			ActionExecutor: &ModifyServiceActionExecutor{client: client},
+			ActionExample: `# Modify externalTrafficPolicy to Local
+blade create k8s service-self modify --name my-service --namespace default --externalTrafficPolicy Local --kubeconfig ~/.kube/config
+
+# Modify internalTrafficPolicy to Local
+blade create k8s service-self modify --name my-service --namespace default --internalTrafficPolicy Local --kubeconfig ~/.kube/config
+
+# Modify both policies
+blade create k8s service-self modify --name my-service --namespace default --externalTrafficPolicy Local --internalTrafficPolicy Cluster --kubeconfig ~/.kube/config`,
+			ActionCategories: []string{model.CategorySystemContainer},
+		},
+	}
+}
+
+func (*ModifyServiceActionSpec) Name() string {
+	return "modify"
+}
+
+func (*ModifyServiceActionSpec) Aliases() []string {
+	return []string{}
+}
+
+func (*ModifyServiceActionSpec) ShortDesc() string {
+	return "Modify service traffic policy"
+}
+
+func (*ModifyServiceActionSpec) LongDesc() string {
+	return "Modify existing Kubernetes service's externalTrafficPolicy or internalTrafficPolicy"
+}
+
+type ModifyServiceActionExecutor struct {
+	client *channel.Client
+}
+
+func (*ModifyServiceActionExecutor) Name() string {
+	return "modify"
+}
+
+func (*ModifyServiceActionExecutor) SetChannel(channel spec.Channel) {
+}
+
+func (d *ModifyServiceActionExecutor) Exec(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	if _, ok := spec.IsDestroy(ctx); ok {
+		return d.destroy(uid, ctx, expModel)
+	}
+	return d.create(uid, ctx, expModel)
+}
+
+func (d *ModifyServiceActionExecutor) create(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	logrusField := logrus.WithField("experiment", model.GetExperimentIdFromContext(ctx))
+
+	serviceName := expModel.ActionFlags[ServiceNameFlag]
+	if serviceName == "" {
+		util.Errorf(uid, util.GetRunFuncName(), "name is required")
+		return spec.ResponseFailWithResult(spec.ParameterLess,
+			v1alpha1.CreateFailExperimentStatus("name is required", []v1alpha1.ResourceStatus{}),
+			ServiceNameFlag)
+	}
+
+	namespace := expModel.ActionFlags["namespace"]
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	externalPolicy := expModel.ActionFlags[ExternalTrafficPolicyFlag]
+	internalPolicy := expModel.ActionFlags[InternalTrafficPolicyFlag]
+	if externalPolicy == "" && internalPolicy == "" {
+		util.Errorf(uid, util.GetRunFuncName(), "at least one of externalTrafficPolicy or internalTrafficPolicy is required")
+		return spec.ResponseFailWithResult(spec.ParameterLess,
+			v1alpha1.CreateFailExperimentStatus("at least one of externalTrafficPolicy or internalTrafficPolicy is required", []v1alpha1.ResourceStatus{}),
+			ExternalTrafficPolicyFlag)
+	}
+
+	if externalPolicy != "" && !isValidPolicy(externalPolicy) {
+		return spec.ResponseFailWithResult(spec.ParameterIllegal,
+			v1alpha1.CreateFailExperimentStatus(fmt.Sprintf("invalid externalTrafficPolicy: %s, must be Local or Cluster", externalPolicy), []v1alpha1.ResourceStatus{}),
+			ExternalTrafficPolicyFlag, externalPolicy, "must be Local or Cluster")
+	}
+	if internalPolicy != "" && !isValidPolicy(internalPolicy) {
+		return spec.ResponseFailWithResult(spec.ParameterIllegal,
+			v1alpha1.CreateFailExperimentStatus(fmt.Sprintf("invalid internalTrafficPolicy: %s, must be Local or Cluster", internalPolicy), []v1alpha1.ResourceStatus{}),
+			InternalTrafficPolicyFlag, internalPolicy, "must be Local or Cluster")
+	}
+
+	logrusField.Infof("modifying service %s/%s, externalTrafficPolicy=%s, internalTrafficPolicy=%s",
+		namespace, serviceName, externalPolicy, internalPolicy)
+
+	status := v1alpha1.ResourceStatus{
+		Kind:       v1alpha1.ServiceKind,
+		Identifier: fmt.Sprintf("%s/%s", namespace, serviceName),
+	}
+
+	svc := &v1.Service{}
+	objectKey := types.NamespacedName{Name: serviceName, Namespace: namespace}
+	if err := d.client.Get(context.TODO(), objectKey, svc); err != nil {
+		logrusField.Errorf("get service %s err, %v", serviceName, err)
+		status = status.CreateFailResourceStatus(err.Error(), spec.K8sExecFailed.Code)
+		return spec.ReturnResultIgnoreCode(
+			v1alpha1.CreateFailExperimentStatus(err.Error(), []v1alpha1.ResourceStatus{status}))
+	}
+
+	if svc.Annotations == nil {
+		svc.Annotations = make(map[string]string)
+	}
+
+	if externalPolicy != "" {
+		annotationKey := fmt.Sprintf(OriginalPolicyAnnotationFn, ExternalTrafficPolicyFlag)
+		svc.Annotations[annotationKey] = string(svc.Spec.ExternalTrafficPolicy)
+		svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicy(externalPolicy)
+	}
+
+	if internalPolicy != "" {
+		annotationKey := fmt.Sprintf(OriginalPolicyAnnotationFn, InternalTrafficPolicyFlag)
+		if svc.Spec.InternalTrafficPolicy != nil {
+			svc.Annotations[annotationKey] = string(*svc.Spec.InternalTrafficPolicy)
+		} else {
+			svc.Annotations[annotationKey] = ""
+		}
+		policy := v1.ServiceInternalTrafficPolicyType(internalPolicy)
+		svc.Spec.InternalTrafficPolicy = &policy
+	}
+
+	if err := d.client.Update(context.TODO(), svc); err != nil {
+		logrusField.Errorf("update service %s err, %v", serviceName, err)
+		status = status.CreateFailResourceStatus(err.Error(), spec.K8sExecFailed.Code)
+		return spec.ReturnResultIgnoreCode(
+			v1alpha1.CreateFailExperimentStatus(err.Error(), []v1alpha1.ResourceStatus{status}))
+	}
+
+	status = status.CreateSuccessResourceStatus()
+	return spec.ReturnResultIgnoreCode(v1alpha1.CreateSuccessExperimentStatus([]v1alpha1.ResourceStatus{status}))
+}
+
+func (d *ModifyServiceActionExecutor) destroy(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	logrusField := logrus.WithField("experiment", model.GetExperimentIdFromContext(ctx))
+
+	serviceMetaList, err := GetServiceMetaListFromContext(ctx)
+	if err != nil {
+		util.Errorf(uid, util.GetRunFuncName(), err.Error())
+		return spec.ResponseFailWithResult(spec.ContainerInContextNotFound,
+			v1alpha1.CreateFailExperimentStatus("cannot get service meta from context", []v1alpha1.ResourceStatus{}))
+	}
+
+	statuses := make([]v1alpha1.ResourceStatus, 0)
+	for _, meta := range serviceMetaList {
+		status := v1alpha1.ResourceStatus{
+			Id:         meta.Id,
+			Kind:       v1alpha1.ServiceKind,
+			Identifier: fmt.Sprintf("%s/%s", meta.Namespace, meta.ServiceName),
+		}
+
+		svc := &v1.Service{}
+		objectKey := types.NamespacedName{Name: meta.ServiceName, Namespace: meta.Namespace}
+		if err := d.client.Get(context.TODO(), objectKey, svc); err != nil {
+			logrusField.Errorf("get service %s for restoring err, %v", meta.ServiceName, err)
+			status = status.CreateFailResourceStatus(err.Error(), spec.K8sExecFailed.Code)
+			statuses = append(statuses, status)
+			continue
+		}
+
+		restored := false
+		extAnnotationKey := fmt.Sprintf(OriginalPolicyAnnotationFn, ExternalTrafficPolicyFlag)
+		if original, ok := svc.Annotations[extAnnotationKey]; ok {
+			svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicy(original)
+			delete(svc.Annotations, extAnnotationKey)
+			restored = true
+		}
+
+		intAnnotationKey := fmt.Sprintf(OriginalPolicyAnnotationFn, InternalTrafficPolicyFlag)
+		if original, ok := svc.Annotations[intAnnotationKey]; ok {
+			if original == "" {
+				svc.Spec.InternalTrafficPolicy = nil
+			} else {
+				policy := v1.ServiceInternalTrafficPolicyType(original)
+				svc.Spec.InternalTrafficPolicy = &policy
+			}
+			delete(svc.Annotations, intAnnotationKey)
+			restored = true
+		}
+
+		if restored {
+			if err := d.client.Update(context.TODO(), svc); err != nil {
+				logrusField.Errorf("restore service %s err, %v", meta.ServiceName, err)
+				status = status.CreateFailResourceStatus(err.Error(), spec.K8sExecFailed.Code)
+				statuses = append(statuses, status)
+				continue
+			}
+		}
+
+		status.State = v1alpha1.DestroyedState
+		status.Success = true
+		statuses = append(statuses, status)
+	}
+	return spec.ReturnResultIgnoreCode(v1alpha1.CreateDestroyedExperimentStatus(statuses))
+}
+
+func isValidPolicy(policy string) bool {
+	return policy == "Local" || policy == "Cluster"
+}

--- a/exec/service/modify.go
+++ b/exec/service/modify.go
@@ -134,7 +134,7 @@ func (d *ModifyServiceActionExecutor) create(uid string, ctx context.Context, ex
 		util.Errorf(uid, util.GetRunFuncName(), "at least one of externalTrafficPolicy or internalTrafficPolicy is required")
 		return spec.ResponseFailWithResult(spec.ParameterLess,
 			v1alpha1.CreateFailExperimentStatus("at least one of externalTrafficPolicy or internalTrafficPolicy is required", []v1alpha1.ResourceStatus{}),
-			ExternalTrafficPolicyFlag)
+			fmt.Sprintf("%s or %s", ExternalTrafficPolicyFlag, InternalTrafficPolicyFlag))
 	}
 
 	if externalPolicy != "" && !isValidPolicy(externalPolicy) {

--- a/exec/service/modify.go
+++ b/exec/service/modify.go
@@ -227,7 +227,14 @@ func (d *ModifyServiceActionExecutor) destroy(uid string, ctx context.Context, e
 		restored := false
 		extAnnotationKey := fmt.Sprintf(OriginalPolicyAnnotationFn, ExternalTrafficPolicyFlag)
 		if original, ok := svc.Annotations[extAnnotationKey]; ok {
-			svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicy(original)
+			if !isValidPolicy(original) {
+				err := fmt.Errorf("invalid externalTrafficPolicy value %q for service %s/%s", original, meta.Namespace, meta.ServiceName)
+				logrusField.Errorf("restore service %s err, %v", meta.ServiceName, err)
+				status = status.CreateFailResourceStatus(err.Error(), spec.K8sExecFailed.Code)
+				statuses = append(statuses, status)
+				continue
+			}
+			svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyType(original)
 			delete(svc.Annotations, extAnnotationKey)
 			restored = true
 		}

--- a/exec/service/modify.go
+++ b/exec/service/modify.go
@@ -174,7 +174,21 @@ func (d *ModifyServiceActionExecutor) create(uid string, ctx context.Context, ex
 		if _, exists := svc.Annotations[annotationKey]; !exists {
 			svc.Annotations[annotationKey] = string(svc.Spec.ExternalTrafficPolicy)
 		}
-		svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicy(externalPolicy)
+		switch externalPolicy {
+		case string(v1.ServiceExternalTrafficPolicyTypeLocal):
+			svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
+		case string(v1.ServiceExternalTrafficPolicyTypeCluster):
+			svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeCluster
+		default:
+			err := fmt.Errorf("invalid externalTrafficPolicy %q, must be %q or %q",
+				externalPolicy,
+				v1.ServiceExternalTrafficPolicyTypeLocal,
+				v1.ServiceExternalTrafficPolicyTypeCluster)
+			logrusField.Errorf("modify service %s err, %v", serviceName, err)
+			status = status.CreateFailResourceStatus(err.Error(), spec.K8sExecFailed.Code)
+			return spec.ReturnResultIgnoreCode(
+				v1alpha1.CreateFailExperimentStatus(err.Error(), []v1alpha1.ResourceStatus{status}))
+		}
 	}
 
 	if internalPolicy != "" {

--- a/exec/service/service.go
+++ b/exec/service/service.go
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+
+	"github.com/chaosblade-io/chaosblade-operator/channel"
+	"github.com/chaosblade-io/chaosblade-operator/exec/model"
+)
+
+type ResourceModelSpec struct {
+	model.BaseResourceExpModelSpec
+}
+
+func NewResourceModelSpec(client *channel.Client) model.ResourceExpModelSpec {
+	modelSpec := &ResourceModelSpec{
+		model.NewBaseResourceExpModelSpec("service", client),
+	}
+	expModels := []spec.ExpModelCommandSpec{
+		NewSelfExpModelCommandSpec(client),
+	}
+	spec.AddFlagsToModelSpec(getResourceFlags, expModels...)
+	modelSpec.RegisterExpModels(expModels...)
+	return modelSpec
+}
+
+func getResourceFlags() []spec.ExpFlagSpec {
+	return []spec.ExpFlagSpec{
+		&spec.ExpFlag{
+			Name:     "namespace",
+			Desc:     "Namespace for the services, default is default",
+			NoArgs:   false,
+			Required: false,
+		},
+	}
+}
+
+type SelfExpModelCommandSpec struct {
+	spec.BaseExpModelCommandSpec
+}
+
+func NewSelfExpModelCommandSpec(client *channel.Client) spec.ExpModelCommandSpec {
+	return &SelfExpModelCommandSpec{
+		spec.BaseExpModelCommandSpec{
+			ExpFlags: []spec.ExpFlagSpec{},
+			ExpActions: []spec.ExpActionCommandSpec{
+				NewCreateServiceActionSpec(client),
+				NewModifyServiceActionSpec(client),
+			},
+		},
+	}
+}
+
+func (*SelfExpModelCommandSpec) Name() string {
+	return "self"
+}
+
+func (*SelfExpModelCommandSpec) ShortDesc() string {
+	return "Service experiments"
+}
+
+func (*SelfExpModelCommandSpec) LongDesc() string {
+	return "Service experiments, such as creating services in batch or modifying service traffic policy"
+}
+
+func (*SelfExpModelCommandSpec) Example() string {
+	return "blade create k8s service-self create --name-prefix my-service --namespace default --count 1000 --kubeconfig ~/.kube/config"
+}

--- a/pkg/apis/chaosblade/v1alpha1/types.go
+++ b/pkg/apis/chaosblade/v1alpha1/types.go
@@ -95,6 +95,7 @@ const (
 	PodKind       = "pod"
 	ContainerKind = "container"
 	NodeKind      = "node"
+	ServiceKind   = "service"
 )
 
 type ResourceStatus struct {


### PR DESCRIPTION
## Summary

Add Kubernetes Service as a new experiment resource type for ChaosBlade Operator, enabling chaos experiments on Service resources.

### New Capabilities

- **Batch Create Services** (`blade create k8s service-self create`): Create multiple K8s Services in batch with configurable name prefix, count, port base, and port count. Supports automatic cleanup on experiment destroy.
- **Modify Service Traffic Policy** (`blade create k8s service-self modify`): Modify `externalTrafficPolicy` and/or `internalTrafficPolicy` of an existing Service (Local/Cluster). Original policies are saved in annotations for automatic restore on experiment destroy.

### Changes

- **New `exec/service/` package**: Contains the full implementation including controller, create action, modify action, and resource model spec (4 new files, ~730 lines)
- **RBAC update**: Added `services` resource permission in both Helm chart RBAC templates (x86 and arm64)
- **Controller registration**: Integrated the new Service experiment controller into the dispatcher
- **API types**: Added `ServiceKind` constant to `v1alpha1/types.go`
- **Build spec**: Registered the service resource model spec for CLI spec generation
- **Documentation**: Updated both English and Chinese README with the new Service resource description

### Usage Examples

```bash
# Create 1000 services with prefix "my-service" in default namespace
blade create k8s service-self create --name-prefix my-service --namespace default --count 1000 --kubeconfig ~/.kube/config

# Modify service traffic policy
blade create k8s service-self modify --name my-service --namespace default --externalTrafficPolicy Local --kubeconfig ~/.kube/config
```

## Test Plan

- [ ] Verify batch service creation with various counts (1, 100, 1000)
- [ ] Verify service cleanup (destroy) removes all created services
- [ ] Verify modify action changes traffic policies correctly
- [ ] Verify modify destroy restores original policies from annotations
- [ ] Verify RBAC permissions allow service CRUD operations
- [ ] Verify both x86 and arm64 Helm chart deployments work correctly


Made with [Cursor](https://cursor.com)