### PR TITLE
feat(pod): Added Pod scheduling failure experiments and example files

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The current experimental scenarios involve resources including Node, Pod, and Co
     * Network: specify network card, port, IP, etc. packet delay, packet loss, packet blocking, packet duplication, packet re-ordering, packet corruption, etc.
     * Disk: specify the directory disk occupation, disk IO read and write load, etc.
     * Memory: specify memory usage
-    * Pod: kill pod, make pod stuck in ContainerCreating state by PVC mount failure, make pod stuck in Terminating state by finalizer
+    * Pod: kill pod, make pod stuck in ContainerCreating state by PVC mount failure, make pod stuck in Terminating state by finalizer, make pod scheduling fail by injecting unreachable affinity rules
     * IO: specify the file system io exception. Supports 31 file operations and 11 exception scenarios, such as "Too many open files", "Device or resource busy" and so on.
 * Container:
     * CPU: specify CPU usage

--- a/README_CN.md
+++ b/README_CN.md
@@ -12,11 +12,11 @@ Chaosblade Operator 是混沌工程实验工具 ChaosBlade 下的一款面向云
     * 进程：指定进程 Hang、强杀指定进程等
     * 磁盘：指定目录磁盘填充、磁盘 IO 读写负载等
     * 内存：指定内存使用率
-* Pod：
+* Pod:
     * 网络：指定网卡、端口、IP 等包延迟、丢包、包阻塞、包重复、包乱序、包损坏等
     * 磁盘：指定目录磁盘填充、磁盘 IO 读写负载等
     * 内存：指定内存使用率
-    * Pod：杀 Pod
+    * Pod：杀 Pod、通过 PVC 挂载失败使 Pod 卡在 ContainerCreating 状态、通过 finalizer 使 Pod 卡在 Terminating 状态、通过注入无法满足的亲和性规则使 Pod 调度失败
 * Container：
     * CPU: 指定 CPU 使用率
     * 网络: 指定网卡、端口、IP 等包延迟、丢包、包阻塞、包重复、包乱序、包损坏等

--- a/README_CN.md
+++ b/README_CN.md
@@ -12,7 +12,7 @@ Chaosblade Operator 是混沌工程实验工具 ChaosBlade 下的一款面向云
     * 进程：指定进程 Hang、强杀指定进程等
     * 磁盘：指定目录磁盘填充、磁盘 IO 读写负载等
     * 内存：指定内存使用率
-* Pod:
+* Pod：
     * 网络：指定网卡、端口、IP 等包延迟、丢包、包阻塞、包重复、包乱序、包损坏等
     * 磁盘：指定目录磁盘填充、磁盘 IO 读写负载等
     * 内存：指定内存使用率
@@ -24,7 +24,7 @@ Chaosblade Operator 是混沌工程实验工具 ChaosBlade 下的一款面向云
     * 磁盘：指定目录磁盘填充、磁盘 IO 读写负载等
     * 内存：指定内存使用率
     * Container: 杀 Container
