### PR TITLE
feat(pod): add imageconfig experiment action for pod image configuration

### DIFF
--- a/exec/pod/imageconfigexp.go
+++ b/exec/pod/imageconfigexp.go
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pod
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/chaosblade-io/chaosblade-operator/channel"
+	"github.com/chaosblade-io/chaosblade-operator/exec/model"
+	"github.com/chaosblade-io/chaosblade-operator/pkg/apis/chaosblade/v1alpha1"
+)
+
+type ImageConfigActionSpec struct {
+	spec.BaseExpActionCommandSpec
+}
+
+const (
+	ImageNameFlag = "image-name"
+	ImageTagFlag  = "image-tag"
+)
+
+func NewImageConfigActionSpec(client *channel.Client) spec.ExpActionCommandSpec {
+	return &ImageConfigActionSpec{
+		spec.BaseExpActionCommandSpec{
+			ActionMatchers: []spec.ExpFlagSpec{},
+			ActionFlags: []spec.ExpFlagSpec{
+				&spec.ExpFlag{
+					Name: ImageNameFlag,
+					Desc: "The image name to replace the original image name, e.g. nginx-not-exist",
+				},
+				&spec.ExpFlag{
+					Name: ImageTagFlag,
+					Desc: "The image tag to replace the original image tag, e.g. non-existent-tag",
+				},
+			},
+			ActionExecutor: &ImageConfigActionExecutor{client: client},
+			ActionExample: `# Inject image config error to pods with default behavior
+blade create k8s pod-pod imageconfig --labels "app=test" --namespace default
+
+# Inject image config error with custom image name
+blade create k8s pod-pod imageconfig --labels "app=test" --namespace default --image-name nginx-not-exist
+
+# Inject image config error with custom image tag
+blade create k8s pod-pod imageconfig --labels "app=test" --namespace default --image-tag non-existent-tag
+
+# Inject image config error with both custom image name and tag
+blade create k8s pod-pod imageconfig --labels "app=test" --namespace default --image-name nginx-not-exist --image-tag non-existent-tag
+`,
+			ActionCategories: []string{model.CategorySystemContainer},
+		},
+	}
+}
+
+func (*ImageConfigActionSpec) Name() string {
+	return "imageconfig"
+}
+
+func (*ImageConfigActionSpec) Aliases() []string {
+	return []string{}
+}
+
+func (*ImageConfigActionSpec) ShortDesc() string {
+	return "Inject image config error to pods"
+}
+
+func (*ImageConfigActionSpec) LongDesc() string {
+	return "Modify pod container image to a non-existent image to simulate image config error"
+}
+
+type ImageConfigActionExecutor struct {
+	client *channel.Client
+}
+
+func (*ImageConfigActionExecutor) Name() string {
+	return "imageconfig"
+}
+
+func (*ImageConfigActionExecutor) SetChannel(channel spec.Channel) {}
+
+func (d *ImageConfigActionExecutor) Exec(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	if _, ok := spec.IsDestroy(ctx); ok {
+		return d.destroy(ctx, expModel)
+	}
+	return d.create(ctx, expModel)
+}
+
+func (d *ImageConfigActionExecutor) create(ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	imageName := expModel.ActionFlags[ImageNameFlag]
+	imageTag := expModel.ActionFlags[ImageTagFlag]
+	experimentId := model.GetExperimentIdFromContext(ctx)
+	logrusField := logrus.WithField("experiment", experimentId)
+	containerMatchedList, err := model.GetContainerObjectMetaListFromContext(ctx)
+	if err != nil {
+		util.Errorf(experimentId, util.GetRunFuncName(), err.Error())
+		return spec.ResponseFailWithResult(spec.ContainerInContextNotFound,
+			v1alpha1.CreateFailExperimentStatus(spec.ContainerInContextNotFound.Msg, []v1alpha1.ResourceStatus{}))
+	}
+	statuses := make([]v1alpha1.ResourceStatus, 0)
+	success := false
+	for _, c := range containerMatchedList {
+		status := v1alpha1.ResourceStatus{
+			Kind:       v1alpha1.PodKind,
+			Identifier: c.GetIdentifier(),
+		}
+		objectMeta := types.NamespacedName{Name: c.PodName, Namespace: c.Namespace}
+		pod := &v1.Pod{}
+		err := d.client.Get(ctx, objectMeta, pod)
+		if err != nil {
+			logrusField.Errorf("get pod %s err, %v", c.PodName, err)
+			status = status.CreateFailResourceStatus(spec.K8sExecFailed.Sprintf("get", err), spec.K8sExecFailed.Code)
+			statuses = append(statuses, status)
+			continue
+		}
+
+		if !isImageConfigPodReady(pod) {
+			logrusField.Infof("pod %s is not ready", c.PodName)
+			statuses = append(statuses, status.CreateFailResourceStatus(spec.PodNotReady.Sprintf(c.PodName),
+				spec.PodNotReady.Code))
+			continue
+		}
+
+		if err := d.modifyPodImage(ctx, pod, imageName, imageTag); err != nil {
+			logrusField.Warningf("modify pod %s image err, %v", c.PodName, err)
+			status = status.CreateFailResourceStatus(spec.K8sExecFailed.Sprintf("update", err), spec.K8sExecFailed.Code)
+		} else {
+			status = status.CreateSuccessResourceStatus()
+			success = true
+		}
+		statuses = append(statuses, status)
+	}
+	var experimentStatus v1alpha1.ExperimentStatus
+	if success {
+		experimentStatus = v1alpha1.CreateSuccessExperimentStatus(statuses)
+	} else {
+		experimentStatus = v1alpha1.CreateFailExperimentStatus("see resStatuses for details", statuses)
+	}
+	return spec.ReturnResultIgnoreCode(experimentStatus)
+}
+
+func (d *ImageConfigActionExecutor) destroy(ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	containerMatchedList, err := model.GetContainerObjectMetaListFromContext(ctx)
+	experimentId := model.GetExperimentIdFromContext(ctx)
+	if err != nil {
+		util.Errorf(experimentId, util.GetRunFuncName(), err.Error())
+		return spec.ResponseFailWithResult(spec.ContainerInContextNotFound,
+			v1alpha1.CreateFailExperimentStatus(spec.ContainerInContextNotFound.Msg, []v1alpha1.ResourceStatus{}))
+	}
+	logrusField := logrus.WithField("experiment", experimentId)
+	experimentStatus := v1alpha1.CreateDestroyedExperimentStatus([]v1alpha1.ResourceStatus{})
+	statuses := experimentStatus.ResStatuses
+	for _, c := range containerMatchedList {
+		status := v1alpha1.ResourceStatus{
+			Kind:       v1alpha1.PodKind,
+			Identifier: c.GetIdentifier(),
+		}
+		objectMeta := types.NamespacedName{Name: c.PodName, Namespace: c.Namespace}
+		pod := &v1.Pod{}
+		err := d.client.Get(ctx, objectMeta, pod)
+		if err != nil {
+			logrusField.Errorf("get pod %s err, %v", c.PodName, err)
+			status = status.CreateFailResourceStatus(spec.K8sExecFailed.Sprintf("get", err), spec.K8sExecFailed.Code)
+			statuses = append(statuses, status)
+			continue
+		}
+
+		err = d.client.Delete(ctx, pod)
+		if err != nil {
+			logrusField.Errorf("delete pod %s err, %v", c.PodName, err)
+			status = status.CreateFailResourceStatus(spec.K8sExecFailed.Sprintf("delete", err), spec.K8sExecFailed.Code)
+			statuses = append(statuses, status)
+			continue
+		}
+		status = status.CreateSuccessResourceStatus()
+		statuses = append(statuses, status)
+	}
+	experimentStatus.ResStatuses = statuses
+	return spec.ReturnResultIgnoreCode(experimentStatus)
+}
+
+// modifyPodImage modifies the pod container images to simulate image config error.
+// If imageName and imageTag are both empty, it appends "-image-config-error" to the original image (default behavior).
+// If imageName is provided, the image name portion is replaced.
+// If imageTag is provided, the image tag portion is replaced.
+func (d *ImageConfigActionExecutor) modifyPodImage(ctx context.Context, pod *v1.Pod, imageName, imageTag string) error {
+	modified := false
+	for i, container := range pod.Spec.Containers {
+		key := fmt.Sprintf("%s-%s", "chaosblade.io/imageconfig", container.Name)
+		if pod.Annotations == nil {
+			pod.Annotations = make(map[string]string)
+		}
+		if isImageConfigAnnotationExist(pod.Annotations, key) {
+			continue
+		}
+		pod.Annotations[key] = container.Image
+		pod.Spec.Containers[i].Image = buildNewImage(container.Image, imageName, imageTag)
+		modified = true
+	}
+	if !modified {
+		return nil
+	}
+	return d.client.Update(ctx, pod)
+}
+
+// buildNewImage constructs the new image string based on provided imageName and imageTag.
+// If both are empty, returns "{original}-image-config-error" for backward compatibility.
+// The original image format can be: "name", "name:tag", "registry/name", "registry/name:tag".
+func buildNewImage(originalImage, imageName, imageTag string) string {
+	if imageName == "" && imageTag == "" {
+		return fmt.Sprintf("%s-image-config-error", originalImage)
+	}
+
+	// Parse the original image into name and tag parts
+	origName, origTag := parseImage(originalImage)
+
+	if imageName != "" {
+		origName = imageName
+	}
+	if imageTag != "" {
+		origTag = imageTag
+	}
+
+	if origTag == "" {
+		return origName
+	}
+	return fmt.Sprintf("%s:%s", origName, origTag)
+}
+
+// parseImage splits an image reference into name and tag.
+// Handles formats like "nginx", "nginx:latest", "registry.example.com/nginx:v1.0".
+func parseImage(image string) (name, tag string) {
+	// Find the last colon that is not part of a registry port (after the last /)
+	slashIdx := strings.LastIndex(image, "/")
+	colonIdx := strings.LastIndex(image, ":")
+
+	// If colon exists and is after the last slash, it's a tag separator
+	if colonIdx > slashIdx {
+		return image[:colonIdx], image[colonIdx+1:]
+	}
+	return image, ""
+}
+
+// isImageConfigAnnotationExist checks if the annotation already exists
+func isImageConfigAnnotationExist(annotation map[string]string, key string) bool {
+	_, ok := annotation[key]
+	if !ok {
+		return false
+	}
+	return true
+}
+
+// isImageConfigPodReady checks if the pod is ready
+func isImageConfigPodReady(pod *v1.Pod) bool {
+	if pod.ObjectMeta.DeletionTimestamp != nil {
+		return false
+	}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == v1.PodReady &&
+			condition.Status == v1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}

