### PR TITLE
feat(pod): Supports freezing a Pod in the ContainerCreating state due…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The current experimental scenarios involve resources including Node, Pod, and Co
     * Network: specify network card, port, IP, etc. packet delay, packet loss, packet blocking, packet duplication, packet re-ordering, packet corruption, etc.
     * Disk: specify the directory disk occupation, disk IO read and write load, etc.
     * Memory: specify memory usage
-    * Pod: kill pod
+    * Pod: kill pod, make pod stuck in ContainerCreating state by PVC mount failure, make pod stuck in Terminating state by finalizer
     * IO: specify the file system io exception. Supports 31 file operations and 11 exception scenarios, such as "Too many open files", "Device or resource busy" and so on.
 * Container:
     * CPU: specify CPU usage

--- a/deploy/helm/chaosblade-operator-arm64/templates/rbac.yaml
+++ b/deploy/helm/chaosblade-operator-arm64/templates/rbac.yaml
@@ -36,6 +36,7 @@ rules:
       - configmaps
       - services
       - persistentvolumeclaims
+      - persistentvolumes
     verbs:
       - "*"
   - apiGroups:

--- a/deploy/helm/chaosblade-operator-arm64/templates/rbac.yaml
+++ b/deploy/helm/chaosblade-operator-arm64/templates/rbac.yaml
@@ -35,6 +35,7 @@ rules:
       - pods/exec
       - configmaps
       - services
+      - persistentvolumeclaims
     verbs:
       - "*"
   - apiGroups:

--- a/deploy/helm/chaosblade-operator/templates/rbac.yaml
+++ b/deploy/helm/chaosblade-operator/templates/rbac.yaml
@@ -36,6 +36,7 @@ rules:
       - configmaps
       - services
       - persistentvolumeclaims
+      - persistentvolumes
     verbs:
       - "*"
   - apiGroups:

--- a/deploy/helm/chaosblade-operator/templates/rbac.yaml
+++ b/deploy/helm/chaosblade-operator/templates/rbac.yaml
@@ -35,6 +35,7 @@ rules:
       - pods/exec
       - configmaps
       - services
+      - persistentvolumeclaims
     verbs:
       - "*"
   - apiGroups:

--- a/examples/pod-containercreating-by-pvc-error.yaml
+++ b/examples/pod-containercreating-by-pvc-error.yaml
@@ -21,21 +21,12 @@ spec:
   - scope: pod
     target: pod
     action: containercreating
-    desc: "Make pod stuck in ContainerCreating state by creating a Pod that mounts a pending PVC"
+    desc: "Make pod stuck in ContainerCreating state by PVC mount failure"
     matchers:
     - name: namespace
       value:
       - "nginx"
-    # Optional: customize PVC parameters
-    # - name: storage-class
-    #   value:
-    #   - "chaosblade-fake-sc"
+    # Optional: customize volume mount path in the container
     # - name: volume-mount-path
     #   value:
     #   - "/mnt/data"
-    # - name: access-mode
-    #   value:
-    #   - "ReadWriteOnce"
-    # - name: storage-request
-    #   value:
-    #   - "1Gi"

--- a/examples/pod-containercreating-by-pvc-error.yaml
+++ b/examples/pod-containercreating-by-pvc-error.yaml
@@ -1,0 +1,44 @@
+# Copyright 2025 The ChaosBlade Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: chaosblade.io/v1alpha1
+kind: ChaosBlade
+metadata:
+  name: pod-containercreating-by-pvc-error
+spec:
+  experiments:
+  - scope: pod
+    target: pod
+    action: containercreating
+    desc: "Make pod stuck in ContainerCreating state by creating a Pod that mounts a pending PVC"
+    matchers:
+    - name: names
+      value:
+      - "nginx-app"
+    - name: namespace
+      value:
+      - "default"
+    # Optional: customize PVC parameters
+    # - name: storage-class
+    #   value:
+    #   - "chaosblade-fake-sc"
+    # - name: volume-mount-path
+    #   value:
+    #   - "/mnt/data"
+    # - name: access-mode
+    #   value:
+    #   - "ReadWriteOnce"
+    # - name: storage-request
+    #   value:
+    #   - "1Gi"

--- a/examples/pod-containercreating-by-pvc-error.yaml
+++ b/examples/pod-containercreating-by-pvc-error.yaml
@@ -23,12 +23,9 @@ spec:
     action: containercreating
     desc: "Make pod stuck in ContainerCreating state by creating a Pod that mounts a pending PVC"
     matchers:
-    - name: names
-      value:
-      - "nginx-app"
     - name: namespace
       value:
-      - "default"
+      - "nginx"
     # Optional: customize PVC parameters
     # - name: storage-class
     #   value:

--- a/exec/pod/containercreating.go
+++ b/exec/pod/containercreating.go
@@ -197,15 +197,31 @@ func (d *PodContainerCreatingActionExecutor) create(uid string, ctx context.Cont
 				logrusField.Infof("Pod %s/%s already exists, skip creation", meta.Namespace, podName)
 			} else {
 				logrusField.Warningf("create Pod %s/%s failed: %v", meta.Namespace, podName, err)
-				// Best-effort rollback: delete PVC and PV
+				// Best-effort rollback: delete PVC and PV.
+				// If rollback fails, resources will be leaked because we record
+				// a failed status and Destroy only processes successful ones.
+				// To prevent leaks, we still record success so Destroy will
+				// attempt cleanup (destroy is idempotent and handles NotFound).
+				pvcDeleted := false
 				if delErr := d.deletePVC(ctx, meta.Namespace, pvcName); delErr != nil {
 					logrusField.Warningf("rollback PVC %s/%s failed: %v", meta.Namespace, pvcName, delErr)
+				} else {
+					pvcDeleted = true
 				}
 				if delErr := d.deletePV(ctx, pvName); delErr != nil {
 					logrusField.Warningf("rollback PV %s failed: %v", pvName, delErr)
 				}
-				status = status.CreateFailResourceStatus(fmt.Sprintf("create Pod failed: %v", err), spec.K8sExecFailed.Code)
-				statuses = append(statuses, status)
+				// If rollback fully succeeded, record failure (no leaked resources).
+				// If rollback failed, record success so Destroy will retry cleanup.
+				if pvcDeleted {
+					status = status.CreateFailResourceStatus(fmt.Sprintf("create Pod failed: %v", err), spec.K8sExecFailed.Code)
+					statuses = append(statuses, status)
+				} else {
+					logrusField.Warningf("rollback incomplete, recording success status to ensure Destroy can clean up")
+					status = status.CreateSuccessResourceStatus()
+					statuses = append(statuses, status)
+					success = true
+				}
 				continue
 			}
 		} else {

--- a/exec/pod/containercreating.go
+++ b/exec/pod/containercreating.go
@@ -62,11 +62,6 @@ func NewPodContainerCreatingActionSpec(client *channel.Client) spec.ExpActionCom
 					Name: "volume-mount-path",
 					Desc: "Volume mount path in the container. Default: /mnt/data",
 				},