-* Service:
+* Service：
     * Service: 创建、修改Service
 
 ## 本地构建&安装

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -29,6 +29,7 @@ import (
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -154,6 +155,7 @@ func createManager(cfg *rest.Config) (manager.Manager, error) {
 	scheme := apiruntime.NewScheme()
 	runtimeutil.Must(metav1.AddMetaToScheme(scheme))
 	runtimeutil.Must(corev1.AddToScheme(scheme))
+	runtimeutil.Must(appsv1.AddToScheme(scheme))
 	runtimeutil.Must(apis.AddToScheme(scheme))
 	watchNamespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {

--- a/deploy/helm/chaosblade-operator-arm64/templates/rbac.yaml
+++ b/deploy/helm/chaosblade-operator-arm64/templates/rbac.yaml
@@ -52,6 +52,7 @@ rules:
     resources:
       - daemonsets
       - deployments
+      - statefulsets
     verbs:
       - "*"
   - apiGroups:

--- a/deploy/helm/chaosblade-operator/templates/rbac.yaml
+++ b/deploy/helm/chaosblade-operator/templates/rbac.yaml
@@ -52,6 +52,7 @@ rules:
     resources:
       - daemonsets
       - deployments
+      - statefulsets
     verbs:
       - "*"
   - apiGroups:

--- a/examples/pod-scheduling-failure.yaml
+++ b/examples/pod-scheduling-failure.yaml
@@ -33,13 +33,16 @@ spec:
     matchers:
     - name: namespace
       value:
-      - "default"
+      - "nginx"
     - name: workload-type
       value:
       - "deployment"
     - name: workload-name
       value:
-      - "nginx-deployment"
+      - "nginx-sf-test"
+    - name: affinity-type
+      value:
+      - "node-affinity"
     # Optional: specify affinity type
     # Supported values: node-affinity (default), node-selector, pod-affinity, pod-anti-affinity
     # - name: affinity-type

--- a/examples/pod-scheduling-failure.yaml
+++ b/examples/pod-scheduling-failure.yaml
@@ -17,7 +17,7 @@
 # injected unreachable affinity rules.
 #
 # Prerequisites:
-# - A deployment named "nginx-deployment" should exist in the target namespace
+# - A deployment named "nginx-sf-test" should exist in the target namespace
 # - The operator should have RBAC permissions to get/update deployments
 
 apiVersion: chaosblade.io/v1alpha1

--- a/examples/pod-scheduling-failure.yaml
+++ b/examples/pod-scheduling-failure.yaml
@@ -1,0 +1,47 @@
+# Copyright 2025 The ChaosBlade Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Inject scheduling failure to a deployment by modifying its affinity configuration.
+# This will cause new Pods to remain in Pending state because no node matches the
+# injected unreachable affinity rules.
+#
+# Prerequisites:
+# - A deployment named "nginx-deployment" should exist in the target namespace
+# - The operator should have RBAC permissions to get/update deployments
+
+apiVersion: chaosblade.io/v1alpha1
+kind: ChaosBlade
+metadata:
+  name: pod-scheduling-failure
+spec:
+  experiments:
+  - scope: pod
+    target: pod
+    action: schedulingfailure
+    desc: "Inject scheduling failure by modifying deployment affinity"
+    matchers:
+    - name: namespace
+      value:
+      - "default"
+    - name: workload-type
+      value:
+      - "deployment"
+    - name: workload-name
+      value:
+      - "nginx-deployment"
+    # Optional: specify affinity type
+    # Supported values: node-affinity (default), node-selector, pod-affinity, pod-anti-affinity
+    # - name: affinity-type
+    #   value:
+    #   - "node-affinity"

--- a/examples/pod-scheduling-failure.yaml
+++ b/examples/pod-scheduling-failure.yaml
@@ -40,11 +40,8 @@ spec:
     - name: workload-name
       value:
       - "nginx-sf-test"
-    - name: affinity-type
-      value:
-      - "node-affinity"
-    # Optional: specify affinity type
-    # Supported values: node-affinity (default), node-selector, pod-affinity, pod-anti-affinity
+    # Optional: affinity type, default is node-affinity
+    # Supported values: node-affinity, node-selector, pod-affinity, pod-anti-affinity
     # - name: affinity-type
     #   value:
     #   - "node-affinity"

--- a/exec/controller.go
+++ b/exec/controller.go
@@ -91,7 +91,9 @@ func (e *ResourceDispatchedController) Destroy(bladeName string, expSpec v1alpha
 	}
 	if oldExpStatus.ResStatuses == nil ||
 		len(oldExpStatus.ResStatuses) == 0 {
-		return model.CreateDestroyedStatus(oldExpStatus)
+		// Still attempt to destroy - the action may have succeeded but status wasn't recorded
+		// (e.g., due to status update conflict). The action's destroy logic should handle
+		// the case where the resource was never modified.
 	}
 	ctx := spec.SetDestroyFlag(context.Background(), bladeName)
 	ctx = model.SetExperimentIdToContext(ctx, bladeName)

--- a/exec/model/filter.go
+++ b/exec/model/filter.go
@@ -29,7 +29,7 @@ import (
 
 func GetOneAvailableContainerIdFromPod(pod v1.Pod) (containerId, containerName, runtime string, err error) {
 	containerStatuses := pod.Status.ContainerStatuses
-	if containerStatuses == nil || len(containerStatuses) == 0 {
+	if len(containerStatuses) == 0 {
 		return "", "", "", fmt.Errorf("the container statues is empty in %s pod", pod.Name)
 	}
 	for _, containerStatus := range containerStatuses {

--- a/exec/model/model.go
+++ b/exec/model/model.go
@@ -23,6 +23,7 @@ import (
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
 
 	"github.com/chaosblade-io/chaosblade-operator/channel"
+	"github.com/chaosblade-io/chaosblade-operator/pkg/apis/chaosblade/v1alpha1"
 )
 
 // ActionPreProcessor defines the interface for action-specific pre-processing
@@ -34,6 +35,11 @@ type ActionPreProcessor interface {
 	// if validation fails or early return is needed.
 	// If Response is nil, the main flow continues with the returned context.
 	PreCreate(ctx context.Context, expModel *spec.ExpModel, client *channel.Client) (context.Context, *spec.Response)
+	// PreDestroy is called before the main destroy flow.
+	// Returns a modified context for downstream processing, or a Response
+	// if validation fails or early return is needed.
+	// If Response is nil, the main flow continues with the returned context.
+	PreDestroy(ctx context.Context, expModel *spec.ExpModel, client *channel.Client, oldExpStatus v1alpha1.ExperimentStatus) (context.Context, *spec.Response)
 }
 
 // ResourceExpModelSpec contains node, pod, container

--- a/exec/model/model.go
+++ b/exec/model/model.go
@@ -17,11 +17,24 @@
 package model
 
 import (
+	"context"
+
 	"github.com/chaosblade-io/chaosblade-exec-cri/exec"
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
 
 	"github.com/chaosblade-io/chaosblade-operator/channel"
 )
+
+// ActionPreProcessor defines the interface for action-specific pre-processing
+// before the main create/destroy flow. Actions that don't require pod matching
+// or need custom validation should implement this interface.
+type ActionPreProcessor interface {
+	// PreCreate is called before the main create flow.
+	// Returns a modified context for downstream processing, or a Response
+	// if validation fails or early return is needed.
+	// If Response is nil, the main flow continues with the returned context.
+	PreCreate(ctx context.Context, expModel *spec.ExpModel, client *channel.Client) (context.Context, *spec.Response)
+}
 
 // ResourceExpModelSpec contains node, pod, container
 type ResourceExpModelSpec interface {

--- a/exec/pod/containercreating.go
+++ b/exec/pod/containercreating.go
@@ -527,3 +527,20 @@ func (a *PodContainerCreatingActionSpec) PreCreate(ctx context.Context, expModel
 	ctx = model.SetContainerObjectMetaListToContext(ctx, containerObjectMetaList)
 	return ctx, nil
 }
+
+// PreDestroy implements model.ActionPreProcessor interface.
+// It prepares the context for containercreating destroy flow.
+func (a *PodContainerCreatingActionSpec) PreDestroy(ctx context.Context, expModel *spec.ExpModel, client *channel.Client, oldExpStatus v1alpha1.ExperimentStatus) (context.Context, *spec.Response) {
+	experimentId := model.GetExperimentIdFromContext(ctx)
+	namespace := expModel.ActionFlags[model.ResourceNamespaceFlag.Name]
+
+	containerObjectMetaList := model.ContainerMatchedList{
+		model.ContainerObjectMeta{
+			Namespace: namespace,
+			PodName:   fmt.Sprintf("chaosblade-cc-%s-pod", experimentId),
+		},
+	}
+
+	ctx = model.SetContainerObjectMetaListToContext(ctx, containerObjectMetaList)
+	return ctx, nil
+}

--- a/exec/pod/containercreating.go
+++ b/exec/pod/containercreating.go
@@ -19,6 +19,7 @@ package pod
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
@@ -51,11 +52,12 @@ const (
 
 type PodContainerCreatingActionSpec struct {
 	spec.BaseExpActionCommandSpec
+	client *channel.Client
 }
 
 func NewPodContainerCreatingActionSpec(client *channel.Client) spec.ExpActionCommandSpec {
 	return &PodContainerCreatingActionSpec{
-		spec.BaseExpActionCommandSpec{
+		BaseExpActionCommandSpec: spec.BaseExpActionCommandSpec{
 			ActionMatchers: []spec.ExpFlagSpec{},
 			ActionFlags: []spec.ExpFlagSpec{
 				&spec.ExpFlag{
@@ -72,6 +74,7 @@ blade create k8s pod-pod containercreating --namespace default --volume-mount-pa
 `,
 			ActionCategories: []string{model.CategorySystemContainer},
 		},
+		client: client,
 	}
 }
 
@@ -498,4 +501,29 @@ func (d *PodContainerCreatingActionExecutor) deletePV(ctx context.Context, pvNam
 		},
 	}
 	return d.client.Delete(ctx, pv)
+}
+
+// PreCreate implements model.ActionPreProcessor interface.
+// It validates the namespace and prepares the context for containercreating action.
+func (a *PodContainerCreatingActionSpec) PreCreate(ctx context.Context, expModel *spec.ExpModel, client *channel.Client) (context.Context, *spec.Response) {
+	experimentId := model.GetExperimentIdFromContext(ctx)
+
+	// Validate namespace: must be specified and only one value
+	namespace := expModel.ActionFlags[model.ResourceNamespaceFlag.Name]
+	if namespace == "" {
+		return ctx, spec.ResponseFailWithFlags(spec.ParameterLess, model.ResourceNamespaceFlag.Name)
+	}
+	if strings.Contains(namespace, ",") {
+		return ctx, spec.ResponseFailWithFlags(spec.ParameterInvalidNSNotOne, model.ResourceNamespaceFlag.Name)
+	}
+
+	containerObjectMetaList := model.ContainerMatchedList{
+		model.ContainerObjectMeta{
+			Namespace: namespace,
+			PodName:   fmt.Sprintf("chaosblade-cc-%s-pod", experimentId),
+		},
+	}
+
+	ctx = model.SetContainerObjectMetaListToContext(ctx, containerObjectMetaList)
+	return ctx, nil
 }

--- a/exec/pod/containercreating.go
+++ b/exec/pod/containercreating.go
@@ -277,7 +277,7 @@ func (d *PodContainerCreatingActionExecutor) destroy(uid string, ctx context.Con
 
 		pvName := fmt.Sprintf("chaosblade-cc-%s-pv", experimentId)
 		pvcName := fmt.Sprintf("chaosblade-cc-%s-pvc", experimentId)
-		podName := meta.PodName
+		podName := fmt.Sprintf("chaosblade-cc-%s-pod", experimentId)
 		namespace := meta.Namespace
 
 		status := v1alpha1.ResourceStatus{

--- a/exec/pod/controller.go
+++ b/exec/pod/controller.go
@@ -103,7 +103,7 @@ func (e *ExpController) Destroy(ctx context.Context, expSpec v1alpha1.Experiment
 
 	// Default flow: find matched containers and destroy
 	statuses := oldExpStatus.ResStatuses
-	if statuses == nil {
+	if len(statuses) == 0 {
 		return spec.ReturnSuccess(v1alpha1.CreateSuccessExperimentStatus([]v1alpha1.ResourceStatus{}))
 	}
 	containerObjectMetaList := model.ContainerMatchedList{}
@@ -114,6 +114,9 @@ func (e *ExpController) Destroy(ctx context.Context, expSpec v1alpha1.Experiment
 		containerObjectMeta := model.ParseIdentifier(status.Identifier)
 		containerObjectMeta.Id = status.Id
 		containerObjectMetaList = append(containerObjectMetaList, containerObjectMeta)
+	}
+	if len(containerObjectMetaList) == 0 {
+		return spec.ReturnSuccess(v1alpha1.CreateSuccessExperimentStatus([]v1alpha1.ResourceStatus{}))
 	}
 	ctx = model.SetContainerObjectMetaListToContext(ctx, containerObjectMetaList)
 	return e.Exec(ctx, expModel)

--- a/exec/pod/controller.go
+++ b/exec/pod/controller.go
@@ -76,6 +76,35 @@ func (e *ExpController) Create(ctx context.Context, expSpec v1alpha1.ExperimentS
 		return e.Exec(ctx, expModel)
 	}
 
+	// schedulingfailure action modifies workload (Deployment/DaemonSet/StatefulSet) affinity
+	// and does not require finding existing pods. It needs workload-type, workload-name and namespace.
+	if expModel.ActionName == "schedulingfailure" {
+		// Validate required flags
+		namespace := expModel.ActionFlags[model.ResourceNamespaceFlag.Name]
+		workloadType := expModel.ActionFlags["workload-type"]
+		if workloadType == "" {
+			workloadType = "deployment"
+		}
+		workloadName := expModel.ActionFlags["workload-name"]
+
+		if namespace == "" {
+			return spec.ResponseFailWithFlags(spec.ParameterLess, model.ResourceNamespaceFlag.Name)
+		}
+		if workloadName == "" {
+			return spec.ResponseFailWithFlags(spec.ParameterLess, "workload-name")
+		}
+
+		containerObjectMetaList := model.ContainerMatchedList{
+			model.ContainerObjectMeta{
+				Namespace: namespace,
+				PodName:   fmt.Sprintf("chaosblade-sf-%s-%s", workloadType, workloadName),
+			},
+		}
+		logrusField.Infof("creating schedulingfailure experiment for %s/%s in namespace %s", workloadType, workloadName, namespace)
+		ctx = model.SetContainerObjectMetaListToContext(ctx, containerObjectMetaList)
+		return e.Exec(ctx, expModel)
+	}
+
 	pods, resp := e.GetMatchedPodResources(ctx, *expModel)
 	if !resp.Success {
 		logrusField.Errorf("uid: %s, get matched pod experiment failed, %v", experimentId, resp.Err)

--- a/exec/pod/controller.go
+++ b/exec/pod/controller.go
@@ -18,8 +18,6 @@ package pod
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	"github.com/chaosblade-io/chaosblade-exec-cri/exec/container"
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
@@ -54,57 +52,21 @@ func (e *ExpController) Create(ctx context.Context, expSpec v1alpha1.ExperimentS
 	experimentId := model.GetExperimentIdFromContext(ctx)
 	logrusField := logrus.WithField("experiment", experimentId)
 
-	// containercreating action creates new resources (PV+PVC+Pod) and does not require
-	// finding existing pods. It only needs the namespace to know where to create them.
-	if expModel.ActionName == "containercreating" {
-		// Validate namespace: must be specified and only one value
-		namespace := expModel.ActionFlags[model.ResourceNamespaceFlag.Name]
-		if namespace == "" {
-			return spec.ResponseFailWithFlags(spec.ParameterLess, model.ResourceNamespaceFlag.Name)
+	// Get action spec to check if it implements ActionPreProcessor
+	actionSpec := e.ResourceModelSpec.GetExpActionModelSpec(expModel.Target, expModel.ActionName)
+	if actionSpec != nil {
+		if preProcessor, ok := actionSpec.(model.ActionPreProcessor); ok {
+			newCtx, resp := preProcessor.PreCreate(ctx, expModel, e.Client)
+			if resp != nil {
+				return resp
+			}
+			ctx = newCtx
+			logrusField.Infof("creating %s experiment with pre-processing", expModel.ActionName)
+			return e.Exec(ctx, expModel)
 		}
-		if strings.Contains(namespace, ",") {
-			return spec.ResponseFailWithFlags(spec.ParameterInvalidNSNotOne, model.ResourceNamespaceFlag.Name)
-		}
-		containerObjectMetaList := model.ContainerMatchedList{
-			model.ContainerObjectMeta{
-				Namespace: namespace,
-				PodName:   fmt.Sprintf("chaosblade-cc-%s-pod", experimentId),
-			},
-		}
-		logrusField.Infof("creating containercreating experiment in namespace %s", namespace)
-		ctx = model.SetContainerObjectMetaListToContext(ctx, containerObjectMetaList)
-		return e.Exec(ctx, expModel)
 	}
 
-	// schedulingfailure action modifies workload (Deployment/DaemonSet/StatefulSet) affinity
-	// and does not require finding existing pods. It needs workload-type, workload-name and namespace.
-	if expModel.ActionName == "schedulingfailure" {
-		// Validate required flags
-		namespace := expModel.ActionFlags[model.ResourceNamespaceFlag.Name]
-		workloadType := expModel.ActionFlags["workload-type"]
-		if workloadType == "" {
-			workloadType = "deployment"
-		}
-		workloadName := expModel.ActionFlags["workload-name"]
-
-		if namespace == "" {
-			return spec.ResponseFailWithFlags(spec.ParameterLess, model.ResourceNamespaceFlag.Name)
-		}
-		if workloadName == "" {
-			return spec.ResponseFailWithFlags(spec.ParameterLess, "workload-name")
-		}
-
-		containerObjectMetaList := model.ContainerMatchedList{
-			model.ContainerObjectMeta{
-				Namespace: namespace,
-				PodName:   fmt.Sprintf("chaosblade-sf-%s-%s", workloadType, workloadName),
-			},
-		}
-		logrusField.Infof("creating schedulingfailure experiment for %s/%s in namespace %s", workloadType, workloadName, namespace)
-		ctx = model.SetContainerObjectMetaListToContext(ctx, containerObjectMetaList)
-		return e.Exec(ctx, expModel)
-	}
-
+	// Default flow: find matched pods and execute
 	pods, resp := e.GetMatchedPodResources(ctx, *expModel)
 	if !resp.Success {
 		logrusField.Errorf("uid: %s, get matched pod experiment failed, %v", experimentId, resp.Err)

--- a/exec/pod/controller.go
+++ b/exec/pod/controller.go
@@ -84,8 +84,24 @@ func (e *ExpController) Create(ctx context.Context, expSpec v1alpha1.ExperimentS
 }
 
 func (e *ExpController) Destroy(ctx context.Context, expSpec v1alpha1.ExperimentSpec, oldExpStatus v1alpha1.ExperimentStatus) *spec.Response {
-	logrus.WithField("experiment", model.GetExperimentIdFromContext(ctx)).Infoln("start to destroy")
 	expModel := model.ExtractExpModelFromExperimentSpec(expSpec)
+	experimentId := model.GetExperimentIdFromContext(ctx)
+	logrus.WithField("experiment", experimentId).Infoln("start to destroy")
+
+	// Check if action implements ActionPreProcessor - use the same path as Create
+	actionSpec := e.ResourceModelSpec.GetExpActionModelSpec(expModel.Target, expModel.ActionName)
+	if actionSpec != nil {
+		if preProcessor, ok := actionSpec.(model.ActionPreProcessor); ok {
+			newCtx, resp := preProcessor.PreDestroy(ctx, expModel, e.Client, oldExpStatus)
+			if resp != nil {
+				return resp
+			}
+			ctx = newCtx
+			return e.Exec(ctx, expModel)
+		}
+	}
+
+	// Default flow: find matched containers and destroy
 	statuses := oldExpStatus.ResStatuses
 	if statuses == nil {
 		return spec.ReturnSuccess(v1alpha1.CreateSuccessExperimentStatus([]v1alpha1.ResourceStatus{}))

--- a/exec/pod/pod.go
+++ b/exec/pod/pod.go
@@ -232,6 +232,14 @@ blade create k8s pod-pod containercreating --namespace default --kubeconfig ~/.k
 
 # Create a pod stuck in ContainerCreating state with custom volume mount path
 blade create k8s pod-pod containercreating --namespace default --volume-mount-path /data --kubeconfig ~/.kube/config`)
+			case *PodSchedulingFailureActionSpec:
+				action.SetLongDesc("Make pod scheduling fail by injecting unreachable affinity rules to the target workload (Deployment/DaemonSet/StatefulSet). The scheduler will not find any node matching the rules, causing the Pod to remain in Pending state.")
+				action.SetExample(
+					`# Inject scheduling failure to a deployment by node affinity
+blade create k8s pod-pod schedulingfailure --namespace default --workload-type deployment --workload-name nginx-deployment --kubeconfig ~/.kube/config
+
+# Inject scheduling failure using node-selector
+blade create k8s pod-pod schedulingfailure --namespace default --workload-type deployment --workload-name nginx-deployment --affinity-type node-selector --kubeconfig ~/.kube/config`)
 			default:
 				action.SetExample(strings.Replace(action.Example(),
 					fmt.Sprintf("blade create %s %s", expModelSpec.Name(), action.Name()),
@@ -270,6 +278,7 @@ func NewSelfExpModelCommandSpec(client *channel.Client) spec.ExpModelCommandSpec
 				NewFailPodActionSpec(client),
 				NewPodTerminatingActionSpec(client),
 				NewPodContainerCreatingActionSpec(client),
+				NewPodSchedulingFailureActionSpec(client),
 			},
 		},
 	}

--- a/exec/pod/schedulingfailure.go
+++ b/exec/pod/schedulingfailure.go
@@ -1,0 +1,613 @@
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pod
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
+	"github.com/sirupsen/logrus"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/chaosblade-io/chaosblade-operator/channel"
+	"github.com/chaosblade-io/chaosblade-operator/exec/model"
+	"github.com/chaosblade-io/chaosblade-operator/pkg/apis/chaosblade/v1alpha1"
+)
+
+const (
+	// ChaosBladeWorkloadAnnotation is the annotation for workload resources modified by schedulingfailure action
+	ChaosBladeWorkloadAnnotation = "chaosblade.io/workload"
+	// ChaosBladeOriginalAffinityAnnotation stores the original affinity configuration
+	ChaosBladeOriginalAffinityAnnotation = "chaosblade.io/original-affinity"
+	// ChaosBladeOriginalNodeSelectorAnnotation stores the original node selector configuration
+	ChaosBladeOriginalNodeSelectorAnnotation = "chaosblade.io/original-nodeselector"
+	// ChaosBladeSchedulingFailureAction indicates scheduling failure action
+	ChaosBladeSchedulingFailureAction = "schedulingfailure"
+	// UnreachableNodeLabel is a label that no node will have
+	UnreachableNodeLabelKey   = "chaosblade.io/unreachable"
+	UnreachableNodeLabelValue = "true"
+)
+
+type PodSchedulingFailureActionSpec struct {
+	spec.BaseExpActionCommandSpec
+}
+
+func NewPodSchedulingFailureActionSpec(client *channel.Client) spec.ExpActionCommandSpec {
+	return &PodSchedulingFailureActionSpec{
+		spec.BaseExpActionCommandSpec{
+			ActionMatchers: []spec.ExpFlagSpec{},
+			ActionFlags: []spec.ExpFlagSpec{
+				&spec.ExpFlag{
+					Name: "workload-type",
+					Desc: "Workload type: deployment, daemonset, statefulset. Default: deployment",
+				},
+				&spec.ExpFlag{
+					Name: "workload-name",
+					Desc: "Workload name to inject scheduling failure",
+				},
+				&spec.ExpFlag{
+					Name: "affinity-type",
+					Desc: "Affinity type to inject: node-affinity, node-selector, pod-affinity, pod-anti-affinity. Default: node-affinity",
+				},
+			},
+			ActionExecutor: &PodSchedulingFailureActionExecutor{client: client},
+			ActionExample: `# Inject scheduling failure to a deployment by node affinity
+blade create k8s pod-pod schedulingfailure --namespace default --workload-type deployment --workload-name nginx-deployment --kubeconfig ~/.kube/config
+
+# Inject scheduling failure using node-selector
+blade create k8s pod-pod schedulingfailure --namespace default --workload-type deployment --workload-name nginx-deployment --affinity-type node-selector --kubeconfig ~/.kube/config
+`,
+			ActionCategories: []string{model.CategorySystemContainer},
+		},
+	}
+}
+
+func (*PodSchedulingFailureActionSpec) Name() string {
+	return "schedulingfailure"
+}
+
+func (*PodSchedulingFailureActionSpec) Aliases() []string {
+	return []string{}
+}
+
+func (*PodSchedulingFailureActionSpec) ShortDesc() string {
+	return "Make pod scheduling fail by injecting unreachable affinity rules"
+}
+
+func (*PodSchedulingFailureActionSpec) LongDesc() string {
+	return "Simulate the scenario where a Pod cannot be scheduled due to affinity configuration issues. " +
+		"This fault is injected by modifying the target workload's (Deployment/DaemonSet/StatefulSet) Pod template " +
+		"to add an unreachable node affinity or node selector. The scheduler will not find any node matching the rules, " +
+		"causing the Pod to remain in Pending state. When the experiment is destroyed, the original affinity " +
+		"configuration will be restored."
+}
+
+type PodSchedulingFailureActionExecutor struct {
+	client *channel.Client
+}
+
+func (*PodSchedulingFailureActionExecutor) Name() string {
+	return "schedulingfailure"
+}
+
+func (*PodSchedulingFailureActionExecutor) SetChannel(channel spec.Channel) {}
+
+func (d *PodSchedulingFailureActionExecutor) Exec(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	if _, ok := spec.IsDestroy(ctx); ok {
+		return d.destroy(uid, ctx, expModel)
+	}
+	return d.create(uid, ctx, expModel)
+}
+
+func (d *PodSchedulingFailureActionExecutor) create(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	experimentId := model.GetExperimentIdFromContext(ctx)
+	logrusField := logrus.WithField("experiment", experimentId)
+
+	// Parse flags
+	namespace := expModel.ActionFlags[model.ResourceNamespaceFlag.Name]
+	workloadType := expModel.ActionFlags["workload-type"]
+	if workloadType == "" {
+		workloadType = "deployment"
+	}
+	workloadName := expModel.ActionFlags["workload-name"]
+	affinityType := expModel.ActionFlags["affinity-type"]
+	if affinityType == "" {
+		affinityType = "node-affinity"
+	}
+
+	// Validate required flags
+	if namespace == "" {
+		util.Errorf(uid, util.GetRunFuncName(), "namespace is required")
+		return spec.ResponseFailWithFlags(spec.ParameterLess, model.ResourceNamespaceFlag.Name)
+	}
+	if workloadName == "" {
+		util.Errorf(uid, util.GetRunFuncName(), "workload-name is required")
+		return spec.ResponseFailWithFlags(spec.ParameterLess, "workload-name")
+	}
+
+	status := v1alpha1.ResourceStatus{
+		Kind:       v1alpha1.PodKind,
+		Identifier: fmt.Sprintf("%s//%s//%s", namespace, workloadType, workloadName),
+	}
+
+	// Get and modify the workload
+	switch workloadType {
+	case "deployment":
+		deployment := &appsv1.Deployment{}
+		err := d.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: workloadName}, deployment)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				logrusField.Warningf("deployment %s/%s not found", namespace, workloadName)
+				status = status.CreateFailResourceStatus(fmt.Sprintf("deployment not found: %v", err), spec.K8sExecFailed.Code)
+			} else {
+				logrusField.Warningf("get deployment %s/%s failed: %v", namespace, workloadName, err)
+				status = status.CreateFailResourceStatus(fmt.Sprintf("get deployment failed: %v", err), spec.K8sExecFailed.Code)
+			}
+			return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+		}
+
+		// Inject scheduling failure
+		if err := d.injectDeploymentSchedulingFailure(ctx, deployment, affinityType, experimentId); err != nil {
+			logrusField.Warningf("inject scheduling failure to deployment %s/%s failed: %v", namespace, workloadName, err)
+			status = status.CreateFailResourceStatus(fmt.Sprintf("inject scheduling failure failed: %v", err), spec.K8sExecFailed.Code)
+			return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+		}
+		logrusField.Infof("injected scheduling failure to deployment %s/%s with affinity type %s", namespace, workloadName, affinityType)
+
+	case "daemonset":
+		daemonset := &appsv1.DaemonSet{}
+		err := d.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: workloadName}, daemonset)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				logrusField.Warningf("daemonset %s/%s not found", namespace, workloadName)
+				status = status.CreateFailResourceStatus(fmt.Sprintf("daemonset not found: %v", err), spec.K8sExecFailed.Code)
+			} else {
+				logrusField.Warningf("get daemonset %s/%s failed: %v", namespace, workloadName, err)
+				status = status.CreateFailResourceStatus(fmt.Sprintf("get daemonset failed: %v", err), spec.K8sExecFailed.Code)
+			}
+			return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+		}
+
+		if err := d.injectDaemonSetSchedulingFailure(ctx, daemonset, affinityType, experimentId); err != nil {
+			logrusField.Warningf("inject scheduling failure to daemonset %s/%s failed: %v", namespace, workloadName, err)
+			status = status.CreateFailResourceStatus(fmt.Sprintf("inject scheduling failure failed: %v", err), spec.K8sExecFailed.Code)
+			return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+		}
+		logrusField.Infof("injected scheduling failure to daemonset %s/%s with affinity type %s", namespace, workloadName, affinityType)
+
+	case "statefulset":
+		statefulset := &appsv1.StatefulSet{}
+		err := d.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: workloadName}, statefulset)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				logrusField.Warningf("statefulset %s/%s not found", namespace, workloadName)
+				status = status.CreateFailResourceStatus(fmt.Sprintf("statefulset not found: %v", err), spec.K8sExecFailed.Code)
+			} else {
+				logrusField.Warningf("get statefulset %s/%s failed: %v", namespace, workloadName, err)
+				status = status.CreateFailResourceStatus(fmt.Sprintf("get statefulset failed: %v", err), spec.K8sExecFailed.Code)
+			}
+			return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+		}
+
+		if err := d.injectStatefulSetSchedulingFailure(ctx, statefulset, affinityType, experimentId); err != nil {
+			logrusField.Warningf("inject scheduling failure to statefulset %s/%s failed: %v", namespace, workloadName, err)
+			status = status.CreateFailResourceStatus(fmt.Sprintf("inject scheduling failure failed: %v", err), spec.K8sExecFailed.Code)
+			return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+		}
+		logrusField.Infof("injected scheduling failure to statefulset %s/%s with affinity type %s", namespace, workloadName, affinityType)
+
+	default:
+		status = status.CreateFailResourceStatus(fmt.Sprintf("unsupported workload type: %s", workloadType), spec.ParameterIllegal.Code)
+		return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+	}
+
+	status = status.CreateSuccessResourceStatus()
+	return spec.ReturnResultIgnoreCode(v1alpha1.CreateSuccessExperimentStatus([]v1alpha1.ResourceStatus{status}))
+}
+
+func (d *PodSchedulingFailureActionExecutor) destroy(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	experimentId := model.GetExperimentIdFromContext(ctx)
+	logrusField := logrus.WithField("experiment", experimentId)
+
+	// Parse flags
+	namespace := expModel.ActionFlags[model.ResourceNamespaceFlag.Name]
+	workloadType := expModel.ActionFlags["workload-type"]
+	if workloadType == "" {
+		workloadType = "deployment"
+	}
+	workloadName := expModel.ActionFlags["workload-name"]
+
+	status := v1alpha1.ResourceStatus{
+		Kind:       v1alpha1.PodKind,
+		Identifier: fmt.Sprintf("%s//%s//%s", namespace, workloadType, workloadName),
+	}
+
+	// Restore the workload
+	switch workloadType {
+	case "deployment":
+		deployment := &appsv1.Deployment{}
+		err := d.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: workloadName}, deployment)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				logrusField.Infof("deployment %s/%s already deleted", namespace, workloadName)
+				status = status.CreateSuccessResourceStatus()
+				status.State = v1alpha1.DestroyedState
+				return spec.ReturnResultIgnoreCode(v1alpha1.CreateDestroyedExperimentStatus([]v1alpha1.ResourceStatus{status}))
+			}
+			logrusField.Warningf("get deployment %s/%s failed: %v", namespace, workloadName, err)
+			status = status.CreateFailResourceStatus(fmt.Sprintf("get deployment failed: %v", err), spec.K8sExecFailed.Code)
+			return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+		}
+
+		if err := d.restoreDeployment(ctx, deployment, experimentId); err != nil {
+			logrusField.Warningf("restore deployment %s/%s failed: %v", namespace, workloadName, err)
+			status = status.CreateFailResourceStatus(fmt.Sprintf("restore deployment failed: %v", err), spec.K8sExecFailed.Code)
+			return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+		}
+		logrusField.Infof("restored deployment %s/%s", namespace, workloadName)
+
+	case "daemonset":
+		daemonset := &appsv1.DaemonSet{}
+		err := d.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: workloadName}, daemonset)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				logrusField.Infof("daemonset %s/%s already deleted", namespace, workloadName)
+				status = status.CreateSuccessResourceStatus()
+				status.State = v1alpha1.DestroyedState
+				return spec.ReturnResultIgnoreCode(v1alpha1.CreateDestroyedExperimentStatus([]v1alpha1.ResourceStatus{status}))
+			}
+			logrusField.Warningf("get daemonset %s/%s failed: %v", namespace, workloadName, err)
+			status = status.CreateFailResourceStatus(fmt.Sprintf("get daemonset failed: %v", err), spec.K8sExecFailed.Code)
+			return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+		}
+
+		if err := d.restoreDaemonSet(ctx, daemonset, experimentId); err != nil {
+			logrusField.Warningf("restore daemonset %s/%s failed: %v", namespace, workloadName, err)
+			status = status.CreateFailResourceStatus(fmt.Sprintf("restore daemonset failed: %v", err), spec.K8sExecFailed.Code)
+			return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+		}
+		logrusField.Infof("restored daemonset %s/%s", namespace, workloadName)
+
+	case "statefulset":
+		statefulset := &appsv1.StatefulSet{}
+		err := d.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: workloadName}, statefulset)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				logrusField.Infof("statefulset %s/%s already deleted", namespace, workloadName)
+				status = status.CreateSuccessResourceStatus()
+				status.State = v1alpha1.DestroyedState
+				return spec.ReturnResultIgnoreCode(v1alpha1.CreateDestroyedExperimentStatus([]v1alpha1.ResourceStatus{status}))
+			}
+			logrusField.Warningf("get statefulset %s/%s failed: %v", namespace, workloadName, err)
+			status = status.CreateFailResourceStatus(fmt.Sprintf("get statefulset failed: %v", err), spec.K8sExecFailed.Code)
+			return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+		}
+
+		if err := d.restoreStatefulSet(ctx, statefulset, experimentId); err != nil {
+			logrusField.Warningf("restore statefulset %s/%s failed: %v", namespace, workloadName, err)
+			status = status.CreateFailResourceStatus(fmt.Sprintf("restore statefulset failed: %v", err), spec.K8sExecFailed.Code)
+			return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+		}
+		logrusField.Infof("restored statefulset %s/%s", namespace, workloadName)
+
+	default:
+		status = status.CreateFailResourceStatus(fmt.Sprintf("unsupported workload type: %s", workloadType), spec.ParameterIllegal.Code)
+		return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+	}
+
+	status = status.CreateSuccessResourceStatus()
+	status.State = v1alpha1.DestroyedState
+	return spec.ReturnResultIgnoreCode(v1alpha1.CreateDestroyedExperimentStatus([]v1alpha1.ResourceStatus{status}))
+}
+
+// injectDeploymentSchedulingFailure injects scheduling failure to a Deployment
+func (d *PodSchedulingFailureActionExecutor) injectDeploymentSchedulingFailure(ctx context.Context, deployment *appsv1.Deployment, affinityType, experimentId string) error {
+	// Backup original configuration
+	if deployment.Annotations == nil {
+		deployment.Annotations = make(map[string]string)
+	}
+	deployment.Annotations[ChaosBladeWorkloadAnnotation] = ChaosBladeSchedulingFailureAction
+	deployment.Annotations[ChaosBladeExperimentAnnotation] = experimentId
+
+	// Backup and inject affinity
+	if err := d.backupAndInjectAffinity(&deployment.Spec.Template.Spec, deployment.Annotations, affinityType); err != nil {
+		return err
+	}
+
+	return d.client.Update(ctx, deployment)
+}
+
+// injectDaemonSetSchedulingFailure injects scheduling failure to a DaemonSet
+func (d *PodSchedulingFailureActionExecutor) injectDaemonSetSchedulingFailure(ctx context.Context, daemonset *appsv1.DaemonSet, affinityType, experimentId string) error {
+	if daemonset.Annotations == nil {
+		daemonset.Annotations = make(map[string]string)
+	}
+	daemonset.Annotations[ChaosBladeWorkloadAnnotation] = ChaosBladeSchedulingFailureAction
+	daemonset.Annotations[ChaosBladeExperimentAnnotation] = experimentId
+
+	if err := d.backupAndInjectAffinity(&daemonset.Spec.Template.Spec, daemonset.Annotations, affinityType); err != nil {
+		return err
+	}
+
+	return d.client.Update(ctx, daemonset)
+}
+
+// injectStatefulSetSchedulingFailure injects scheduling failure to a StatefulSet
+func (d *PodSchedulingFailureActionExecutor) injectStatefulSetSchedulingFailure(ctx context.Context, statefulset *appsv1.StatefulSet, affinityType, experimentId string) error {
+	if statefulset.Annotations == nil {
+		statefulset.Annotations = make(map[string]string)
+	}
+	statefulset.Annotations[ChaosBladeWorkloadAnnotation] = ChaosBladeSchedulingFailureAction
+	statefulset.Annotations[ChaosBladeExperimentAnnotation] = experimentId
+
+	if err := d.backupAndInjectAffinity(&statefulset.Spec.Template.Spec, statefulset.Annotations, affinityType); err != nil {
+		return err
+	}
+
+	return d.client.Update(ctx, statefulset)
+}
+
+// backupAndInjectAffinity backs up original affinity and injects unreachable affinity rules
+func (d *PodSchedulingFailureActionExecutor) backupAndInjectAffinity(podSpec *v1.PodSpec, annotations map[string]string, affinityType string) error {
+	switch affinityType {
+	case "node-affinity":
+		// Backup original affinity
+		if podSpec.Affinity != nil && podSpec.Affinity.NodeAffinity != nil {
+			originalBytes, err := json.Marshal(podSpec.Affinity.NodeAffinity)
+			if err != nil {
+				return fmt.Errorf("marshal original node affinity failed: %v", err)
+			}
+			annotations[ChaosBladeOriginalAffinityAnnotation] = string(originalBytes)
+		}
+
+		// Inject unreachable node affinity
+		unreachableAffinity := &v1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{
+					{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{
+								Key:      UnreachableNodeLabelKey,
+								Operator: v1.NodeSelectorOpIn,
+								Values:   []string{UnreachableNodeLabelValue},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		if podSpec.Affinity == nil {
+			podSpec.Affinity = &v1.Affinity{}
+		}
+		podSpec.Affinity.NodeAffinity = unreachableAffinity
+
+	case "node-selector":
+		// Backup original node selector
+		if podSpec.NodeSelector != nil && len(podSpec.NodeSelector) > 0 {
+			originalBytes, err := json.Marshal(podSpec.NodeSelector)
+			if err != nil {
+				return fmt.Errorf("marshal original node selector failed: %v", err)
+			}
+			annotations[ChaosBladeOriginalNodeSelectorAnnotation] = string(originalBytes)
+		}
+
+		// Inject unreachable node selector
+		podSpec.NodeSelector = map[string]string{
+			UnreachableNodeLabelKey: UnreachableNodeLabelValue,
+		}
+
+	case "pod-affinity":
+		// Backup original pod affinity
+		if podSpec.Affinity != nil && podSpec.Affinity.PodAffinity != nil {
+			originalBytes, err := json.Marshal(podSpec.Affinity.PodAffinity)
+			if err != nil {
+				return fmt.Errorf("marshal original pod affinity failed: %v", err)
+			}
+			annotations[ChaosBladeOriginalAffinityAnnotation] = string(originalBytes)
+		}
+
+		// Inject unreachable pod affinity
+		unreachablePodAffinity := &v1.PodAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      UnreachableNodeLabelKey,
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{UnreachableNodeLabelValue},
+							},
+						},
+					},
+					TopologyKey: "kubernetes.io/hostname",
+				},
+			},
+		}
+
+		if podSpec.Affinity == nil {
+			podSpec.Affinity = &v1.Affinity{}
+		}
+		podSpec.Affinity.PodAffinity = unreachablePodAffinity
+
+	case "pod-anti-affinity":
+		// Backup original pod anti-affinity
+		if podSpec.Affinity != nil && podSpec.Affinity.PodAntiAffinity != nil {
+			originalBytes, err := json.Marshal(podSpec.Affinity.PodAntiAffinity)
+			if err != nil {
+				return fmt.Errorf("marshal original pod anti-affinity failed: %v", err)
+			}
+			annotations[ChaosBladeOriginalAffinityAnnotation] = string(originalBytes)
+		}
+
+		// Inject unreachable pod anti-affinity (this will block scheduling on any node)
+		unreachablePodAntiAffinity := &v1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "kubernetes.io/hostname",
+								Operator: metav1.LabelSelectorOpExists,
+							},
+						},
+					},
+					TopologyKey: "kubernetes.io/hostname",
+				},
+			},
+		}
+
+		if podSpec.Affinity == nil {
+			podSpec.Affinity = &v1.Affinity{}
+		}
+		podSpec.Affinity.PodAntiAffinity = unreachablePodAntiAffinity
+
+	default:
+		return fmt.Errorf("unsupported affinity type: %s", affinityType)
+	}
+
+	return nil
+}
+
+// restoreDeployment restores a Deployment's original affinity configuration
+func (d *PodSchedulingFailureActionExecutor) restoreDeployment(ctx context.Context, deployment *appsv1.Deployment, experimentId string) error {
+	// Verify this deployment was modified by the same experiment
+	if deployment.Annotations[ChaosBladeExperimentAnnotation] != experimentId {
+		return fmt.Errorf("deployment was not modified by experiment %s", experimentId)
+	}
+
+	if err := d.restoreAffinity(&deployment.Spec.Template.Spec, deployment.Annotations); err != nil {
+		return err
+	}
+
+	// Clean up annotations
+	delete(deployment.Annotations, ChaosBladeWorkloadAnnotation)
+	delete(deployment.Annotations, ChaosBladeExperimentAnnotation)
+	delete(deployment.Annotations, ChaosBladeOriginalAffinityAnnotation)
+	delete(deployment.Annotations, ChaosBladeOriginalNodeSelectorAnnotation)
+
+	return d.client.Update(ctx, deployment)
+}
+
+// restoreDaemonSet restores a DaemonSet's original affinity configuration
+func (d *PodSchedulingFailureActionExecutor) restoreDaemonSet(ctx context.Context, daemonset *appsv1.DaemonSet, experimentId string) error {
+	if daemonset.Annotations[ChaosBladeExperimentAnnotation] != experimentId {
+		return fmt.Errorf("daemonset was not modified by experiment %s", experimentId)
+	}
+
+	if err := d.restoreAffinity(&daemonset.Spec.Template.Spec, daemonset.Annotations); err != nil {
+		return err
+	}
+
+	delete(daemonset.Annotations, ChaosBladeWorkloadAnnotation)
+	delete(daemonset.Annotations, ChaosBladeExperimentAnnotation)
+	delete(daemonset.Annotations, ChaosBladeOriginalAffinityAnnotation)
+	delete(daemonset.Annotations, ChaosBladeOriginalNodeSelectorAnnotation)
+
+	return d.client.Update(ctx, daemonset)
+}
+
+// restoreStatefulSet restores a StatefulSet's original affinity configuration
+func (d *PodSchedulingFailureActionExecutor) restoreStatefulSet(ctx context.Context, statefulset *appsv1.StatefulSet, experimentId string) error {
+	if statefulset.Annotations[ChaosBladeExperimentAnnotation] != experimentId {
+		return fmt.Errorf("statefulset was not modified by experiment %s", experimentId)
+	}
+
+	if err := d.restoreAffinity(&statefulset.Spec.Template.Spec, statefulset.Annotations); err != nil {
+		return err
+	}
+
+	delete(statefulset.Annotations, ChaosBladeWorkloadAnnotation)
+	delete(statefulset.Annotations, ChaosBladeExperimentAnnotation)
+	delete(statefulset.Annotations, ChaosBladeOriginalAffinityAnnotation)
+	delete(statefulset.Annotations, ChaosBladeOriginalNodeSelectorAnnotation)
+
+	return d.client.Update(ctx, statefulset)
+}
+
+// restoreAffinity restores the original affinity configuration from annotations
+func (d *PodSchedulingFailureActionExecutor) restoreAffinity(podSpec *v1.PodSpec, annotations map[string]string) error {
+	// Restore node affinity
+	if originalAffinityStr, ok := annotations[ChaosBladeOriginalAffinityAnnotation]; ok {
+		var originalAffinity interface{}
+		if err := json.Unmarshal([]byte(originalAffinityStr), &originalAffinity); err != nil {
+			return fmt.Errorf("unmarshal original affinity failed: %v", err)
+		}
+
+		// Try to determine the type and restore
+		switch v := originalAffinity.(type) {
+		case map[string]interface{}:
+			// Could be NodeAffinity or PodAffinity or PodAntiAffinity
+			// Check which one was backed up by looking at the structure
+			if _, hasNodeSelectorTerms := v["nodeSelectorTerms"]; hasNodeSelectorTerms {
+				var nodeAffinity v1.NodeAffinity
+				if err := json.Unmarshal([]byte(originalAffinityStr), &nodeAffinity); err != nil {
+					return fmt.Errorf("unmarshal node affinity failed: %v", err)
+				}
+				if podSpec.Affinity == nil {
+					podSpec.Affinity = &v1.Affinity{}
+				}
+				podSpec.Affinity.NodeAffinity = &nodeAffinity
+			} else if _, hasRequiredDuringScheduling := v["requiredDuringSchedulingIgnoredDuringExecution"]; hasRequiredDuringScheduling {
+				// Could be PodAffinity or PodAntiAffinity - restore to both for simplicity
+				var podAffinity v1.PodAffinity
+				if err := json.Unmarshal([]byte(originalAffinityStr), &podAffinity); err != nil {
+					return fmt.Errorf("unmarshal pod affinity failed: %v", err)
+				}
+				if podSpec.Affinity == nil {
+					podSpec.Affinity = &v1.Affinity{}
+				}
+				podSpec.Affinity.PodAffinity = &podAffinity
+			}
+		}
+	} else {
+		// No backup means there was no original affinity, clear injected one
+		if podSpec.Affinity != nil {
+			podSpec.Affinity.NodeAffinity = nil
+			podSpec.Affinity.PodAffinity = nil
+			podSpec.Affinity.PodAntiAffinity = nil
+			// If all affinity fields are nil, set Affinity to nil
+			if podSpec.Affinity.NodeAffinity == nil &&
+				podSpec.Affinity.PodAffinity == nil &&
+				podSpec.Affinity.PodAntiAffinity == nil {
+				podSpec.Affinity = nil
+			}
+		}
+	}
+
+	// Restore node selector
+	if originalNodeSelectorStr, ok := annotations[ChaosBladeOriginalNodeSelectorAnnotation]; ok {
+		var originalNodeSelector map[string]string
+		if err := json.Unmarshal([]byte(originalNodeSelectorStr), &originalNodeSelector); err != nil {
+			return fmt.Errorf("unmarshal original node selector failed: %v", err)
+		}
+		podSpec.NodeSelector = originalNodeSelector
+	} else {
+		// No backup means there was no original node selector, clear injected one
+		podSpec.NodeSelector = nil
+	}
+
+	return nil
+}