--- a/exec/pod/imageconfigexp_test.go
+++ b/exec/pod/imageconfigexp_test.go
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pod
+
+import (
+	"testing"
+)
+
+func TestParseImage(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantName string
+		wantTag  string
+	}{
+		{"nginx", "nginx", ""},
+		{"nginx:latest", "nginx", "latest"},
+		{"nginx:1.19.0", "nginx", "1.19.0"},
+		{"registry.example.com/nginx", "registry.example.com/nginx", ""},
+		{"registry.example.com/nginx:v1.0", "registry.example.com/nginx", "v1.0"},
+		{"registry.example.com:5000/nginx", "registry.example.com:5000/nginx", ""},
+		{"registry.example.com:5000/nginx:v1.0", "registry.example.com:5000/nginx", "v1.0"},
+		{"my-registry.io:5000/my-org/my-image:sha-abc123", "my-registry.io:5000/my-org/my-image", "sha-abc123"},
+		{"localhost:5000/test", "localhost:5000/test", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			gotName, gotTag := parseImage(tt.input)
+			if gotName != tt.wantName {
+				t.Errorf("parseImage(%q) name = %q, want %q", tt.input, gotName, tt.wantName)
+			}
+			if gotTag != tt.wantTag {
+				t.Errorf("parseImage(%q) tag = %q, want %q", tt.input, gotTag, tt.wantTag)
+			}
+		})
+	}
+}
+
+func TestBuildNewImage(t *testing.T) {
+	tests := []struct {
+		name          string
+		originalImage string
+		imageName     string
+		imageTag      string
+		want          string
+	}{
+		// Default behavior: both params empty -> append "-image-config-error"
+		{
+			name:          "default behavior - simple image",
+			originalImage: "nginx",
+			imageName:     "",
+			imageTag:      "",
+			want:          "nginx-image-config-error",
+		},
+		{
+			name:          "default behavior - image with tag",
+			originalImage: "nginx:latest",
+			imageName:     "",
+			imageTag:      "",
+			want:          "nginx:latest-image-config-error",
+		},
+		{
+			name:          "default behavior - full registry path",
+			originalImage: "registry.example.com/nginx:v1.0",
+			imageName:     "",
+			imageTag:      "",
+			want:          "registry.example.com/nginx:v1.0-image-config-error",
+		},
+
+		// Only imageName provided
+		{
+			name:          "replace image name only - simple image",
+			originalImage: "nginx",
+			imageName:     "nginx-not-exist",
+			imageTag:      "",
+			want:          "nginx-not-exist",
+		},
+		{
+			name:          "replace image name only - image with tag",
+			originalImage: "nginx:latest",
+			imageName:     "nginx-not-exist",
+			imageTag:      "",
+			want:          "nginx-not-exist:latest",
+		},
+		{
+			name:          "replace image name only - full registry path",
+			originalImage: "registry.example.com/nginx:v1.0",
+			imageName:     "my-bad-image",
+			imageTag:      "",
+			want:          "my-bad-image:v1.0",
+		},
+
+		// Only imageTag provided
+		{
+			name:          "replace tag only - simple image without tag",
+			originalImage: "nginx",
+			imageName:     "",
+			imageTag:      "non-existent-tag",
+			want:          "nginx:non-existent-tag",
+		},
+		{
+			name:          "replace tag only - image with tag",
+			originalImage: "nginx:latest",
+			imageName:     "",
+			imageTag:      "non-existent-tag",
+			want:          "nginx:non-existent-tag",
+		},
+		{
+			name:          "replace tag only - full registry path",
+			originalImage: "registry.example.com/nginx:v1.0",
+			imageName:     "",
+			imageTag:      "broken-tag",
+			want:          "registry.example.com/nginx:broken-tag",
+		},
+
+		// Both imageName and imageTag provided
+		{
+			name:          "replace both name and tag",
+			originalImage: "nginx:latest",
+			imageName:     "bad-image",
+			imageTag:      "bad-tag",
+			want:          "bad-image:bad-tag",
+		},
+		{
+			name:          "replace both - full registry path",
+			originalImage: "registry.example.com/nginx:v1.0",
+			imageName:     "totally-wrong",
+			imageTag:      "no-such-tag",
+			want:          "totally-wrong:no-such-tag",
+		},
+
+		// Edge cases with registry port
+		{
+			name:          "registry with port - replace tag only",
+			originalImage: "registry.example.com:5000/nginx:v1.0",
+			imageName:     "",
+			imageTag:      "broken",
+			want:          "registry.example.com:5000/nginx:broken",
+		},
+		{
+			name:          "registry with port no tag - replace tag",
+			originalImage: "registry.example.com:5000/nginx",
+			imageName:     "",
+			imageTag:      "broken",
+			want:          "registry.example.com:5000/nginx:broken",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildNewImage(tt.originalImage, tt.imageName, tt.imageTag)
+			if got != tt.want {
+				t.Errorf("buildNewImage(%q, %q, %q) = %q, want %q",
+					tt.originalImage, tt.imageName, tt.imageTag, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsImageConfigAnnotationExist(t *testing.T) {
+	tests := []struct {
+		name       string
+		annotation map[string]string
+		key        string
+		want       bool
+	}{
+		{
+			name:       "annotation exists",
+			annotation: map[string]string{"imageConfig-nginx": "nginx:latest"},
+			key:        "imageConfig-nginx",
+			want:       true,
+		},
+		{
+			name:       "annotation does not exist",
+			annotation: map[string]string{"imageConfig-nginx": "nginx:latest"},
+			key:        "imageConfig-redis",
+			want:       false,
+		},
+		{
+			name:       "empty annotations",
+			annotation: map[string]string{},
+			key:        "imageConfig-nginx",
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isImageConfigAnnotationExist(tt.annotation, tt.key)
+			if got != tt.want {
+				t.Errorf("isImageConfigAnnotationExist() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/exec/pod/pod.go
+++ b/exec/pod/pod.go
@@ -270,6 +270,7 @@ func NewSelfExpModelCommandSpec(client *channel.Client) spec.ExpModelCommandSpec
 				NewFailPodActionSpec(client),
 				NewPodTerminatingActionSpec(client),
 				NewPodContainerCreatingActionSpec(client),
+				NewImageConfigActionSpec(client),
 			},
 		},
 	}


### PR DESCRIPTION
Add ImageConfigActionSpec to support modifying pod container image configuration (image name and tag) as a chaos experiment. This enables testing application resilience to image configuration changes.

- Add imageconfigexp.go with ImageConfigActionSpec implementation
- Add imageconfigexp_test.go with unit tests
- Register NewImageConfigActionSpec in pod experiment model

Change-Id: I973e9e67e631f364f9c0d35e16f3d962bee44578
Co-developed-by: Qoder <noreply@qoder.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
新增 imageconfig 混沌实验动作，通过修改 Pod 容器镜像为不存在的镜像来模拟镜像配置错误，支持自定义 --image-name 和 --image-tag 参数。

### Does this pull request fix one issue?
NONE

### Describe how you did it
1. 新增 exec/pod/imageconfigexp.go：实现 ImageConfigActionSpec 和 ImageConfigActionExecutor，支持修改 Pod 容器镜像并通过 annotation 保存原始镜像信息；destroy 时通过删除 Pod 触发控制器重建恢复
2. 新增 exec/pod/imageconfigexp_test.go：覆盖镜像解析、镜像构建、annotation 判断等核心逻辑的单元测试
3. 修改 exec/pod/pod.go：注册 NewImageConfigActionSpec 到 Pod 实验模型

### Describe how to verify it
```bash
# 创建测试应用
kubectl create deployment test --image=nginx --namespace default

# 默认行为：镜像后追加 -image-config-error
blade create k8s pod-pod imageconfig --labels "app=test" --namespace default

# 自定义镜像名/标签
blade create k8s pod-pod imageconfig --labels "app=test" --namespace default --image-name nginx-not-exist --image-tag non-existent-tag

# 销毁实验，Pod 自动重建恢复
blade destroy <uid>

# 单元测试
go test ./exec/pod/ -run "TestParseImage|TestBuildNewImage|TestIsImageConfigAnnotationExist" -v
```

### Special notes for reviews
- destroy 采用删除 Pod 而非还原镜像，依赖 Deployment 等控制器自动重建，与项目中已有的 delete 动作保持一致
- parseImage 通过比较冒号与最后一个斜杠的位置来正确处理带端口的 registry 地址（如 registry:5000/image:tag）
- 原始镜像通过 imageConfig-{containerName} annotation 保存，防止对同一容器重复注入