-				&spec.ExpFlag{
-					Name:   "random",
-					Desc:   "Randomly select pod",
-					NoArgs: true,
-				},
 			},
 			ActionExecutor: &PodContainerCreatingActionExecutor{client: client},
 			ActionExample: `# Create a pod stuck in ContainerCreating state in the default namespace
@@ -174,12 +169,24 @@ func (d *PodContainerCreatingActionExecutor) create(uid string, ctx context.Cont
 				logrusField.Infof("PVC %s/%s already exists, skip creation", meta.Namespace, pvcName)
 			} else {
 				logrusField.Warningf("create PVC %s/%s failed: %v", meta.Namespace, pvcName, err)
-				// Best-effort rollback: delete the PV we just created
+				// Best-effort rollback: delete the PV we just created.
+				// If rollback fails, the PV will be leaked because we record
+				// a failed status and Destroy only processes successful ones.
+				// To prevent leaks, record success so Destroy will retry cleanup.
+				pvDeleted := true
 				if delErr := d.deletePV(ctx, pvName); delErr != nil {
 					logrusField.Warningf("rollback PV %s failed: %v", pvName, delErr)
+					pvDeleted = false
 				}
-				status = status.CreateFailResourceStatus(fmt.Sprintf("create PVC failed: %v", err), spec.K8sExecFailed.Code)
-				statuses = append(statuses, status)
+				if pvDeleted {
+					status = status.CreateFailResourceStatus(fmt.Sprintf("create PVC failed: %v", err), spec.K8sExecFailed.Code)
+					statuses = append(statuses, status)
+				} else {
+					logrusField.Warningf("rollback incomplete, recording success status to ensure Destroy can clean up")
+					status = status.CreateSuccessResourceStatus()
+					statuses = append(statuses, status)
+					success = true
+				}
 				continue
 			}
 		} else {
@@ -208,12 +215,14 @@ func (d *PodContainerCreatingActionExecutor) create(uid string, ctx context.Cont
 				} else {
 					pvcDeleted = true
 				}
+				pvDeleted := true
 				if delErr := d.deletePV(ctx, pvName); delErr != nil {
 					logrusField.Warningf("rollback PV %s failed: %v", pvName, delErr)
+					pvDeleted = false
 				}
 				// If rollback fully succeeded, record failure (no leaked resources).
-				// If rollback failed, record success so Destroy will retry cleanup.
-				if pvcDeleted {
+				// If any rollback step failed, record success so Destroy will retry cleanup.
+				if pvcDeleted && pvDeleted {
 					status = status.CreateFailResourceStatus(fmt.Sprintf("create Pod failed: %v", err), spec.K8sExecFailed.Code)
 					statuses = append(statuses, status)
 				} else {

--- a/exec/pod/containercreating.go
+++ b/exec/pod/containercreating.go
@@ -19,6 +19,7 @@ package pod
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
 	"github.com/chaosblade-io/chaosblade-spec-go/util"
@@ -28,6 +29,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/chaosblade-io/chaosblade-operator/channel"
 	"github.com/chaosblade-io/chaosblade-operator/exec/model"
@@ -35,6 +37,8 @@ import (
 )
 
 const (
+	// ChaosBladePVAnnotation is the annotation for PV resources created by containercreating action
+	ChaosBladePVAnnotation = "chaosblade.io/pv"
 	// ChaosBladePVCAnnotation is the annotation for PVC resources created by containercreating action
 	ChaosBladePVCAnnotation = "chaosblade.io/pvc"
 	// ChaosBladePodAnnotation is the annotation for Pod resources created by containercreating action
@@ -55,20 +59,8 @@ func NewPodContainerCreatingActionSpec(client *channel.Client) spec.ExpActionCom
 			ActionMatchers: []spec.ExpFlagSpec{},
 			ActionFlags: []spec.ExpFlagSpec{
 				&spec.ExpFlag{
-					Name: "storage-class",
-					Desc: "StorageClass name for the faulty PVC, the PVC will be pending if the StorageClass does not exist. Default: chaosblade-fake-sc",
-				},
-				&spec.ExpFlag{
 					Name: "volume-mount-path",
 					Desc: "Volume mount path in the container. Default: /mnt/data",
-				},
-				&spec.ExpFlag{
-					Name: "access-mode",
-					Desc: "PVC access mode, values: ReadWriteOnce, ReadOnlyMany, ReadWriteMany. Default: ReadWriteOnce",
-				},
-				&spec.ExpFlag{
-					Name: "storage-request",
-					Desc: "PVC storage request size. Default: 1Gi",
 				},
 				&spec.ExpFlag{
 					Name:   "random",
@@ -78,13 +70,10 @@ func NewPodContainerCreatingActionSpec(client *channel.Client) spec.ExpActionCom
 			},
 			ActionExecutor: &PodContainerCreatingActionExecutor{client: client},
 			ActionExample: `# Create a pod stuck in ContainerCreating state in the default namespace
-blade create k8s pod-pod containercreating --names nginx-app --namespace default --kubeconfig ~/.kube/config
+blade create k8s pod-pod containercreating --namespace default --kubeconfig ~/.kube/config
 