--- a/exec/pod/schedulingfailure.go
+++ b/exec/pod/schedulingfailure.go
@@ -338,7 +338,7 @@ func (d *PodSchedulingFailureActionExecutor) injectDeploymentSchedulingFailure(c
 	deployment.Annotations[ChaosBladeExperimentAnnotation] = experimentId
 
 	// Backup and inject affinity
-	if err := d.backupAndInjectAffinity(&deployment.Spec.Template.Spec, deployment.Annotations, affinityType); err != nil {
+	if err := d.backupAndInjectAffinity(&deployment.Spec.Template.Spec, deployment.Annotations, affinityType, deployment.Spec.Template.Labels); err != nil {
 		return err
 	}
 
@@ -353,7 +353,7 @@ func (d *PodSchedulingFailureActionExecutor) injectDaemonSetSchedulingFailure(ct
 	daemonset.Annotations[ChaosBladeDaemonSetAnnotation] = ChaosBladeModifyAction
 	daemonset.Annotations[ChaosBladeExperimentAnnotation] = experimentId
 
-	if err := d.backupAndInjectAffinity(&daemonset.Spec.Template.Spec, daemonset.Annotations, affinityType); err != nil {
+	if err := d.backupAndInjectAffinity(&daemonset.Spec.Template.Spec, daemonset.Annotations, affinityType, daemonset.Spec.Template.Labels); err != nil {
 		return err
 	}
 
@@ -368,7 +368,7 @@ func (d *PodSchedulingFailureActionExecutor) injectStatefulSetSchedulingFailure(
 	statefulset.Annotations[ChaosBladeStatefulSetAnnotation] = ChaosBladeModifyAction
 	statefulset.Annotations[ChaosBladeExperimentAnnotation] = experimentId
 
-	if err := d.backupAndInjectAffinity(&statefulset.Spec.Template.Spec, statefulset.Annotations, affinityType); err != nil {
+	if err := d.backupAndInjectAffinity(&statefulset.Spec.Template.Spec, statefulset.Annotations, affinityType, statefulset.Spec.Template.Labels); err != nil {
 		return err
 	}
 
@@ -376,7 +376,8 @@ func (d *PodSchedulingFailureActionExecutor) injectStatefulSetSchedulingFailure(
 }
 
 // backupAndInjectAffinity backs up original affinity and injects unreachable affinity rules
-func (d *PodSchedulingFailureActionExecutor) backupAndInjectAffinity(podSpec *v1.PodSpec, annotations map[string]string, affinityType string) error {
+// podLabels is used by pod-anti-affinity to target the workload's own labels
+func (d *PodSchedulingFailureActionExecutor) backupAndInjectAffinity(podSpec *v1.PodSpec, annotations map[string]string, affinityType string, podLabels map[string]string) error {
 	switch affinityType {
 	case "node-affinity":
 		// Backup original affinity
@@ -412,7 +413,7 @@ func (d *PodSchedulingFailureActionExecutor) backupAndInjectAffinity(podSpec *v1
 
 	case "node-selector":
 		// Backup original node selector
-		if podSpec.NodeSelector != nil && len(podSpec.NodeSelector) > 0 {
+		if len(podSpec.NodeSelector) > 0 {
 			originalBytes, err := json.Marshal(podSpec.NodeSelector)
 			if err != nil {
 				return fmt.Errorf("marshal original node selector failed: %v", err)
@@ -468,17 +469,26 @@ func (d *PodSchedulingFailureActionExecutor) backupAndInjectAffinity(podSpec *v1
 			annotations[ChaosBladeOriginalPodAntiAffinityAnnotation] = string(originalBytes)
 		}
 
-		// Inject unreachable pod anti-affinity (this will block scheduling on any node)
+		// Inject pod anti-affinity against the workload's own labels
+		// This creates a "one pod per node" constraint: new pods can't be scheduled
+		// on nodes that already have a pod with the same labels.
+		// With enough replicas (> number of available nodes), pods will be Pending.
+		var matchExpressions []metav1.LabelSelectorRequirement
+		for key := range podLabels {
+			matchExpressions = append(matchExpressions, metav1.LabelSelectorRequirement{
+				Key:      key,
+				Operator: metav1.LabelSelectorOpExists,
+			})
+		}
+		if len(matchExpressions) == 0 {
+			return fmt.Errorf("pod template has no labels, cannot inject pod-anti-affinity")
+		}
+
 		unreachablePodAntiAffinity := &v1.PodAntiAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
 				{
 					LabelSelector: &metav1.LabelSelector{
-						MatchExpressions: []metav1.LabelSelectorRequirement{
-							{
-								Key:      "kubernetes.io/hostname",
-								Operator: metav1.LabelSelectorOpExists,
-							},
-						},
+						MatchExpressions: matchExpressions,
 					},
 					TopologyKey: "kubernetes.io/hostname",
 				},
@@ -514,6 +524,29 @@ func (a *PodSchedulingFailureActionSpec) PreCreate(ctx context.Context, expModel
 	if workloadName == "" {
 		return ctx, spec.ResponseFailWithFlags(spec.ParameterLess, "workload-name")
 	}
+
+	containerObjectMetaList := model.ContainerMatchedList{
+		model.ContainerObjectMeta{
+			Namespace: namespace,
+			PodName:   fmt.Sprintf("chaosblade-sf-%s-%s", workloadType, workloadName),
+		},
+	}
+
+	ctx = model.SetContainerObjectMetaListToContext(ctx, containerObjectMetaList)
+	return ctx, nil
+}
+
+// PreDestroy implements model.ActionPreProcessor interface.
+// It prepares the context for schedulingfailure destroy flow.
+// Unlike the default destroy path, it always attempts to restore the workload
+// regardless of the old experiment status.
+func (a *PodSchedulingFailureActionSpec) PreDestroy(ctx context.Context, expModel *spec.ExpModel, client *channel.Client, oldExpStatus v1alpha1.ExperimentStatus) (context.Context, *spec.Response) {
+	namespace := expModel.ActionFlags[model.ResourceNamespaceFlag.Name]
+	workloadType := expModel.ActionFlags["workload-type"]
+	if workloadType == "" {
+		workloadType = "deployment"
+	}
+	workloadName := expModel.ActionFlags["workload-name"]
 
 	containerObjectMetaList := model.ContainerMatchedList{
 		model.ContainerObjectMeta{

--- a/exec/pod/schedulingfailure.go
+++ b/exec/pod/schedulingfailure.go
@@ -74,16 +74,21 @@ func NewPodSchedulingFailureActionSpec(client *channel.Client) spec.ExpActionCom
 			ActionMatchers: []spec.ExpFlagSpec{},
 			ActionFlags: []spec.ExpFlagSpec{
 				&spec.ExpFlag{
-					Name: "workload-type",
-					Desc: "Workload type: deployment, daemonset, statefulset. Default: deployment",
+					Name:     "workload-type",
+					Desc:     "Workload type: deployment, daemonset, statefulset. Default: deployment",
+					Required: false,
+					Default:  "deployment",
 				},
 				&spec.ExpFlag{
-					Name: "workload-name",
-					Desc: "Workload name to inject scheduling failure",
+					Name:     "workload-name",
+					Desc:     "Workload name to inject scheduling failure",
+					Required: true,
 				},
 				&spec.ExpFlag{
-					Name: "affinity-type",
-					Desc: "Affinity type to inject: node-affinity, node-selector, pod-affinity, pod-anti-affinity. Default: node-affinity",
+					Name:     "affinity-type",
+					Desc:     "Affinity type to inject: node-affinity, node-selector, pod-affinity, pod-anti-affinity. Default: node-affinity",
+					Required: false,
+					Default:  "node-affinity",
 				},
 			},
 			ActionExecutor: &PodSchedulingFailureActionExecutor{client: client},

--- a/exec/pod/schedulingfailure.go
+++ b/exec/pod/schedulingfailure.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
 	"github.com/chaosblade-io/chaosblade-spec-go/util"
@@ -330,11 +331,23 @@ func (d *PodSchedulingFailureActionExecutor) destroy(uid string, ctx context.Con
 	return spec.ReturnResultIgnoreCode(v1alpha1.CreateDestroyedExperimentStatus([]v1alpha1.ResourceStatus{status}))
 }
 
+// ensureNoConflictingExperiment checks whether the workload is already modified by
+// another chaosblade experiment. This prevents overwriting backup data from a
+// running experiment, which would make the workload unrecoverable on destroy.
+func ensureNoConflictingExperiment(annotations map[string]string, experimentId string) error {
+	if existingId, ok := annotations[ChaosBladeExperimentAnnotation]; ok && existingId != "" && existingId != experimentId {
+		return fmt.Errorf("workload is already modified by another chaosblade experiment: %s", existingId)
+	}
+	return nil
+}
+
 // injectDeploymentSchedulingFailure injects scheduling failure to a Deployment
 func (d *PodSchedulingFailureActionExecutor) injectDeploymentSchedulingFailure(ctx context.Context, deployment *appsv1.Deployment, affinityType, experimentId string) error {
-	// Backup original configuration
 	if deployment.Annotations == nil {
 		deployment.Annotations = make(map[string]string)
+	}
+	if err := ensureNoConflictingExperiment(deployment.Annotations, experimentId); err != nil {
+		return err
 	}
 	deployment.Annotations[ChaosBladeDeploymentAnnotation] = ChaosBladeModifyAction
 	deployment.Annotations[ChaosBladeExperimentAnnotation] = experimentId
@@ -352,6 +365,9 @@ func (d *PodSchedulingFailureActionExecutor) injectDaemonSetSchedulingFailure(ct
 	if daemonset.Annotations == nil {
 		daemonset.Annotations = make(map[string]string)
 	}
+	if err := ensureNoConflictingExperiment(daemonset.Annotations, experimentId); err != nil {
+		return err
+	}
 	daemonset.Annotations[ChaosBladeDaemonSetAnnotation] = ChaosBladeModifyAction
 	daemonset.Annotations[ChaosBladeExperimentAnnotation] = experimentId
 
@@ -366,6 +382,9 @@ func (d *PodSchedulingFailureActionExecutor) injectDaemonSetSchedulingFailure(ct
 func (d *PodSchedulingFailureActionExecutor) injectStatefulSetSchedulingFailure(ctx context.Context, statefulset *appsv1.StatefulSet, affinityType, experimentId string) error {
 	if statefulset.Annotations == nil {
 		statefulset.Annotations = make(map[string]string)
+	}
+	if err := ensureNoConflictingExperiment(statefulset.Annotations, experimentId); err != nil {
+		return err
 	}
 	statefulset.Annotations[ChaosBladeStatefulSetAnnotation] = ChaosBladeModifyAction
 	statefulset.Annotations[ChaosBladeExperimentAnnotation] = experimentId
@@ -478,10 +497,11 @@ func (d *PodSchedulingFailureActionExecutor) backupAndInjectAffinity(podSpec *v1
 		// on nodes that already have a pod with the same labels.
 		// With enough replicas (> number of available nodes), pods will be Pending.
 		var matchExpressions []metav1.LabelSelectorRequirement
-		for key := range podLabels {
+		for key, value := range podLabels {
 			matchExpressions = append(matchExpressions, metav1.LabelSelectorRequirement{
 				Key:      key,
-				Operator: metav1.LabelSelectorOpExists,
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{value},
 			})
 		}
 		if len(matchExpressions) == 0 {
@@ -525,6 +545,9 @@ func (a *PodSchedulingFailureActionSpec) PreCreate(ctx context.Context, expModel
 	if namespace == "" {
 		return ctx, spec.ResponseFailWithFlags(spec.ParameterLess, model.ResourceNamespaceFlag.Name)
 	}
+	if strings.Contains(namespace, ",") {
+		return ctx, spec.ResponseFailWithFlags(spec.ParameterInvalidNSNotOne, model.ResourceNamespaceFlag.Name)
+	}
 	if workloadName == "" {
 		return ctx, spec.ResponseFailWithFlags(spec.ParameterLess, "workload-name")
 	}
@@ -551,6 +574,16 @@ func (a *PodSchedulingFailureActionSpec) PreDestroy(ctx context.Context, expMode
 		workloadType = "deployment"
 	}
 	workloadName := expModel.ActionFlags["workload-name"]
+
+	if namespace == "" {
+		return ctx, spec.ResponseFailWithFlags(spec.ParameterLess, model.ResourceNamespaceFlag.Name)
+	}
+	if strings.Contains(namespace, ",") {
+		return ctx, spec.ResponseFailWithFlags(spec.ParameterInvalidNSNotOne, model.ResourceNamespaceFlag.Name)
+	}
+	if workloadName == "" {
+		return ctx, spec.ResponseFailWithFlags(spec.ParameterLess, "workload-name")
+	}
 
 	containerObjectMetaList := model.ContainerMatchedList{
 		model.ContainerObjectMeta{

--- a/exec/pod/schedulingfailure.go
+++ b/exec/pod/schedulingfailure.go
@@ -58,11 +58,12 @@ const (
 
 type PodSchedulingFailureActionSpec struct {
 	spec.BaseExpActionCommandSpec
+	client *channel.Client
 }
 
 func NewPodSchedulingFailureActionSpec(client *channel.Client) spec.ExpActionCommandSpec {
 	return &PodSchedulingFailureActionSpec{
-		spec.BaseExpActionCommandSpec{
+		BaseExpActionCommandSpec: spec.BaseExpActionCommandSpec{
 			ActionMatchers: []spec.ExpFlagSpec{},
 			ActionFlags: []spec.ExpFlagSpec{
 				&spec.ExpFlag{
@@ -87,6 +88,7 @@ blade create k8s pod-pod schedulingfailure --namespace default --workload-type d
 `,
 			ActionCategories: []string{model.CategorySystemContainer},
 		},
+		client: client,
 	}
 }
 
@@ -495,6 +497,35 @@ func (d *PodSchedulingFailureActionExecutor) backupAndInjectAffinity(podSpec *v1
 	}
 
 	return nil
+}
+
+// PreCreate implements model.ActionPreProcessor interface.
+// It validates the required flags and prepares the context for schedulingfailure action.
+func (a *PodSchedulingFailureActionSpec) PreCreate(ctx context.Context, expModel *spec.ExpModel, client *channel.Client) (context.Context, *spec.Response) {
+	// Validate required flags
+	namespace := expModel.ActionFlags[model.ResourceNamespaceFlag.Name]
+	workloadType := expModel.ActionFlags["workload-type"]
+	if workloadType == "" {
+		workloadType = "deployment"
+	}
+	workloadName := expModel.ActionFlags["workload-name"]
+
+	if namespace == "" {
+		return ctx, spec.ResponseFailWithFlags(spec.ParameterLess, model.ResourceNamespaceFlag.Name)
+	}
+	if workloadName == "" {
+		return ctx, spec.ResponseFailWithFlags(spec.ParameterLess, "workload-name")
+	}
+
+	containerObjectMetaList := model.ContainerMatchedList{
+		model.ContainerObjectMeta{
+			Namespace: namespace,
+			PodName:   fmt.Sprintf("chaosblade-sf-%s-%s", workloadType, workloadName),
+		},
+	}
+
+	ctx = model.SetContainerObjectMetaListToContext(ctx, containerObjectMetaList)
+	return ctx, nil
 }
 
 // restoreDeployment restores a Deployment's original affinity configuration

--- a/exec/pod/schedulingfailure.go
+++ b/exec/pod/schedulingfailure.go
@@ -37,8 +37,14 @@ import (
 )
 
 const (
-	// ChaosBladeWorkloadAnnotation is the annotation for workload resources modified by schedulingfailure action
-	ChaosBladeWorkloadAnnotation = "chaosblade.io/workload"
+	// ChaosBladeDeploymentAnnotation indicates the deployment resource is modified
+	ChaosBladeDeploymentAnnotation = "chaosblade.io/deployment"
+	// ChaosBladeDaemonSetAnnotation indicates the daemonset resource is modified
+	ChaosBladeDaemonSetAnnotation = "chaosblade.io/daemonset"
+	// ChaosBladeStatefulSetAnnotation indicates the statefulset resource is modified
+	ChaosBladeStatefulSetAnnotation = "chaosblade.io/statefulset"
+	// ChaosBladeModifyAction indicates modify action
+	ChaosBladeModifyAction = "modify"
 	// ChaosBladeOriginalAffinityAnnotation stores the original affinity configuration
 	ChaosBladeOriginalAffinityAnnotation = "chaosblade.io/original-affinity"
 	// ChaosBladeOriginalNodeSelectorAnnotation stores the original node selector configuration
@@ -328,7 +334,7 @@ func (d *PodSchedulingFailureActionExecutor) injectDeploymentSchedulingFailure(c
 	if deployment.Annotations == nil {
 		deployment.Annotations = make(map[string]string)
 	}
-	deployment.Annotations[ChaosBladeWorkloadAnnotation] = ChaosBladeSchedulingFailureAction
+	deployment.Annotations[ChaosBladeDeploymentAnnotation] = ChaosBladeModifyAction
 	deployment.Annotations[ChaosBladeExperimentAnnotation] = experimentId
 
 	// Backup and inject affinity
@@ -344,7 +350,7 @@ func (d *PodSchedulingFailureActionExecutor) injectDaemonSetSchedulingFailure(ct
 	if daemonset.Annotations == nil {
 		daemonset.Annotations = make(map[string]string)
 	}
-	daemonset.Annotations[ChaosBladeWorkloadAnnotation] = ChaosBladeSchedulingFailureAction
+	daemonset.Annotations[ChaosBladeDaemonSetAnnotation] = ChaosBladeModifyAction
 	daemonset.Annotations[ChaosBladeExperimentAnnotation] = experimentId
 
 	if err := d.backupAndInjectAffinity(&daemonset.Spec.Template.Spec, daemonset.Annotations, affinityType); err != nil {
@@ -359,7 +365,7 @@ func (d *PodSchedulingFailureActionExecutor) injectStatefulSetSchedulingFailure(
 	if statefulset.Annotations == nil {
 		statefulset.Annotations = make(map[string]string)
 	}
-	statefulset.Annotations[ChaosBladeWorkloadAnnotation] = ChaosBladeSchedulingFailureAction
+	statefulset.Annotations[ChaosBladeStatefulSetAnnotation] = ChaosBladeModifyAction
 	statefulset.Annotations[ChaosBladeExperimentAnnotation] = experimentId
 
 	if err := d.backupAndInjectAffinity(&statefulset.Spec.Template.Spec, statefulset.Annotations, affinityType); err != nil {
@@ -503,7 +509,7 @@ func (d *PodSchedulingFailureActionExecutor) restoreDeployment(ctx context.Conte
 	}
 
 	// Clean up annotations
-	delete(deployment.Annotations, ChaosBladeWorkloadAnnotation)
+	delete(deployment.Annotations, ChaosBladeDeploymentAnnotation)
 	delete(deployment.Annotations, ChaosBladeExperimentAnnotation)
 	delete(deployment.Annotations, ChaosBladeOriginalAffinityAnnotation)
 	delete(deployment.Annotations, ChaosBladeOriginalNodeSelectorAnnotation)
@@ -521,7 +527,7 @@ func (d *PodSchedulingFailureActionExecutor) restoreDaemonSet(ctx context.Contex
 		return err
 	}
 
-	delete(daemonset.Annotations, ChaosBladeWorkloadAnnotation)
+	delete(daemonset.Annotations, ChaosBladeDaemonSetAnnotation)
 	delete(daemonset.Annotations, ChaosBladeExperimentAnnotation)
 	delete(daemonset.Annotations, ChaosBladeOriginalAffinityAnnotation)
 	delete(daemonset.Annotations, ChaosBladeOriginalNodeSelectorAnnotation)
@@ -539,7 +545,7 @@ func (d *PodSchedulingFailureActionExecutor) restoreStatefulSet(ctx context.Cont
 		return err
 	}
 
-	delete(statefulset.Annotations, ChaosBladeWorkloadAnnotation)
+	delete(statefulset.Annotations, ChaosBladeStatefulSetAnnotation)
 	delete(statefulset.Annotations, ChaosBladeExperimentAnnotation)
 	delete(statefulset.Annotations, ChaosBladeOriginalAffinityAnnotation)
 	delete(statefulset.Annotations, ChaosBladeOriginalNodeSelectorAnnotation)

--- a/exec/pod/schedulingfailure.go
+++ b/exec/pod/schedulingfailure.go
@@ -53,6 +53,8 @@ const (
 	ChaosBladeOriginalPodAntiAffinityAnnotation = "chaosblade.io/original-pod-anti-affinity"
 	// ChaosBladeOriginalNodeSelectorAnnotation stores the original node selector configuration
 	ChaosBladeOriginalNodeSelectorAnnotation = "chaosblade.io/original-nodeselector"
+	// ChaosBladeAffinityTypeAnnotation records which affinity type was injected
+	ChaosBladeAffinityTypeAnnotation = "chaosblade.io/affinity-type"
 	// ChaosBladeSchedulingFailureAction indicates scheduling failure action
 	ChaosBladeSchedulingFailureAction = "schedulingfailure"
 	// UnreachableNodeLabel is a label that no node will have
@@ -378,6 +380,8 @@ func (d *PodSchedulingFailureActionExecutor) injectStatefulSetSchedulingFailure(
 // backupAndInjectAffinity backs up original affinity and injects unreachable affinity rules
 // podLabels is used by pod-anti-affinity to target the workload's own labels
 func (d *PodSchedulingFailureActionExecutor) backupAndInjectAffinity(podSpec *v1.PodSpec, annotations map[string]string, affinityType string, podLabels map[string]string) error {
+	annotations[ChaosBladeAffinityTypeAnnotation] = affinityType
+
 	switch affinityType {
 	case "node-affinity":
 		// Backup original affinity
@@ -573,6 +577,7 @@ func (d *PodSchedulingFailureActionExecutor) restoreDeployment(ctx context.Conte
 	// Clean up annotations
 	delete(deployment.Annotations, ChaosBladeDeploymentAnnotation)
 	delete(deployment.Annotations, ChaosBladeExperimentAnnotation)
+	delete(deployment.Annotations, ChaosBladeAffinityTypeAnnotation)
 	delete(deployment.Annotations, ChaosBladeOriginalNodeAffinityAnnotation)
 	delete(deployment.Annotations, ChaosBladeOriginalPodAffinityAnnotation)
 	delete(deployment.Annotations, ChaosBladeOriginalPodAntiAffinityAnnotation)
@@ -593,6 +598,7 @@ func (d *PodSchedulingFailureActionExecutor) restoreDaemonSet(ctx context.Contex
 
 	delete(daemonset.Annotations, ChaosBladeDaemonSetAnnotation)
 	delete(daemonset.Annotations, ChaosBladeExperimentAnnotation)
+	delete(daemonset.Annotations, ChaosBladeAffinityTypeAnnotation)
 	delete(daemonset.Annotations, ChaosBladeOriginalNodeAffinityAnnotation)
 	delete(daemonset.Annotations, ChaosBladeOriginalPodAffinityAnnotation)
 	delete(daemonset.Annotations, ChaosBladeOriginalPodAntiAffinityAnnotation)
@@ -613,6 +619,7 @@ func (d *PodSchedulingFailureActionExecutor) restoreStatefulSet(ctx context.Cont
 
 	delete(statefulset.Annotations, ChaosBladeStatefulSetAnnotation)
 	delete(statefulset.Annotations, ChaosBladeExperimentAnnotation)
+	delete(statefulset.Annotations, ChaosBladeAffinityTypeAnnotation)
 	delete(statefulset.Annotations, ChaosBladeOriginalNodeAffinityAnnotation)
 	delete(statefulset.Annotations, ChaosBladeOriginalPodAffinityAnnotation)
 	delete(statefulset.Annotations, ChaosBladeOriginalPodAntiAffinityAnnotation)
@@ -621,57 +628,77 @@ func (d *PodSchedulingFailureActionExecutor) restoreStatefulSet(ctx context.Cont
 	return d.client.Update(ctx, statefulset)
 }
 
-// restoreAffinity restores the original affinity configuration from annotations
+// restoreAffinity restores only the affinity field that was modified during injection.
+// It uses the ChaosBladeAffinityTypeAnnotation to determine which field to restore,
+// avoiding unintentional clearing of pre-existing affinity/selector settings.
 func (d *PodSchedulingFailureActionExecutor) restoreAffinity(podSpec *v1.PodSpec, annotations map[string]string) error {
-	// Restore node affinity
-	if originalNodeAffinityStr, ok := annotations[ChaosBladeOriginalNodeAffinityAnnotation]; ok {
-		var nodeAffinity v1.NodeAffinity
-		if err := json.Unmarshal([]byte(originalNodeAffinityStr), &nodeAffinity); err != nil {
-			return fmt.Errorf("unmarshal original node affinity failed: %v", err)
-		}
-		if podSpec.Affinity == nil {
-			podSpec.Affinity = &v1.Affinity{}
-		}
-		podSpec.Affinity.NodeAffinity = &nodeAffinity
-	} else {
-		// No backup means there was no original node affinity, clear injected one
-		if podSpec.Affinity != nil {
-			podSpec.Affinity.NodeAffinity = nil
-		}
+	affinityType := annotations[ChaosBladeAffinityTypeAnnotation]
+	if affinityType == "" {
+		return fmt.Errorf("affinity type annotation not found, cannot determine which field to restore")
 	}
 
-	// Restore pod affinity
-	if originalPodAffinityStr, ok := annotations[ChaosBladeOriginalPodAffinityAnnotation]; ok {
-		var podAffinity v1.PodAffinity
-		if err := json.Unmarshal([]byte(originalPodAffinityStr), &podAffinity); err != nil {
-			return fmt.Errorf("unmarshal original pod affinity failed: %v", err)
+	switch affinityType {
+	case "node-affinity":
+		if originalNodeAffinityStr, ok := annotations[ChaosBladeOriginalNodeAffinityAnnotation]; ok {
+			var nodeAffinity v1.NodeAffinity
+			if err := json.Unmarshal([]byte(originalNodeAffinityStr), &nodeAffinity); err != nil {
+				return fmt.Errorf("unmarshal original node affinity failed: %v", err)
+			}
+			if podSpec.Affinity == nil {
+				podSpec.Affinity = &v1.Affinity{}
+			}
+			podSpec.Affinity.NodeAffinity = &nodeAffinity
+		} else {
+			if podSpec.Affinity != nil {
+				podSpec.Affinity.NodeAffinity = nil
+			}
 		}
-		if podSpec.Affinity == nil {
-			podSpec.Affinity = &v1.Affinity{}
-		}
-		podSpec.Affinity.PodAffinity = &podAffinity
-	} else {
-		// No backup means there was no original pod affinity, clear injected one
-		if podSpec.Affinity != nil {
-			podSpec.Affinity.PodAffinity = nil
-		}
-	}
 
-	// Restore pod anti-affinity
-	if originalPodAntiAffinityStr, ok := annotations[ChaosBladeOriginalPodAntiAffinityAnnotation]; ok {
-		var podAntiAffinity v1.PodAntiAffinity
-		if err := json.Unmarshal([]byte(originalPodAntiAffinityStr), &podAntiAffinity); err != nil {
-			return fmt.Errorf("unmarshal original pod anti-affinity failed: %v", err)
+	case "pod-affinity":
+		if originalPodAffinityStr, ok := annotations[ChaosBladeOriginalPodAffinityAnnotation]; ok {
+			var podAffinity v1.PodAffinity
+			if err := json.Unmarshal([]byte(originalPodAffinityStr), &podAffinity); err != nil {
+				return fmt.Errorf("unmarshal original pod affinity failed: %v", err)
+			}
+			if podSpec.Affinity == nil {
+				podSpec.Affinity = &v1.Affinity{}
+			}
+			podSpec.Affinity.PodAffinity = &podAffinity
+		} else {
+			if podSpec.Affinity != nil {
+				podSpec.Affinity.PodAffinity = nil
+			}
 		}
-		if podSpec.Affinity == nil {
-			podSpec.Affinity = &v1.Affinity{}
+
+	case "pod-anti-affinity":
+		if originalPodAntiAffinityStr, ok := annotations[ChaosBladeOriginalPodAntiAffinityAnnotation]; ok {
+			var podAntiAffinity v1.PodAntiAffinity
+			if err := json.Unmarshal([]byte(originalPodAntiAffinityStr), &podAntiAffinity); err != nil {
+				return fmt.Errorf("unmarshal original pod anti-affinity failed: %v", err)
+			}
+			if podSpec.Affinity == nil {
+				podSpec.Affinity = &v1.Affinity{}
+			}
+			podSpec.Affinity.PodAntiAffinity = &podAntiAffinity
+		} else {
+			if podSpec.Affinity != nil {
+				podSpec.Affinity.PodAntiAffinity = nil
+			}
 		}
-		podSpec.Affinity.PodAntiAffinity = &podAntiAffinity
-	} else {
-		// No backup means there was no original pod anti-affinity, clear injected one
-		if podSpec.Affinity != nil {
-			podSpec.Affinity.PodAntiAffinity = nil
+
+	case "node-selector":
+		if originalNodeSelectorStr, ok := annotations[ChaosBladeOriginalNodeSelectorAnnotation]; ok {
+			var originalNodeSelector map[string]string
+			if err := json.Unmarshal([]byte(originalNodeSelectorStr), &originalNodeSelector); err != nil {
+				return fmt.Errorf("unmarshal original node selector failed: %v", err)
+			}
+			podSpec.NodeSelector = originalNodeSelector
+		} else {
+			podSpec.NodeSelector = nil
 		}
+
+	default:
+		return fmt.Errorf("unknown affinity type in annotation: %s", affinityType)
 	}
 
 	// Clean up empty Affinity struct
@@ -680,18 +707,6 @@ func (d *PodSchedulingFailureActionExecutor) restoreAffinity(podSpec *v1.PodSpec
 		podSpec.Affinity.PodAffinity == nil &&
 		podSpec.Affinity.PodAntiAffinity == nil {
 		podSpec.Affinity = nil
-	}
-
-	// Restore node selector
-	if originalNodeSelectorStr, ok := annotations[ChaosBladeOriginalNodeSelectorAnnotation]; ok {
-		var originalNodeSelector map[string]string
-		if err := json.Unmarshal([]byte(originalNodeSelectorStr), &originalNodeSelector); err != nil {
-			return fmt.Errorf("unmarshal original node selector failed: %v", err)
-		}
-		podSpec.NodeSelector = originalNodeSelector
-	} else {
-		// No backup means there was no original node selector, clear injected one
-		podSpec.NodeSelector = nil
 	}
 
 	return nil

--- a/exec/pod/schedulingfailure.go
+++ b/exec/pod/schedulingfailure.go
@@ -45,8 +45,12 @@ const (
 	ChaosBladeStatefulSetAnnotation = "chaosblade.io/statefulset"
 	// ChaosBladeModifyAction indicates modify action
 	ChaosBladeModifyAction = "modify"
-	// ChaosBladeOriginalAffinityAnnotation stores the original affinity configuration
-	ChaosBladeOriginalAffinityAnnotation = "chaosblade.io/original-affinity"
+	// ChaosBladeOriginalNodeAffinityAnnotation stores the original node affinity configuration
+	ChaosBladeOriginalNodeAffinityAnnotation = "chaosblade.io/original-node-affinity"
+	// ChaosBladeOriginalPodAffinityAnnotation stores the original pod affinity configuration
+	ChaosBladeOriginalPodAffinityAnnotation = "chaosblade.io/original-pod-affinity"
+	// ChaosBladeOriginalPodAntiAffinityAnnotation stores the original pod anti-affinity configuration
+	ChaosBladeOriginalPodAntiAffinityAnnotation = "chaosblade.io/original-pod-anti-affinity"
 	// ChaosBladeOriginalNodeSelectorAnnotation stores the original node selector configuration
 	ChaosBladeOriginalNodeSelectorAnnotation = "chaosblade.io/original-nodeselector"
 	// ChaosBladeSchedulingFailureAction indicates scheduling failure action
@@ -235,6 +239,24 @@ func (d *PodSchedulingFailureActionExecutor) create(uid string, ctx context.Cont
 	return spec.ReturnResultIgnoreCode(v1alpha1.CreateSuccessExperimentStatus([]v1alpha1.ResourceStatus{status}))
 }
 
+// handleGetError handles errors from client.Get operations in destroy.
+// Returns true if the error was handled (NotFound or other error), false otherwise.
+// When returning true, the response pointer is set with the appropriate status.
+func handleGetError(err error, namespace, workloadType, workloadName string, status *v1alpha1.ResourceStatus, logrusField *logrus.Entry) (*spec.Response, bool) {
+	if err == nil {
+		return nil, false
+	}
+	if apierrors.IsNotFound(err) {
+		logrusField.Infof("%s %s/%s already deleted", workloadType, namespace, workloadName)
+		*status = status.CreateSuccessResourceStatus()
+		status.State = v1alpha1.DestroyedState
+		return spec.ReturnResultIgnoreCode(v1alpha1.CreateDestroyedExperimentStatus([]v1alpha1.ResourceStatus{*status})), true
+	}
+	logrusField.Warningf("get %s %s/%s failed: %v", workloadType, namespace, workloadName, err)
+	*status = status.CreateFailResourceStatus(fmt.Sprintf("get %s failed: %v", workloadType, err), spec.K8sExecFailed.Code)
+	return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{*status})), true
+}
+
 func (d *PodSchedulingFailureActionExecutor) destroy(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
 	experimentId := model.GetExperimentIdFromContext(ctx)
 	logrusField := logrus.WithField("experiment", experimentId)
@@ -257,16 +279,8 @@ func (d *PodSchedulingFailureActionExecutor) destroy(uid string, ctx context.Con
 	case "deployment":
 		deployment := &appsv1.Deployment{}
 		err := d.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: workloadName}, deployment)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				logrusField.Infof("deployment %s/%s already deleted", namespace, workloadName)
-				status = status.CreateSuccessResourceStatus()
-				status.State = v1alpha1.DestroyedState
-				return spec.ReturnResultIgnoreCode(v1alpha1.CreateDestroyedExperimentStatus([]v1alpha1.ResourceStatus{status}))
-			}
-			logrusField.Warningf("get deployment %s/%s failed: %v", namespace, workloadName, err)
-			status = status.CreateFailResourceStatus(fmt.Sprintf("get deployment failed: %v", err), spec.K8sExecFailed.Code)
-			return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+		if resp, handled := handleGetError(err, namespace, workloadType, workloadName, &status, logrusField); handled {
+			return resp
 		}
 
 		if err := d.restoreDeployment(ctx, deployment, experimentId); err != nil {
@@ -279,16 +293,8 @@ func (d *PodSchedulingFailureActionExecutor) destroy(uid string, ctx context.Con
 	case "daemonset":
 		daemonset := &appsv1.DaemonSet{}
 		err := d.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: workloadName}, daemonset)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				logrusField.Infof("daemonset %s/%s already deleted", namespace, workloadName)
-				status = status.CreateSuccessResourceStatus()
-				status.State = v1alpha1.DestroyedState
-				return spec.ReturnResultIgnoreCode(v1alpha1.CreateDestroyedExperimentStatus([]v1alpha1.ResourceStatus{status}))
-			}
-			logrusField.Warningf("get daemonset %s/%s failed: %v", namespace, workloadName, err)
-			status = status.CreateFailResourceStatus(fmt.Sprintf("get daemonset failed: %v", err), spec.K8sExecFailed.Code)
-			return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+		if resp, handled := handleGetError(err, namespace, workloadType, workloadName, &status, logrusField); handled {
+			return resp
 		}
 
 		if err := d.restoreDaemonSet(ctx, daemonset, experimentId); err != nil {
@@ -301,16 +307,8 @@ func (d *PodSchedulingFailureActionExecutor) destroy(uid string, ctx context.Con
 	case "statefulset":
 		statefulset := &appsv1.StatefulSet{}
 		err := d.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: workloadName}, statefulset)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				logrusField.Infof("statefulset %s/%s already deleted", namespace, workloadName)
-				status = status.CreateSuccessResourceStatus()
-				status.State = v1alpha1.DestroyedState
-				return spec.ReturnResultIgnoreCode(v1alpha1.CreateDestroyedExperimentStatus([]v1alpha1.ResourceStatus{status}))
-			}
-			logrusField.Warningf("get statefulset %s/%s failed: %v", namespace, workloadName, err)
-			status = status.CreateFailResourceStatus(fmt.Sprintf("get statefulset failed: %v", err), spec.K8sExecFailed.Code)
-			return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+		if resp, handled := handleGetError(err, namespace, workloadType, workloadName, &status, logrusField); handled {
+			return resp
 		}
 
 		if err := d.restoreStatefulSet(ctx, statefulset, experimentId); err != nil {
@@ -387,7 +385,7 @@ func (d *PodSchedulingFailureActionExecutor) backupAndInjectAffinity(podSpec *v1
 			if err != nil {
 				return fmt.Errorf("marshal original node affinity failed: %v", err)
 			}
-			annotations[ChaosBladeOriginalAffinityAnnotation] = string(originalBytes)
+			annotations[ChaosBladeOriginalNodeAffinityAnnotation] = string(originalBytes)
 		}
 
 		// Inject unreachable node affinity
@@ -434,7 +432,7 @@ func (d *PodSchedulingFailureActionExecutor) backupAndInjectAffinity(podSpec *v1
 			if err != nil {
 				return fmt.Errorf("marshal original pod affinity failed: %v", err)
 			}
-			annotations[ChaosBladeOriginalAffinityAnnotation] = string(originalBytes)
+			annotations[ChaosBladeOriginalPodAffinityAnnotation] = string(originalBytes)
 		}
 
 		// Inject unreachable pod affinity
@@ -467,7 +465,7 @@ func (d *PodSchedulingFailureActionExecutor) backupAndInjectAffinity(podSpec *v1
 			if err != nil {
 				return fmt.Errorf("marshal original pod anti-affinity failed: %v", err)
 			}
-			annotations[ChaosBladeOriginalAffinityAnnotation] = string(originalBytes)
+			annotations[ChaosBladeOriginalPodAntiAffinityAnnotation] = string(originalBytes)
 		}
 
 		// Inject unreachable pod anti-affinity (this will block scheduling on any node)
@@ -542,7 +540,9 @@ func (d *PodSchedulingFailureActionExecutor) restoreDeployment(ctx context.Conte
 	// Clean up annotations
 	delete(deployment.Annotations, ChaosBladeDeploymentAnnotation)
 	delete(deployment.Annotations, ChaosBladeExperimentAnnotation)
-	delete(deployment.Annotations, ChaosBladeOriginalAffinityAnnotation)
+	delete(deployment.Annotations, ChaosBladeOriginalNodeAffinityAnnotation)
+	delete(deployment.Annotations, ChaosBladeOriginalPodAffinityAnnotation)
+	delete(deployment.Annotations, ChaosBladeOriginalPodAntiAffinityAnnotation)
 	delete(deployment.Annotations, ChaosBladeOriginalNodeSelectorAnnotation)
 
 	return d.client.Update(ctx, deployment)
@@ -560,7 +560,9 @@ func (d *PodSchedulingFailureActionExecutor) restoreDaemonSet(ctx context.Contex
 
 	delete(daemonset.Annotations, ChaosBladeDaemonSetAnnotation)
 	delete(daemonset.Annotations, ChaosBladeExperimentAnnotation)
-	delete(daemonset.Annotations, ChaosBladeOriginalAffinityAnnotation)
+	delete(daemonset.Annotations, ChaosBladeOriginalNodeAffinityAnnotation)
+	delete(daemonset.Annotations, ChaosBladeOriginalPodAffinityAnnotation)
+	delete(daemonset.Annotations, ChaosBladeOriginalPodAntiAffinityAnnotation)
 	delete(daemonset.Annotations, ChaosBladeOriginalNodeSelectorAnnotation)
 
 	return d.client.Update(ctx, daemonset)
@@ -578,7 +580,9 @@ func (d *PodSchedulingFailureActionExecutor) restoreStatefulSet(ctx context.Cont
 
 	delete(statefulset.Annotations, ChaosBladeStatefulSetAnnotation)
 	delete(statefulset.Annotations, ChaosBladeExperimentAnnotation)
-	delete(statefulset.Annotations, ChaosBladeOriginalAffinityAnnotation)
+	delete(statefulset.Annotations, ChaosBladeOriginalNodeAffinityAnnotation)
+	delete(statefulset.Annotations, ChaosBladeOriginalPodAffinityAnnotation)
+	delete(statefulset.Annotations, ChaosBladeOriginalPodAntiAffinityAnnotation)
 	delete(statefulset.Annotations, ChaosBladeOriginalNodeSelectorAnnotation)
 
 	return d.client.Update(ctx, statefulset)
@@ -587,51 +591,62 @@ func (d *PodSchedulingFailureActionExecutor) restoreStatefulSet(ctx context.Cont
 // restoreAffinity restores the original affinity configuration from annotations
 func (d *PodSchedulingFailureActionExecutor) restoreAffinity(podSpec *v1.PodSpec, annotations map[string]string) error {
 	// Restore node affinity
-	if originalAffinityStr, ok := annotations[ChaosBladeOriginalAffinityAnnotation]; ok {
-		var originalAffinity interface{}
-		if err := json.Unmarshal([]byte(originalAffinityStr), &originalAffinity); err != nil {
-			return fmt.Errorf("unmarshal original affinity failed: %v", err)
+	if originalNodeAffinityStr, ok := annotations[ChaosBladeOriginalNodeAffinityAnnotation]; ok {
+		var nodeAffinity v1.NodeAffinity
+		if err := json.Unmarshal([]byte(originalNodeAffinityStr), &nodeAffinity); err != nil {
+			return fmt.Errorf("unmarshal original node affinity failed: %v", err)
 		}
-
-		// Try to determine the type and restore
-		switch v := originalAffinity.(type) {
-		case map[string]interface{}:
-			// Could be NodeAffinity or PodAffinity or PodAntiAffinity
-			// Check which one was backed up by looking at the structure
-			if _, hasNodeSelectorTerms := v["nodeSelectorTerms"]; hasNodeSelectorTerms {
-				var nodeAffinity v1.NodeAffinity
-				if err := json.Unmarshal([]byte(originalAffinityStr), &nodeAffinity); err != nil {
-					return fmt.Errorf("unmarshal node affinity failed: %v", err)
-				}
-				if podSpec.Affinity == nil {
-					podSpec.Affinity = &v1.Affinity{}
-				}
-				podSpec.Affinity.NodeAffinity = &nodeAffinity
-			} else if _, hasRequiredDuringScheduling := v["requiredDuringSchedulingIgnoredDuringExecution"]; hasRequiredDuringScheduling {
-				// Could be PodAffinity or PodAntiAffinity - restore to both for simplicity
-				var podAffinity v1.PodAffinity
-				if err := json.Unmarshal([]byte(originalAffinityStr), &podAffinity); err != nil {
-					return fmt.Errorf("unmarshal pod affinity failed: %v", err)
-				}
-				if podSpec.Affinity == nil {
-					podSpec.Affinity = &v1.Affinity{}
-				}
-				podSpec.Affinity.PodAffinity = &podAffinity
-			}
+		if podSpec.Affinity == nil {
+			podSpec.Affinity = &v1.Affinity{}
 		}
+		podSpec.Affinity.NodeAffinity = &nodeAffinity
 	} else {
-		// No backup means there was no original affinity, clear injected one
+		// No backup means there was no original node affinity, clear injected one
 		if podSpec.Affinity != nil {
 			podSpec.Affinity.NodeAffinity = nil
-			podSpec.Affinity.PodAffinity = nil
-			podSpec.Affinity.PodAntiAffinity = nil
-			// If all affinity fields are nil, set Affinity to nil
-			if podSpec.Affinity.NodeAffinity == nil &&
-				podSpec.Affinity.PodAffinity == nil &&
-				podSpec.Affinity.PodAntiAffinity == nil {
-				podSpec.Affinity = nil
-			}
 		}
+	}
+
+	// Restore pod affinity
+	if originalPodAffinityStr, ok := annotations[ChaosBladeOriginalPodAffinityAnnotation]; ok {
+		var podAffinity v1.PodAffinity
+		if err := json.Unmarshal([]byte(originalPodAffinityStr), &podAffinity); err != nil {
+			return fmt.Errorf("unmarshal original pod affinity failed: %v", err)
+		}
+		if podSpec.Affinity == nil {
+			podSpec.Affinity = &v1.Affinity{}
+		}
+		podSpec.Affinity.PodAffinity = &podAffinity
+	} else {
+		// No backup means there was no original pod affinity, clear injected one
+		if podSpec.Affinity != nil {
+			podSpec.Affinity.PodAffinity = nil
+		}
+	}
+
+	// Restore pod anti-affinity
+	if originalPodAntiAffinityStr, ok := annotations[ChaosBladeOriginalPodAntiAffinityAnnotation]; ok {
+		var podAntiAffinity v1.PodAntiAffinity
+		if err := json.Unmarshal([]byte(originalPodAntiAffinityStr), &podAntiAffinity); err != nil {
+			return fmt.Errorf("unmarshal original pod anti-affinity failed: %v", err)
+		}
+		if podSpec.Affinity == nil {
+			podSpec.Affinity = &v1.Affinity{}
+		}
+		podSpec.Affinity.PodAntiAffinity = &podAntiAffinity
+	} else {
+		// No backup means there was no original pod anti-affinity, clear injected one
+		if podSpec.Affinity != nil {
+			podSpec.Affinity.PodAntiAffinity = nil
+		}
+	}
+
+	// Clean up empty Affinity struct
+	if podSpec.Affinity != nil &&
+		podSpec.Affinity.NodeAffinity == nil &&
+		podSpec.Affinity.PodAffinity == nil &&
+		podSpec.Affinity.PodAntiAffinity == nil {
+		podSpec.Affinity = nil
 	}
 
 	// Restore node selector

--- a/exec/pod/schedulingfailure.go
+++ b/exec/pod/schedulingfailure.go
@@ -349,6 +349,11 @@ func (d *PodSchedulingFailureActionExecutor) injectDeploymentSchedulingFailure(c
 	if err := ensureNoConflictingExperiment(deployment.Annotations, experimentId); err != nil {
 		return err
 	}
+	// Idempotent: if already modified by the same experiment, skip re-injection
+	// to avoid overwriting the saved original affinity backup.
+	if deployment.Annotations[ChaosBladeExperimentAnnotation] == experimentId {
+		return nil
+	}
 	deployment.Annotations[ChaosBladeDeploymentAnnotation] = ChaosBladeModifyAction
 	deployment.Annotations[ChaosBladeExperimentAnnotation] = experimentId
 
@@ -368,6 +373,9 @@ func (d *PodSchedulingFailureActionExecutor) injectDaemonSetSchedulingFailure(ct
 	if err := ensureNoConflictingExperiment(daemonset.Annotations, experimentId); err != nil {
 		return err
 	}
+	if daemonset.Annotations[ChaosBladeExperimentAnnotation] == experimentId {
+		return nil
+	}
 	daemonset.Annotations[ChaosBladeDaemonSetAnnotation] = ChaosBladeModifyAction
 	daemonset.Annotations[ChaosBladeExperimentAnnotation] = experimentId
 
@@ -385,6 +393,9 @@ func (d *PodSchedulingFailureActionExecutor) injectStatefulSetSchedulingFailure(
 	}
 	if err := ensureNoConflictingExperiment(statefulset.Annotations, experimentId); err != nil {
 		return err
+	}
+	if statefulset.Annotations[ChaosBladeExperimentAnnotation] == experimentId {
+		return nil
 	}
 	statefulset.Annotations[ChaosBladeStatefulSetAnnotation] = ChaosBladeModifyAction
 	statefulset.Annotations[ChaosBladeExperimentAnnotation] = experimentId

--- a/exec/pod/terminating.go
+++ b/exec/pod/terminating.go
@@ -46,13 +46,7 @@ func NewPodTerminatingActionSpec(client *channel.Client) spec.ExpActionCommandSp
 	return &PodTerminatingActionSpec{
 		spec.BaseExpActionCommandSpec{
 			ActionMatchers: []spec.ExpFlagSpec{},
-			ActionFlags: []spec.ExpFlagSpec{
-				&spec.ExpFlag{
-					Name:   "random",
-					Desc:   "Randomly select pod",
-					NoArgs: true,
-				},
-			},
+			ActionFlags:    []spec.ExpFlagSpec{},
 			ActionExecutor: &PodTerminatingActionExecutor{client: client},
 			ActionExample: `# Make the pod stuck in Terminating state in the default namespace
 blade create k8s pod-pod terminating --names nginx-app --namespace default --kubeconfig ~/.kube/config
@@ -132,10 +126,9 @@ func (d *PodTerminatingActionExecutor) create(uid string, ctx context.Context, e
 
 		// Skip if pod is already being deleted
 		if pod.DeletionTimestamp != nil {
-			logrusField.Infof("pod %s/%s is already terminating, skip", meta.Namespace, meta.PodName)
-			status = status.CreateSuccessResourceStatus()
+			logrusField.Warningf("pod %s/%s is already terminating, cannot inject fault", meta.Namespace, meta.PodName)
+			status = status.CreateFailResourceStatus("pod is already in Terminating state, no fault injected", spec.K8sExecFailed.Code)
 			statuses = append(statuses, status)
-			success = true
 			continue
 		}
 

--- a/pkg/controller/chaosblade/controller.go
+++ b/pkg/controller/chaosblade/controller.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -255,15 +256,16 @@ func (r *ReconcileChaosBlade) Reconcile(ctx context.Context, request reconcile.R
 			}
 			expStatusList = append(expStatusList, experimentStatus)
 		}
-		// Re-fetch the CR to avoid conflict
-		latestCb := &v1alpha1.ChaosBlade{}
-		if err := r.client.Get(ctx, request.NamespacedName, latestCb); err != nil {
-			reqLogger.WithError(err).Errorln("re-fetch chaosblade failed before status update")
-			return reconcile.Result{}, err
-		}
-		latestCb.Status.ExpStatuses = expStatusList
-		latestCb.Status.Phase = phase
-		if err := r.client.Status().Update(ctx, latestCb); err != nil {
+		// Retry status update on conflict to avoid re-executing Create side effects
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			latestCb := &v1alpha1.ChaosBlade{}
+			if err := r.client.Get(ctx, request.NamespacedName, latestCb); err != nil {
+				return err
+			}
+			latestCb.Status.ExpStatuses = expStatusList
+			latestCb.Status.Phase = phase
+			return r.client.Status().Update(ctx, latestCb)
+		}); err != nil {
 			reqLogger.WithError(err).Errorf("update phase from %s to %s failed", originalPhase, phase)
 			return reconcile.Result{}, err
 		}
@@ -298,8 +300,19 @@ func (r *ReconcileChaosBlade) Reconcile(ctx context.Context, request reconcile.R
 					cb.Status.ExpStatuses[idx] = experimentStatus
 				}
 			}
+			// Retry status update on conflict to avoid re-executing Destroy side effects
+			updatedExpStatuses := make([]v1alpha1.ExperimentStatus, len(cb.Status.ExpStatuses))
+			copy(updatedExpStatuses, cb.Status.ExpStatuses)
 			cb.Status.Phase = phase
-			if err := r.client.Status().Update(ctx, cb); err != nil {
+			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				latestCb := &v1alpha1.ChaosBlade{}
+				if err := r.client.Get(ctx, request.NamespacedName, latestCb); err != nil {
+					return err
+				}
+				latestCb.Status.ExpStatuses = updatedExpStatuses
+				latestCb.Status.Phase = phase
+				return r.client.Status().Update(ctx, latestCb)
+			}); err != nil {
 				reqLogger.WithError(err).Errorf("update phase from %s to %s failed", originalPhase, phase)
 			}
 			return forget, nil
@@ -324,19 +337,20 @@ func (r *ReconcileChaosBlade) finalizeChaosBlade(ctx context.Context, reqLogger 
 			cb.Status.ExpStatuses[idx] = oldExpStatus
 		}
 	}
-	// Re-fetch the CR to avoid conflict
-	latestCb := &v1alpha1.ChaosBlade{}
-	if err := r.client.Get(ctx, namespacedName, latestCb); err != nil {
-		return fmt.Errorf("re-fetch chaosblade failed in finalize phase, %v", err)
-	}
-	latestCb.Status.ExpStatuses = cb.Status.ExpStatuses
-	latestCb.Status.Phase = phase
-	err := r.client.Status().Update(ctx, latestCb)
-	if err != nil {
+	// Retry status update on conflict to avoid re-executing Destroy side effects
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latestCb := &v1alpha1.ChaosBlade{}
+		if err := r.client.Get(ctx, namespacedName, latestCb); err != nil {
+			return err
+		}
+		latestCb.Status.ExpStatuses = cb.Status.ExpStatuses
+		latestCb.Status.Phase = phase
+		return r.client.Status().Update(ctx, latestCb)
+	}); err != nil {
 		return fmt.Errorf("update chaosblade status failed in finalize phase, %v", err)
 	}
 	if phase == v1alpha1.ClusterPhaseDestroying {
-		return fmt.Errorf("failed to destory, please see the experiment status")
+		return fmt.Errorf("failed to destroy, please see the experiment status")
 	}
 	reqLogger.Info("Successfully finalized chaosblade")
 	return nil

--- a/pkg/controller/chaosblade/controller.go
+++ b/pkg/controller/chaosblade/controller.go
@@ -200,17 +200,25 @@ func (r *ReconcileChaosBlade) Reconcile(ctx context.Context, request reconcile.R
 	// Destroyed->delete
 	// Remove the Finalizer if the CR object status is destroyed to delete it
 	if cb.Status.Phase == v1alpha1.ClusterPhaseDestroyed {
-		cb.SetFinalizers(remove(cb.GetFinalizers(), chaosbladeFinalizer))
-		err := r.client.Update(ctx, cb)
+		// Re-fetch the CR to avoid conflict
+		latestCb := &v1alpha1.ChaosBlade{}
+		if err := r.client.Get(ctx, request.NamespacedName, latestCb); err != nil {
+			reqLogger.WithError(err).Errorln("re-fetch chaosblade failed before removing finalizer")
+			return reconcile.Result{}, err
+		}
+		latestCb.SetFinalizers(remove(latestCb.GetFinalizers(), chaosbladeFinalizer))
+		err := r.client.Update(ctx, latestCb)
 		if err != nil {
 			reqLogger.WithError(err).Errorln("remove chaosblade finalizer failed at destroyed phase")
+			return reconcile.Result{}, err
 		}
 		return forget, nil
 	}
 	if cb.Status.Phase == v1alpha1.ClusterPhaseDestroying || cb.GetDeletionTimestamp() != nil {
-		err := r.finalizeChaosBlade(ctx, reqLogger, cb)
+		err := r.finalizeChaosBlade(ctx, reqLogger, cb, request.NamespacedName)
 		if err != nil {
 			reqLogger.WithError(err).Errorln("finalize chaosblade failed at destroying phase")
+			return reconcile.Result{}, err
 		}
 		return forget, nil
 	}
@@ -221,12 +229,14 @@ func (r *ReconcileChaosBlade) Reconcile(ctx context.Context, request reconcile.R
 			cb.Status.ExpStatuses = make([]v1alpha1.ExperimentStatus, 0)
 			if err := r.client.Status().Update(ctx, cb); err != nil {
 				reqLogger.WithError(err).Errorln("update chaosblade phase to Initialized failed")
+				return reconcile.Result{}, err
 			}
 		} else {
 			cb.SetFinalizers(append(cb.GetFinalizers(), chaosbladeFinalizer))
 			// Update CR
 			if err := r.client.Update(ctx, cb); err != nil {
 				reqLogger.WithError(err).Errorln("add finalizer to chaosblade failed")
+				return reconcile.Result{}, err
 			}
 		}
 		return forget, nil
@@ -245,10 +255,17 @@ func (r *ReconcileChaosBlade) Reconcile(ctx context.Context, request reconcile.R
 			}
 			expStatusList = append(expStatusList, experimentStatus)
 		}
-		cb.Status.ExpStatuses = expStatusList
-		cb.Status.Phase = phase
-		if err := r.client.Status().Update(ctx, cb); err != nil {
-			reqLogger.WithError(err).Errorf("Important!!!!!update phase from %s to %s failed", originalPhase, phase)
+		// Re-fetch the CR to avoid conflict
+		latestCb := &v1alpha1.ChaosBlade{}
+		if err := r.client.Get(ctx, request.NamespacedName, latestCb); err != nil {
+			reqLogger.WithError(err).Errorln("re-fetch chaosblade failed before status update")
+			return reconcile.Result{}, err
+		}
+		latestCb.Status.ExpStatuses = expStatusList
+		latestCb.Status.Phase = phase
+		if err := r.client.Status().Update(ctx, latestCb); err != nil {
+			reqLogger.WithError(err).Errorf("update phase from %s to %s failed", originalPhase, phase)
+			return reconcile.Result{}, err
 		}
 		return forget, nil
 	}
@@ -293,7 +310,7 @@ func (r *ReconcileChaosBlade) Reconcile(ctx context.Context, request reconcile.R
 }
 
 // finalizeChaosBlade
-func (r *ReconcileChaosBlade) finalizeChaosBlade(ctx context.Context, reqLogger *logrus.Entry, cb *v1alpha1.ChaosBlade) error {
+func (r *ReconcileChaosBlade) finalizeChaosBlade(ctx context.Context, reqLogger *logrus.Entry, cb *v1alpha1.ChaosBlade, namespacedName types.NamespacedName) error {
 	phase := v1alpha1.ClusterPhaseDestroyed
 	reqLogger.Infoln("Finalize the chaosblade")
 	if cb.Status.ExpStatuses != nil &&
@@ -307,12 +324,18 @@ func (r *ReconcileChaosBlade) finalizeChaosBlade(ctx context.Context, reqLogger 
 			cb.Status.ExpStatuses[idx] = oldExpStatus
 		}
 	}
-	cb.Status.Phase = phase
-	err := r.client.Status().Update(ctx, cb)
+	// Re-fetch the CR to avoid conflict
+	latestCb := &v1alpha1.ChaosBlade{}
+	if err := r.client.Get(ctx, namespacedName, latestCb); err != nil {
+		return fmt.Errorf("re-fetch chaosblade failed in finalize phase, %v", err)
+	}
+	latestCb.Status.ExpStatuses = cb.Status.ExpStatuses
+	latestCb.Status.Phase = phase
+	err := r.client.Status().Update(ctx, latestCb)
 	if err != nil {
 		return fmt.Errorf("update chaosblade status failed in finalize phase, %v", err)
 	}
-	if cb.Status.Phase == v1alpha1.ClusterPhaseDestroying {
+	if phase == v1alpha1.ClusterPhaseDestroying {
 		return fmt.Errorf("failed to destory, please see the experiment status")
 	}
 	reqLogger.Info("Successfully finalized chaosblade")


### PR DESCRIPTION
- 新增 pod 调度失败实验支持，通过修改部署的亲和性配置注入调度失败
- 允许通过 workload-type、workload-name 和 namespace 参数指定目标工作负载
- Create 方法中新增对 schedulingfailure 动作的处理逻辑，无需查找已有 Pod
- 新增 pod 调度失败示例 YAML 文件，演示如何注入无法调度的亲和规则
- 更新 Pod 资源模型示例和文档，统一实验创建示例格式，增强示例可读性与完整性
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
新增 Pod 调度失败（亲和性配置问题） 故障注入功能。该功能支持通过修改 Deployment/DaemonSet/StatefulSet 的亲和性配置，模拟 Pod 因亲和性规则无法满足而处于 Pending 状态的故障场景。

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
1. 新增 exec/pod/schedulingfailure.go：定义 PodSchedulingFailureActionSpec 和 PodSchedulingFailureActionExecutor
- 支持四种亲和性类型：node-affinity、node-selector、pod-affinity、pod-anti-affinity
- 支持三种工作负载类型：deployment、daemonset、statefulset
- Create 阶段：备份原始亲和性配置到 annotation，注入无法满足的亲和性规则
- Destroy 阶段：从 annotation 恢复原始亲和性配置
2. 修改 exec/pod/pod.go：注册 schedulingfailure Action 并添加示例
3. 修改 exec/pod/controller.go：添加 schedulingfailure action 的特殊处理逻辑（无需匹配现有 Pod）
4. 新增 examples/pod-scheduling-failure.yaml：提供 CR 示例文件

### Describe how to verify it
```bash
# 1. 编译项目
go build ./...

# 2. 构建并部署 operator 镜像
make build_linux_amd64_image
# 部署到集群...

# 3. 创建测试 deployment
kubectl create deployment nginx-deployment --image=nginx -n default

# 4. 创建 ChaosBlade CR 注入故障
kubectl apply -f examples/pod-scheduling-failure.yaml

# 5. 验证 Pod 处于 Pending 状态
kubectl get pods -n default
kubectl describe pod <pod-name> -n default | grep -A 5 Events

# 6. 删除 CR 恢复环境
kubectl delete chaosblade pod-scheduling-failure -n default

# 7. 验证 Pod 恢复正常运行
kubectl get pods -n default
```

### Special notes for reviews
1. RBAC 权限：确保 Operator 拥有对 deployments、daemonsets、statefulsets 资源的 get、update 权限
2. 命名约定：annotation key 遵循 chaosblade.io/ 前缀规范
3. 与现有 action 一致：代码风格与 containercreating、terminating action 保持一致