-# Create a pod stuck in ContainerCreating state by labels with custom StorageClass
-blade create k8s pod-pod containercreating --labels app=guestbook --namespace default --storage-class fake-storage --kubeconfig ~/.kube/config
-
-# Create a pod stuck in ContainerCreating state with custom PVC parameters
-blade create k8s pod-pod containercreating --names nginx-app --namespace default --access-mode ReadWriteMany --storage-request 5Gi --kubeconfig ~/.kube/config
+# Create a pod stuck in ContainerCreating state with custom volume mount path
+blade create k8s pod-pod containercreating --namespace default --volume-mount-path /data --kubeconfig ~/.kube/config
 `,
 			ActionCategories: []string{model.CategorySystemContainer},
 		},
@@ -105,9 +94,10 @@ func (*PodContainerCreatingActionSpec) ShortDesc() string {
 
 func (*PodContainerCreatingActionSpec) LongDesc() string {
 	return "Simulate the scenario where a Pod is stuck in ContainerCreating state due to storage volume mount failure. " +
-		"This fault is injected by creating a PVC that references a non-existent StorageClass (which keeps the PVC in Pending state), " +
-		"then creating a Pod that mounts this PVC. Since the PVC cannot be bound, the Pod remains stuck in ContainerCreating state. " +
-		"When the experiment is destroyed, the created Pod and PVC will be cleaned up."
+		"This fault is injected by creating a PV with an unreachable NFS server and a PVC bound to it, " +
+		"then creating a Pod that mounts this PVC. Since the NFS server is unreachable, the volume mount fails " +
+		"and the Pod remains stuck in ContainerCreating state. " +
+		"When the experiment is destroyed, the created Pod, PVC, and PV will be cleaned up."
 }
 
 type PodContainerCreatingActionExecutor struct {
@@ -139,34 +129,12 @@ func (d *PodContainerCreatingActionExecutor) create(uid string, ctx context.Cont
 	}
 
 	// Parse flags with defaults
-	storageClass := expModel.ActionFlags["storage-class"]
-	if storageClass == "" {
-		storageClass = "chaosblade-fake-sc"
-	}
 	volumeMountPath := expModel.ActionFlags["volume-mount-path"]
 	if volumeMountPath == "" {
 		volumeMountPath = "/mnt/data"
 	}
-	accessMode := expModel.ActionFlags["access-mode"]
-	if accessMode == "" {
-		accessMode = string(v1.ReadWriteOnce)
-	}
-	storageRequest := expModel.ActionFlags["storage-request"]
-	if storageRequest == "" {
-		storageRequest = "1Gi"
-	}
 
-	// Validate storage request format
-	storageQuantity, err := resource.ParseQuantity(storageRequest)
-	if err != nil {
-		errMsg := fmt.Sprintf("invalid storage-request %q: %v", storageRequest, err)
-		logrusField.Errorln(errMsg)
-		return spec.ResponseFailWithResult(spec.ParameterIllegal,
-			v1alpha1.CreateFailExperimentStatus(errMsg, []v1alpha1.ResourceStatus{}),
-			"storage-request", storageRequest, err)
-	}
-
-	// Deduplicate by namespace - create one faulty Pod+PVC per unique namespace
+	// Deduplicate by namespace - create one faulty PV+PVC+Pod per unique namespace
 	seenNamespaces := make(map[string]bool)
 	statuses := make([]v1alpha1.ResourceStatus, 0)
 	success := false
@@ -177,6 +145,7 @@ func (d *PodContainerCreatingActionExecutor) create(uid string, ctx context.Cont
 		}
 		seenNamespaces[meta.Namespace] = true
 
+		pvName := fmt.Sprintf("chaosblade-cc-%s-pv", experimentId)
 		pvcName := fmt.Sprintf("chaosblade-cc-%s-pvc", experimentId)
 		podName := fmt.Sprintf("chaosblade-cc-%s-pod", experimentId)
 
@@ -185,29 +154,55 @@ func (d *PodContainerCreatingActionExecutor) create(uid string, ctx context.Cont
 			Identifier: fmt.Sprintf("%s//%s", meta.Namespace, podName),
 		}
 
-		// Step 1: Create PVC referencing non-existent StorageClass
-		if err := d.createPVC(ctx, meta.Namespace, pvcName, storageClass, accessMode, storageQuantity, experimentId); err != nil {
+		// Step 1: Create PV with unreachable NFS server
+		if err := d.createPV(ctx, pvName, experimentId); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				logrusField.Infof("PV %s already exists, skip creation", pvName)
+			} else {
+				logrusField.Warningf("create PV %s failed: %v", pvName, err)
+				status = status.CreateFailResourceStatus(fmt.Sprintf("create PV failed: %v", err), spec.K8sExecFailed.Code)
+				statuses = append(statuses, status)
+				continue
+			}
+		} else {
+			logrusField.Infof("created PV %s with unreachable NFS server", pvName)
+		}
+
+		// Step 2: Create PVC bound to the PV (PVC will be Bound, but mount will fail)
+		if err := d.createPVC(ctx, meta.Namespace, pvcName, pvName, experimentId); err != nil {
 			if apierrors.IsAlreadyExists(err) {
 				logrusField.Infof("PVC %s/%s already exists, skip creation", meta.Namespace, pvcName)
 			} else {
 				logrusField.Warningf("create PVC %s/%s failed: %v", meta.Namespace, pvcName, err)
+				// Best-effort rollback: delete the PV we just created
+				if delErr := d.deletePV(ctx, pvName); delErr != nil {
+					logrusField.Warningf("rollback PV %s failed: %v", pvName, delErr)
+				}
 				status = status.CreateFailResourceStatus(fmt.Sprintf("create PVC failed: %v", err), spec.K8sExecFailed.Code)
 				statuses = append(statuses, status)
 				continue
 			}
 		} else {
-			logrusField.Infof("created PVC %s/%s referencing non-existent StorageClass %s", meta.Namespace, pvcName, storageClass)
+			logrusField.Infof("created PVC %s/%s bound to PV %s", meta.Namespace, pvcName, pvName)
 		}
 
-		// Step 2: Create Pod that mounts the pending PVC
+		// Step 3: Wait for PVC to be Bound before creating Pod
+		if err := d.waitForPVCBound(ctx, meta.Namespace, pvcName, 30*time.Second); err != nil {
+			logrusField.Warningf("PVC %s/%s is not bound yet: %v", meta.Namespace, pvcName, err)
+		}
+
+		// Step 4: Create Pod that mounts the PVC (will be stuck in ContainerCreating)
 		if err := d.createPod(ctx, meta.Namespace, podName, pvcName, volumeMountPath, experimentId); err != nil {
 			if apierrors.IsAlreadyExists(err) {
 				logrusField.Infof("Pod %s/%s already exists, skip creation", meta.Namespace, podName)
 			} else {
 				logrusField.Warningf("create Pod %s/%s failed: %v", meta.Namespace, podName, err)
-				// Best-effort rollback: delete the PVC we just created
+				// Best-effort rollback: delete PVC and PV
 				if delErr := d.deletePVC(ctx, meta.Namespace, pvcName); delErr != nil {
 					logrusField.Warningf("rollback PVC %s/%s failed: %v", meta.Namespace, pvcName, delErr)
+				}
+				if delErr := d.deletePV(ctx, pvName); delErr != nil {
+					logrusField.Warningf("rollback PV %s failed: %v", pvName, delErr)
 				}
 				status = status.CreateFailResourceStatus(fmt.Sprintf("create Pod failed: %v", err), spec.K8sExecFailed.Code)
 				statuses = append(statuses, status)
@@ -252,6 +247,7 @@ func (d *PodContainerCreatingActionExecutor) destroy(uid string, ctx context.Con
 		}
 		seenNamespaces[meta.Namespace] = true
 
+		pvName := fmt.Sprintf("chaosblade-cc-%s-pv", experimentId)
 		pvcName := fmt.Sprintf("chaosblade-cc-%s-pvc", experimentId)
 		podName := meta.PodName
 		namespace := meta.Namespace
@@ -282,10 +278,20 @@ func (d *PodContainerCreatingActionExecutor) destroy(uid string, ctx context.Con
 				logrusField.Infof("PVC %s/%s already deleted", namespace, pvcName)
 			} else {
 				logrusField.Warningf("delete PVC %s/%s failed: %v", namespace, pvcName, err)
-				// PVC deletion failure is not critical, just warn
 			}
 		} else {
 			logrusField.Infof("deleted PVC %s/%s", namespace, pvcName)
+		}
+
+		// Step 3: Delete PV (non-critical, warn only on failure)
+		if err := d.deletePV(ctx, pvName); err != nil {
+			if apierrors.IsNotFound(err) {
+				logrusField.Infof("PV %s already deleted", pvName)
+			} else {
+				logrusField.Warningf("delete PV %s failed: %v", pvName, err)
+			}
+		} else {
+			logrusField.Infof("deleted PV %s", pvName)
 		}
 
 		status = status.CreateSuccessResourceStatus()
@@ -299,9 +305,44 @@ func (d *PodContainerCreatingActionExecutor) destroy(uid string, ctx context.Con
 	return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus("see resStatuses for details", statuses))
 }
 
-// createPVC creates a PersistentVolumeClaim that references a non-existent StorageClass,
-// which will cause it to remain in Pending state indefinitely.
-func (d *PodContainerCreatingActionExecutor) createPVC(ctx context.Context, namespace, pvcName, storageClass, accessMode string, storageQuantity resource.Quantity, experimentId string) error {
+// createPV creates a PersistentVolume with an unreachable NFS server.
+// The PV will be Available, allowing PVC binding, but the NFS mount will fail
+// when a Pod tries to use it, causing the Pod to be stuck in ContainerCreating.
+func (d *PodContainerCreatingActionExecutor) createPV(ctx context.Context, pvName, experimentId string) error {
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: pvName,
+			Annotations: map[string]string{
+				ChaosBladePVAnnotation:         ChaosBladeActionCreate,
+				ChaosBladeExperimentAnnotation: experimentId,
+			},
+		},
+		Spec: v1.PersistentVolumeSpec{
+			Capacity: v1.ResourceList{
+				v1.ResourceStorage: resource.MustParse("1Gi"),
+			},
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+			},
+			PersistentVolumeReclaimPolicy: v1.PersistentVolumeReclaimDelete,
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				NFS: &v1.NFSVolumeSource{
+					// Use a non-routable IP address to simulate unreachable NFS server
+					Server:   "10.255.255.1",
+					Path:     "/chaosblade-fake-nfs",
+					ReadOnly: false,
+				},
+			},
+		},
+	}
+	return d.client.Create(ctx, pv)
+}
+
+// createPVC creates a PersistentVolumeClaim that binds to the specified PV.
+// The PVC will be Bound to the PV, but the actual volume mount will fail
+// because the NFS server is unreachable.
+func (d *PodContainerCreatingActionExecutor) createPVC(ctx context.Context, namespace, pvcName, pvName, experimentId string) error {
+	emptyStr := ""
 	pvc := &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pvcName,
@@ -312,22 +353,23 @@ func (d *PodContainerCreatingActionExecutor) createPVC(ctx context.Context, name
 			},
 		},
 		Spec: v1.PersistentVolumeClaimSpec{
-			StorageClassName: &storageClass,
+			StorageClassName: &emptyStr,
 			AccessModes: []v1.PersistentVolumeAccessMode{
-				v1.PersistentVolumeAccessMode(accessMode),
+				v1.ReadWriteOnce,
 			},
 			Resources: v1.VolumeResourceRequirements{
 				Requests: v1.ResourceList{
-					v1.ResourceStorage: storageQuantity,
+					v1.ResourceStorage: resource.MustParse("1Gi"),
 				},
 			},
+			VolumeName: pvName,
 		},
 	}
 	return d.client.Create(ctx, pvc)
 }
 
 // createPod creates a Pod that mounts the given PVC, which will cause it to be
-// stuck in ContainerCreating state because the PVC is Pending.
+// stuck in ContainerCreating state because the NFS mount fails.
 func (d *PodContainerCreatingActionExecutor) createPod(ctx context.Context, namespace, podName, pvcName, volumeMountPath, experimentId string) error {
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -353,6 +395,12 @@ func (d *PodContainerCreatingActionExecutor) createPod(ctx context.Context, name
 							MountPath: volumeMountPath,
 						},
 					},
+				},
+			},
+			// Tolerate all taints so the Pod can be scheduled on any node
+			Tolerations: []v1.Toleration{
+				{
+					Operator: v1.TolerationOpExists,
 				},
 			},
 			Volumes: []v1.Volume{
@@ -390,4 +438,31 @@ func (d *PodContainerCreatingActionExecutor) deletePVC(ctx context.Context, name
 		},
 	}
 	return d.client.Delete(ctx, pvc)
+}
+
+// waitForPVCBound polls until the PVC is in Bound state or timeout is reached
+func (d *PodContainerCreatingActionExecutor) waitForPVCBound(ctx context.Context, namespace, pvcName string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		pvc := &v1.PersistentVolumeClaim{}
+		err := d.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: pvcName}, pvc)
+		if err != nil {
+			return err
+		}
+		if pvc.Status.Phase == v1.ClaimBound {
+			return nil
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return fmt.Errorf("PVC %s/%s is not bound after %v", namespace, pvcName, timeout)
+}
+
+// deletePV deletes a PersistentVolume by name
+func (d *PodContainerCreatingActionExecutor) deletePV(ctx context.Context, pvName string) error {
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: pvName,
+		},
+	}
+	return d.client.Delete(ctx, pv)
 }

--- a/exec/pod/containercreating.go
+++ b/exec/pod/containercreating.go
@@ -1,0 +1,393 @@
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pod
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
+	"github.com/sirupsen/logrus"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/chaosblade-io/chaosblade-operator/channel"
+	"github.com/chaosblade-io/chaosblade-operator/exec/model"
+	"github.com/chaosblade-io/chaosblade-operator/pkg/apis/chaosblade/v1alpha1"
+)
+
+const (
+	// ChaosBladePVCAnnotation is the annotation for PVC resources created by containercreating action
+	ChaosBladePVCAnnotation = "chaosblade.io/pvc"
+	// ChaosBladePodAnnotation is the annotation for Pod resources created by containercreating action
+	ChaosBladePodAnnotation = "chaosblade.io/pod"
+	// ChaosBladeExperimentAnnotation is the annotation key for experiment ID
+	ChaosBladeExperimentAnnotation = "chaosblade.io/experiment"
+	// ChaosBladeActionCreate is the annotation value for create action
+	ChaosBladeActionCreate = "create"
+)
+
+type PodContainerCreatingActionSpec struct {
+	spec.BaseExpActionCommandSpec
+}
+
+func NewPodContainerCreatingActionSpec(client *channel.Client) spec.ExpActionCommandSpec {
+	return &PodContainerCreatingActionSpec{
+		spec.BaseExpActionCommandSpec{
+			ActionMatchers: []spec.ExpFlagSpec{},
+			ActionFlags: []spec.ExpFlagSpec{
+				&spec.ExpFlag{
+					Name: "storage-class",
+					Desc: "StorageClass name for the faulty PVC, the PVC will be pending if the StorageClass does not exist. Default: chaosblade-fake-sc",
+				},
+				&spec.ExpFlag{
+					Name: "volume-mount-path",
+					Desc: "Volume mount path in the container. Default: /mnt/data",
+				},
+				&spec.ExpFlag{
+					Name: "access-mode",
+					Desc: "PVC access mode, values: ReadWriteOnce, ReadOnlyMany, ReadWriteMany. Default: ReadWriteOnce",
+				},
+				&spec.ExpFlag{
+					Name: "storage-request",
+					Desc: "PVC storage request size. Default: 1Gi",
+				},
+				&spec.ExpFlag{
+					Name:   "random",
+					Desc:   "Randomly select pod",
+					NoArgs: true,
+				},
+			},
+			ActionExecutor: &PodContainerCreatingActionExecutor{client: client},
+			ActionExample: `# Create a pod stuck in ContainerCreating state in the default namespace
+blade create k8s pod-pod containercreating --names nginx-app --namespace default --kubeconfig ~/.kube/config
+
+# Create a pod stuck in ContainerCreating state by labels with custom StorageClass
+blade create k8s pod-pod containercreating --labels app=guestbook --namespace default --storage-class fake-storage --kubeconfig ~/.kube/config
+
+# Create a pod stuck in ContainerCreating state with custom PVC parameters
+blade create k8s pod-pod containercreating --names nginx-app --namespace default --access-mode ReadWriteMany --storage-request 5Gi --kubeconfig ~/.kube/config
+`,
+			ActionCategories: []string{model.CategorySystemContainer},
+		},
+	}
+}
+
+func (*PodContainerCreatingActionSpec) Name() string {
+	return "containercreating"
+}
+
+func (*PodContainerCreatingActionSpec) Aliases() []string {
+	return []string{}
+}
+
+func (*PodContainerCreatingActionSpec) ShortDesc() string {
+	return "Make pod stuck in ContainerCreating state by PVC mount failure"
+}
+
+func (*PodContainerCreatingActionSpec) LongDesc() string {
+	return "Simulate the scenario where a Pod is stuck in ContainerCreating state due to storage volume mount failure. " +
+		"This fault is injected by creating a PVC that references a non-existent StorageClass (which keeps the PVC in Pending state), " +
+		"then creating a Pod that mounts this PVC. Since the PVC cannot be bound, the Pod remains stuck in ContainerCreating state. " +
+		"When the experiment is destroyed, the created Pod and PVC will be cleaned up."
+}
+
+type PodContainerCreatingActionExecutor struct {
+	client *channel.Client
+}
+
+func (*PodContainerCreatingActionExecutor) Name() string {
+	return "containercreating"
+}
+
+func (*PodContainerCreatingActionExecutor) SetChannel(channel spec.Channel) {}
+
+func (d *PodContainerCreatingActionExecutor) Exec(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	if _, ok := spec.IsDestroy(ctx); ok {
+		return d.destroy(uid, ctx, expModel)
+	}
+	return d.create(uid, ctx, expModel)
+}
+
+func (d *PodContainerCreatingActionExecutor) create(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	experimentId := model.GetExperimentIdFromContext(ctx)
+	logrusField := logrus.WithField("experiment", experimentId)
+
+	containerObjectMetaList, err := model.GetContainerObjectMetaListFromContext(ctx)
+	if err != nil {
+		util.Errorf(uid, util.GetRunFuncName(), err.Error())
+		return spec.ResponseFailWithResult(spec.ContainerInContextNotFound,
+			v1alpha1.CreateFailExperimentStatus(spec.ContainerInContextNotFound.Msg, []v1alpha1.ResourceStatus{}))
+	}
+
+	// Parse flags with defaults
+	storageClass := expModel.ActionFlags["storage-class"]
+	if storageClass == "" {
+		storageClass = "chaosblade-fake-sc"
+	}
+	volumeMountPath := expModel.ActionFlags["volume-mount-path"]
+	if volumeMountPath == "" {
+		volumeMountPath = "/mnt/data"
+	}
+	accessMode := expModel.ActionFlags["access-mode"]
+	if accessMode == "" {
+		accessMode = string(v1.ReadWriteOnce)
+	}
+	storageRequest := expModel.ActionFlags["storage-request"]
+	if storageRequest == "" {
+		storageRequest = "1Gi"
+	}
+
+	// Validate storage request format
+	storageQuantity, err := resource.ParseQuantity(storageRequest)
+	if err != nil {
+		errMsg := fmt.Sprintf("invalid storage-request %q: %v", storageRequest, err)
+		logrusField.Errorln(errMsg)
+		return spec.ResponseFailWithResult(spec.ParameterIllegal,
+			v1alpha1.CreateFailExperimentStatus(errMsg, []v1alpha1.ResourceStatus{}),
+			"storage-request", storageRequest, err)
+	}
+
+	// Deduplicate by namespace - create one faulty Pod+PVC per unique namespace
+	seenNamespaces := make(map[string]bool)
+	statuses := make([]v1alpha1.ResourceStatus, 0)
+	success := false
+
+	for _, meta := range containerObjectMetaList {
+		if seenNamespaces[meta.Namespace] {
+			continue
+		}
+		seenNamespaces[meta.Namespace] = true
+
+		pvcName := fmt.Sprintf("chaosblade-cc-%s-pvc", experimentId)
+		podName := fmt.Sprintf("chaosblade-cc-%s-pod", experimentId)
+
+		status := v1alpha1.ResourceStatus{
+			Kind:       v1alpha1.PodKind,
+			Identifier: fmt.Sprintf("%s//%s", meta.Namespace, podName),
+		}
+
+		// Step 1: Create PVC referencing non-existent StorageClass
+		if err := d.createPVC(ctx, meta.Namespace, pvcName, storageClass, accessMode, storageQuantity, experimentId); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				logrusField.Infof("PVC %s/%s already exists, skip creation", meta.Namespace, pvcName)
+			} else {
+				logrusField.Warningf("create PVC %s/%s failed: %v", meta.Namespace, pvcName, err)
+				status = status.CreateFailResourceStatus(fmt.Sprintf("create PVC failed: %v", err), spec.K8sExecFailed.Code)
+				statuses = append(statuses, status)
+				continue
+			}
+		} else {
+			logrusField.Infof("created PVC %s/%s referencing non-existent StorageClass %s", meta.Namespace, pvcName, storageClass)
+		}
+
+		// Step 2: Create Pod that mounts the pending PVC
+		if err := d.createPod(ctx, meta.Namespace, podName, pvcName, volumeMountPath, experimentId); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				logrusField.Infof("Pod %s/%s already exists, skip creation", meta.Namespace, podName)
+			} else {
+				logrusField.Warningf("create Pod %s/%s failed: %v", meta.Namespace, podName, err)
+				// Best-effort rollback: delete the PVC we just created
+				if delErr := d.deletePVC(ctx, meta.Namespace, pvcName); delErr != nil {
+					logrusField.Warningf("rollback PVC %s/%s failed: %v", meta.Namespace, pvcName, delErr)
+				}
+				status = status.CreateFailResourceStatus(fmt.Sprintf("create Pod failed: %v", err), spec.K8sExecFailed.Code)
+				statuses = append(statuses, status)
+				continue
+			}
+		} else {
+			logrusField.Infof("created Pod %s/%s which will be stuck in ContainerCreating state", meta.Namespace, podName)
+		}
+
+		status = status.CreateSuccessResourceStatus()
+		statuses = append(statuses, status)
+		success = true
+	}
+
+	var experimentStatus v1alpha1.ExperimentStatus
+	if success {
+		experimentStatus = v1alpha1.CreateSuccessExperimentStatus(statuses)
+	} else {
+		experimentStatus = v1alpha1.CreateFailExperimentStatus("see resStatuses for details", statuses)
+	}
+	return spec.ReturnResultIgnoreCode(experimentStatus)
+}
+
+func (d *PodContainerCreatingActionExecutor) destroy(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	experimentId := model.GetExperimentIdFromContext(ctx)
+	logrusField := logrus.WithField("experiment", experimentId)
+
+	containerObjectMetaList, err := model.GetContainerObjectMetaListFromContext(ctx)
+	if err != nil {
+		util.Errorf(uid, util.GetRunFuncName(), err.Error())
+		return spec.ResponseFailWithResult(spec.ContainerInContextNotFound,
+			v1alpha1.CreateFailExperimentStatus(spec.ContainerInContextNotFound.Msg, []v1alpha1.ResourceStatus{}))
+	}
+
+	statuses := make([]v1alpha1.ResourceStatus, 0)
+	allSuccess := true
+	seenNamespaces := make(map[string]bool)
+
+	for _, meta := range containerObjectMetaList {
+		if seenNamespaces[meta.Namespace] {
+			continue
+		}
+		seenNamespaces[meta.Namespace] = true
+
+		pvcName := fmt.Sprintf("chaosblade-cc-%s-pvc", experimentId)
+		podName := meta.PodName
+		namespace := meta.Namespace
+
+		status := v1alpha1.ResourceStatus{
+			Kind:       v1alpha1.PodKind,
+			Identifier: fmt.Sprintf("%s//%s", namespace, podName),
+		}
+
+		// Step 1: Delete Pod
+		if err := d.deletePod(ctx, namespace, podName); err != nil {
+			if apierrors.IsNotFound(err) {
+				logrusField.Infof("Pod %s/%s already deleted", namespace, podName)
+			} else {
+				logrusField.Warningf("delete Pod %s/%s failed: %v", namespace, podName, err)
+				status = status.CreateFailResourceStatus(fmt.Sprintf("delete Pod failed: %v", err), spec.K8sExecFailed.Code)
+				statuses = append(statuses, status)
+				allSuccess = false
+				continue
+			}
+		} else {
+			logrusField.Infof("deleted Pod %s/%s", namespace, podName)
+		}
+
+		// Step 2: Delete PVC (non-critical, warn only on failure)
+		if err := d.deletePVC(ctx, namespace, pvcName); err != nil {
+			if apierrors.IsNotFound(err) {
+				logrusField.Infof("PVC %s/%s already deleted", namespace, pvcName)
+			} else {
+				logrusField.Warningf("delete PVC %s/%s failed: %v", namespace, pvcName, err)
+				// PVC deletion failure is not critical, just warn
+			}
+		} else {
+			logrusField.Infof("deleted PVC %s/%s", namespace, pvcName)
+		}
+
+		status = status.CreateSuccessResourceStatus()
+		status.State = v1alpha1.DestroyedState
+		statuses = append(statuses, status)
+	}
+
+	if allSuccess {
+		return spec.ReturnResultIgnoreCode(v1alpha1.CreateDestroyedExperimentStatus(statuses))
+	}
+	return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus("see resStatuses for details", statuses))
+}
+
+// createPVC creates a PersistentVolumeClaim that references a non-existent StorageClass,
+// which will cause it to remain in Pending state indefinitely.
+func (d *PodContainerCreatingActionExecutor) createPVC(ctx context.Context, namespace, pvcName, storageClass, accessMode string, storageQuantity resource.Quantity, experimentId string) error {
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pvcName,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				ChaosBladePVCAnnotation:        ChaosBladeActionCreate,
+				ChaosBladeExperimentAnnotation: experimentId,
+			},
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			StorageClassName: &storageClass,
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				v1.PersistentVolumeAccessMode(accessMode),
+			},
+			Resources: v1.VolumeResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceStorage: storageQuantity,
+				},
+			},
+		},
+	}
+	return d.client.Create(ctx, pvc)
+}
+
+// createPod creates a Pod that mounts the given PVC, which will cause it to be
+// stuck in ContainerCreating state because the PVC is Pending.
+func (d *PodContainerCreatingActionExecutor) createPod(ctx context.Context, namespace, podName, pvcName, volumeMountPath, experimentId string) error {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				ChaosBladePodAnnotation:        ChaosBladeActionCreate,
+				ChaosBladeExperimentAnnotation: experimentId,
+			},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "chaosblade-cc",
+					Image: "busybox",
+					Command: []string{
+						"sleep",
+						"infinity",
+					},
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      "chaosblade-cc-volume",
+							MountPath: volumeMountPath,
+						},
+					},
+				},
+			},
+			Volumes: []v1.Volume{
+				{
+					Name: "chaosblade-cc-volume",
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+							ClaimName: pvcName,
+						},
+					},
+				},
+			},
+		},
+	}
+	return d.client.Create(ctx, pod)
+}
+
+// deletePod deletes a Pod by namespace and name
+func (d *PodContainerCreatingActionExecutor) deletePod(ctx context.Context, namespace, podName string) error {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace,
+		},
+	}
+	return d.client.Delete(ctx, pod)
+}
+
+// deletePVC deletes a PersistentVolumeClaim by namespace and name
+func (d *PodContainerCreatingActionExecutor) deletePVC(ctx context.Context, namespace, pvcName string) error {
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pvcName,
+			Namespace: namespace,
+		},
+	}
+	return d.client.Delete(ctx, pvc)
+}

--- a/exec/pod/containercreating.go
+++ b/exec/pod/containercreating.go
@@ -288,23 +288,31 @@ func (d *PodContainerCreatingActionExecutor) destroy(uid string, ctx context.Con
 			logrusField.Infof("deleted Pod %s/%s", namespace, podName)
 		}
 
-		// Step 2: Delete PVC (non-critical, warn only on failure)
+		// Step 2: Delete PVC
 		if err := d.deletePVC(ctx, namespace, pvcName); err != nil {
 			if apierrors.IsNotFound(err) {
 				logrusField.Infof("PVC %s/%s already deleted", namespace, pvcName)
 			} else {
 				logrusField.Warningf("delete PVC %s/%s failed: %v", namespace, pvcName, err)
+				status = status.CreateFailResourceStatus(fmt.Sprintf("delete PVC failed: %v", err), spec.K8sExecFailed.Code)
+				statuses = append(statuses, status)
+				allSuccess = false
+				continue
 			}
 		} else {
 			logrusField.Infof("deleted PVC %s/%s", namespace, pvcName)
 		}
 
-		// Step 3: Delete PV (non-critical, warn only on failure)
+		// Step 3: Delete PV
 		if err := d.deletePV(ctx, pvName); err != nil {
 			if apierrors.IsNotFound(err) {
 				logrusField.Infof("PV %s already deleted", pvName)
 			} else {
 				logrusField.Warningf("delete PV %s failed: %v", pvName, err)
+				status = status.CreateFailResourceStatus(fmt.Sprintf("delete PV failed: %v", err), spec.K8sExecFailed.Code)
+				statuses = append(statuses, status)
+				allSuccess = false
+				continue
 			}
 		} else {
 			logrusField.Infof("deleted PV %s", pvName)

--- a/exec/pod/controller.go
+++ b/exec/pod/controller.go
@@ -53,9 +53,12 @@ func (e *ExpController) Create(ctx context.Context, expSpec v1alpha1.ExperimentS
 	experimentId := model.GetExperimentIdFromContext(ctx)
 	logrusField := logrus.WithField("experiment", experimentId)
 
-	// containercreating action creates new resources (PVC+Pod) and does not require
+	// containercreating action creates new resources (PV+PVC+Pod) and does not require
 	// finding existing pods. It only needs the namespace to know where to create them.
 	if expModel.ActionName == "containercreating" {
+		if resp := model.CheckPodFlags(expModel.ActionFlags); !resp.Success {
+			return resp
+		}
 		namespace := expModel.ActionFlags[model.ResourceNamespaceFlag.Name]
 		if namespace == "" {
 			namespace = model.DefaultNamespace

--- a/exec/pod/controller.go
+++ b/exec/pod/controller.go
@@ -18,6 +18,7 @@ package pod
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/chaosblade-io/chaosblade-exec-cri/exec/container"
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
@@ -51,6 +52,25 @@ func (e *ExpController) Create(ctx context.Context, expSpec v1alpha1.ExperimentS
 	expModel := model.ExtractExpModelFromExperimentSpec(expSpec)
 	experimentId := model.GetExperimentIdFromContext(ctx)
 	logrusField := logrus.WithField("experiment", experimentId)
+
+	// containercreating action creates new resources (PVC+Pod) and does not require
+	// finding existing pods. It only needs the namespace to know where to create them.
+	if expModel.ActionName == "containercreating" {
+		namespace := expModel.ActionFlags[model.ResourceNamespaceFlag.Name]
+		if namespace == "" {
+			namespace = model.DefaultNamespace
+		}
+		containerObjectMetaList := model.ContainerMatchedList{
+			model.ContainerObjectMeta{
+				Namespace: namespace,
+				PodName:   fmt.Sprintf("chaosblade-cc-%s-pod", experimentId),
+			},
+		}
+		logrusField.Infof("creating containercreating experiment in namespace %s", namespace)
+		ctx = model.SetContainerObjectMetaListToContext(ctx, containerObjectMetaList)
+		return e.Exec(ctx, expModel)
+	}
+
 	pods, resp := e.GetMatchedPodResources(ctx, *expModel)
 	if !resp.Success {
 		logrusField.Errorf("uid: %s, get matched pod experiment failed, %v", experimentId, resp.Err)

--- a/exec/pod/controller.go
+++ b/exec/pod/controller.go
@@ -19,6 +19,7 @@ package pod
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/chaosblade-io/chaosblade-exec-cri/exec/container"
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
@@ -56,12 +57,13 @@ func (e *ExpController) Create(ctx context.Context, expSpec v1alpha1.ExperimentS
 	// containercreating action creates new resources (PV+PVC+Pod) and does not require
 	// finding existing pods. It only needs the namespace to know where to create them.
 	if expModel.ActionName == "containercreating" {
-		if resp := model.CheckPodFlags(expModel.ActionFlags); !resp.Success {
-			return resp
-		}
+		// Validate namespace: must be specified and only one value
 		namespace := expModel.ActionFlags[model.ResourceNamespaceFlag.Name]
 		if namespace == "" {
-			namespace = model.DefaultNamespace
+			return spec.ResponseFailWithFlags(spec.ParameterLess, model.ResourceNamespaceFlag.Name)
+		}
+		if strings.Contains(namespace, ",") {
+			return spec.ResponseFailWithFlags(spec.ParameterInvalidNSNotOne, model.ResourceNamespaceFlag.Name)
 		}
 		containerObjectMetaList := model.ContainerMatchedList{
 			model.ContainerObjectMeta{

--- a/exec/pod/pod.go
+++ b/exec/pod/pod.go
@@ -225,16 +225,13 @@ blade create k8s pod-script delay --time 10000 --file test.sh --function-name st
 # Add commands to the script "start0() { echo this-is-error-message; exit 1; ... }"
 blade create k8s pod-script exit --exit-code 1 --exit-message this-is-error-message --file test.sh --function-name start0 --names nginx-app --kubeconfig ~/.kube/config --namespace default`)
 			case *PodContainerCreatingActionSpec:
-				action.SetLongDesc("Make pod stuck in ContainerCreating state by creating a Pod that mounts a pending PVC")
+				action.SetLongDesc("Make pod stuck in ContainerCreating state by creating a PV with an unreachable NFS server, a PVC bound to it, and a Pod that mounts the PVC. Since the NFS server is unreachable, the volume mount fails and the Pod remains stuck in ContainerCreating state.")
 				action.SetExample(
-					`# Create a pod stuck in ContainerCreating state due to PVC mount failure
-blade create k8s pod-pod containercreating --names nginx-app --namespace default --kubeconfig ~/.kube/config
+					`# Create a pod stuck in ContainerCreating state in the default namespace
+blade create k8s pod-pod containercreating --namespace default --kubeconfig ~/.kube/config
 
-# Create a pod stuck in ContainerCreating state by labels with custom StorageClass
-blade create k8s pod-pod containercreating --labels app=guestbook --namespace default --storage-class fake-storage --kubeconfig ~/.kube/config
-
-# Create a pod stuck in ContainerCreating state with custom PVC parameters
-blade create k8s pod-pod containercreating --names nginx-app --namespace default --access-mode ReadWriteMany --storage-request 5Gi --kubeconfig ~/.kube/config`)
+# Create a pod stuck in ContainerCreating state with custom volume mount path
+blade create k8s pod-pod containercreating --namespace default --volume-mount-path /data --kubeconfig ~/.kube/config`)
 			default:
 				action.SetExample(strings.Replace(action.Example(),
 					fmt.Sprintf("blade create %s %s", expModelSpec.Name(), action.Name()),

--- a/exec/pod/pod.go
+++ b/exec/pod/pod.go
@@ -224,6 +224,17 @@ blade create k8s pod-script delay --time 10000 --file test.sh --function-name st
 				action.SetExample(`
 # Add commands to the script "start0() { echo this-is-error-message; exit 1; ... }"
 blade create k8s pod-script exit --exit-code 1 --exit-message this-is-error-message --file test.sh --function-name start0 --names nginx-app --kubeconfig ~/.kube/config --namespace default`)
+			case *PodContainerCreatingActionSpec:
+				action.SetLongDesc("Make pod stuck in ContainerCreating state by creating a Pod that mounts a pending PVC")
+				action.SetExample(
+					`# Create a pod stuck in ContainerCreating state due to PVC mount failure
+blade create k8s pod-pod containercreating --names nginx-app --namespace default --kubeconfig ~/.kube/config
+
+# Create a pod stuck in ContainerCreating state by labels with custom StorageClass
+blade create k8s pod-pod containercreating --labels app=guestbook --namespace default --storage-class fake-storage --kubeconfig ~/.kube/config
+
+# Create a pod stuck in ContainerCreating state with custom PVC parameters
+blade create k8s pod-pod containercreating --names nginx-app --namespace default --access-mode ReadWriteMany --storage-request 5Gi --kubeconfig ~/.kube/config`)
 			default:
 				action.SetExample(strings.Replace(action.Example(),
 					fmt.Sprintf("blade create %s %s", expModelSpec.Name(), action.Name()),
@@ -261,6 +272,7 @@ func NewSelfExpModelCommandSpec(client *channel.Client) spec.ExpModelCommandSpec
 				NewPodIOActionSpec(client),
 				NewFailPodActionSpec(client),
 				NewPodTerminatingActionSpec(client),
+				NewPodContainerCreatingActionSpec(client),
 			},
 		},
 	}


### PR DESCRIPTION
… to PVC mounting failure.

- 在 README 文件中添加了 Pod 实验场景，支持处于 ContainerCreating 和 Terminating 状态的 Pod。

- 在示例目录中添加了 `pod-containercreating-by-pvc-error.yaml` 文件，演示如何通过创建失败的 PVC 来冻结 Pod。

- 添加了 Pod 包 `pod/containercreating.go`，通过创建一个引用不存在的 StorageClass 及其对应挂载 Pod 的 PVC 来实现故障注入。

- 实现了 containercreating 操作的创建和销毁逻辑，包括创建故障的 Pod 和 PVC，并在销毁时清理资源。

- 更新了 Helm charts 的 RBAC，添加了对 persistentvolumeclaims 资源的权限支持。

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
本 PR 新增 `containercreating` 故障注入 action，用于模拟 Pod 因存储卷挂载失败（PVC/CSI/存储配置问题）而卡在 `ContainerCreating` 状态的场景。

该场景在生产环境中常见于：
- StorageClass 不存在或配置错误
- CSI 驱动不可用或故障
- 存储后端问题导致 PVC 无法绑定

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
1. **新增 action 实现** (`exec/pod/containercreating.go`)：
   - 创建 `PodContainerCreatingActionSpec` 和 `PodContainerCreatingActionExecutor`
   - 创建引用不存在 StorageClass 的 PVC（保持 Pending 状态）
   - 创建挂载该 PVC 的 Pod（卡在 ContainerCreating）
   - 支持参数：`storage-class`、`volume-mount-path`、`access-mode`、`storage-request`、`random`
   - 遵循注解规范：`chaosblade.io/<resource>: create`
   - 创建失败时实现回滚机制

2. **RBAC 权限** (`deploy/helm/chaosblade-operator/templates/rbac.yaml`)：
   - 新增 `persistentvolumeclaims` 资源权限

3. **文档更新** (`README.md`)：
   - 更新支持的实验场景说明

### Describe how to verify it
1. 构建并部署 operator：
   ```bash
   make build_all
   helm install chaosblade ./deploy/helm/chaosblade-operator -n chaosblade --create-namespace
  ```
2. 创建实验
  ```bash
  kubectl apply -f examples/pod-containercreating-by-pvc-error.yaml
  ```
3. kubectl apply -f examples/pod-containercreating-by-pvc-error.yaml
  ```bash
  kubectl get pod -n <namespace>
  kubectl describe pod chaosblade-cc-<experiment-id>-pod -n <namespace>
  ```
4. 销毁实验：
  ```bash
  kubectl delete -f examples/pod-containercreating-by-pvc-error.yaml
  ```

### Special notes for reviews
* 该 action 创建新的 K8s 资源（PVC 和 Pod），不修改用户现有资源
* 注解遵循 chaosblade.io/<resource>: create 规范用于资源追踪
* RBAC 权限 persistentvolumeclaims 是该 action 工作的必要条件
* 示例 YAML 文件 examples/pod-containercreating-by-pvc-error.yaml 已包含