### PR TITLE
feat(pod): 新增 badresourcesize 实验场景，支持修改工作负载资源限制

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The current experimental scenarios involve resources including Node, Pod, and Co
     * Network: specify network card, port, IP, etc. packet delay, packet loss, packet blocking, packet duplication, packet re-ordering, packet corruption, etc.
     * Disk: specify the directory disk occupation, disk IO read and write load, etc.
     * Memory: specify memory usage
-    * Pod: kill pod, make pod stuck in ContainerCreating state by PVC mount failure, make pod stuck in Terminating state by finalizer, make pod scheduling fail by injecting unreachable affinity rules
+    * Pod: kill pod, make pod stuck in ContainerCreating state by PVC mount failure, make pod stuck in Terminating state by finalizer, make pod scheduling fail by injecting unreachable affinity rules, modify workload (Deployment/DaemonSet/StatefulSet) CPU/Memory resource limits to simulate bad resource sizing
     * IO: specify the file system io exception. Supports 31 file operations and 11 exception scenarios, such as "Too many open files", "Device or resource busy" and so on.
 * Container:
     * CPU: specify CPU usage

--- a/README_CN.md
+++ b/README_CN.md
@@ -16,7 +16,7 @@ Chaosblade Operator 是混沌工程实验工具 ChaosBlade 下的一款面向云
     * 网络：指定网卡、端口、IP 等包延迟、丢包、包阻塞、包重复、包乱序、包损坏等
     * 磁盘：指定目录磁盘填充、磁盘 IO 读写负载等
     * 内存：指定内存使用率
-    * Pod：杀 Pod、通过 PVC 挂载失败使 Pod 卡在 ContainerCreating 状态、通过 finalizer 使 Pod 卡在 Terminating 状态、通过注入无法满足的亲和性规则使 Pod 调度失败
+    * Pod：杀 Pod、通过 PVC 挂载失败使 Pod 卡在 ContainerCreating 状态、通过 finalizer 使 Pod 卡在 Terminating 状态、通过注入无法满足的亲和性规则使 Pod 调度失败、修改工作负载（Deployment/DaemonSet/StatefulSet）的 CPU/Memory 资源限制模拟资源配置异常
 * Container：
     * CPU: 指定 CPU 使用率
     * 网络: 指定网卡、端口、IP 等包延迟、丢包、包阻塞、包重复、包乱序、包损坏等

--- a/examples/pod-bad-resource-size-cpu-mem.yaml
+++ b/examples/pod-bad-resource-size-cpu-mem.yaml
@@ -1,0 +1,44 @@
+# Copyright 2025 The ChaosBlade Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Modify deployment CPU and memory resource limits to simulate bad resource sizing
+# Equivalent to:
+#   blade create k8s pod-pod badresourcesize --namespace default \
+#     --workload-type deployment --workload-name nginx-app --cpu 1m --mem 128m --kubeconfig ~/.kube/config
+apiVersion: chaosblade.io/v1alpha1
+kind: ChaosBlade
+metadata:
+  name: pod-bad-resource-size-cpu-mem
+spec:
+  experiments:
+  - scope: pod
+    target: pod
+    action: badresourcesize
+    desc: "modify deployment CPU and memory resource limits"
+    matchers:
+    - name: namespace
+      value:
+      - "default"
+    - name: workload-type
+      value:
+      - "deployment"
+    - name: workload-name
+      value:
+      - "nginx-app"
+    - name: cpu
+      value:
+      - "1m"
+    - name: mem
+      value:
+      - "128m"

--- a/examples/pod-bad-resource-size-cpu.yaml
+++ b/examples/pod-bad-resource-size-cpu.yaml
@@ -1,0 +1,41 @@
+# Copyright 2025 The ChaosBlade Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Modify deployment CPU resource limits to simulate bad resource sizing
+# Equivalent to:
+#   blade create k8s pod-pod badresourcesize --namespace default \
+#     --workload-type deployment --workload-name nginx-app --cpu 1m --kubeconfig ~/.kube/config
+apiVersion: chaosblade.io/v1alpha1
+kind: ChaosBlade
+metadata:
+  name: pod-bad-resource-size-cpu
+spec:
+  experiments:
+  - scope: pod
+    target: pod
+    action: badresourcesize
+    desc: "modify deployment CPU resource limits"
+    matchers:
+    - name: namespace
+      value:
+      - "default"
+    - name: workload-type
+      value:
+      - "deployment"
+    - name: workload-name
+      value:
+      - "nginx-app"
+    - name: cpu
+      value:
+      - "1m"

--- a/examples/pod-bad-resource-size-mem.yaml
+++ b/examples/pod-bad-resource-size-mem.yaml
@@ -1,0 +1,41 @@
+# Copyright 2025 The ChaosBlade Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Modify deployment memory resource limits to simulate bad resource sizing
+# Equivalent to:
+#   blade create k8s pod-pod badresourcesize --namespace default \
+#     --workload-type deployment --workload-name nginx-app --mem 128m --kubeconfig ~/.kube/config
+apiVersion: chaosblade.io/v1alpha1
+kind: ChaosBlade
+metadata:
+  name: pod-bad-resource-size-mem
+spec:
+  experiments:
+  - scope: pod
+    target: pod
+    action: badresourcesize
+    desc: "modify deployment memory resource limits"
+    matchers:
+    - name: namespace
+      value:
+      - "default"
+    - name: workload-type
+      value:
+      - "deployment"
+    - name: workload-name
+      value:
+      - "nginx-app"
+    - name: mem
+      value:
+      - "128m"

--- a/exec/pod/badresourcesize.go
+++ b/exec/pod/badresourcesize.go
@@ -383,6 +383,8 @@ func (d *BadResourceSizeActionExecutor) destroy(uid string, ctx context.Context,
 type containerResourcesBackup struct {
 	// ResourcesByName maps container name to its original ResourceRequirements.
 	ResourcesByName map[string]v1.ResourceRequirements `json:"resourcesByName"`
+	// InitResourcesByName maps init container name to its original ResourceRequirements.
+	InitResourcesByName map[string]v1.ResourceRequirements `json:"initResourcesByName,omitempty"`
 }
 
 // buildResourceLimits parses the cpu/mem flag values into a v1.ResourceList for Limits.
@@ -436,14 +438,19 @@ func normalizeMemoryValue(val string) string {
 }
 
 // backupAndInjectResources backs up original container resources (keyed by container name)
-// and sets new pod-level limits. It removes all existing container-level resource
-// requests/limits and sets pod-level limits on each container's resources.
+// for both regular and init containers, then sets new resource limits on each container.
 func backupAndInjectResources(podSpec *v1.PodSpec, annotations map[string]string, newLimits v1.ResourceList) error {
 	backup := containerResourcesBackup{
 		ResourcesByName: make(map[string]v1.ResourceRequirements, len(podSpec.Containers)),
 	}
 	for _, c := range podSpec.Containers {
 		backup.ResourcesByName[c.Name] = *c.Resources.DeepCopy()
+	}
+	if len(podSpec.InitContainers) > 0 {
+		backup.InitResourcesByName = make(map[string]v1.ResourceRequirements, len(podSpec.InitContainers))
+		for _, c := range podSpec.InitContainers {
+			backup.InitResourcesByName[c.Name] = *c.Resources.DeepCopy()
+		}
 	}
 
 	backupBytes, err := json.Marshal(backup)
@@ -454,6 +461,11 @@ func backupAndInjectResources(podSpec *v1.PodSpec, annotations map[string]string
 
 	for i := range podSpec.Containers {
 		podSpec.Containers[i].Resources = v1.ResourceRequirements{
+			Limits: newLimits.DeepCopy(),
+		}
+	}
+	for i := range podSpec.InitContainers {
+		podSpec.InitContainers[i].Resources = v1.ResourceRequirements{
 			Limits: newLimits.DeepCopy(),
 		}
 	}
@@ -490,10 +502,27 @@ func restoreResources(podSpec *v1.PodSpec, annotations map[string]string) error 
 			logrus.Warnf("container %q not found in backup, leaving its resources unchanged", name)
 		}
 	}
-
 	for name := range backup.ResourcesByName {
 		if !restored[name] {
 			logrus.Warnf("backed-up container %q no longer exists in pod spec, skipping restore", name)
+		}
+	}
+
+	if len(backup.InitResourcesByName) > 0 {
+		restoredInit := make(map[string]bool, len(backup.InitResourcesByName))
+		for i := range podSpec.InitContainers {
+			name := podSpec.InitContainers[i].Name
+			if orig, found := backup.InitResourcesByName[name]; found {
+				podSpec.InitContainers[i].Resources = orig
+				restoredInit[name] = true
+			} else {
+				logrus.Warnf("init container %q not found in backup, leaving its resources unchanged", name)
+			}
+		}
+		for name := range backup.InitResourcesByName {
+			if !restoredInit[name] {
+				logrus.Warnf("backed-up init container %q no longer exists in pod spec, skipping restore", name)
+			}
 		}
 	}
 

--- a/exec/pod/badresourcesize.go
+++ b/exec/pod/badresourcesize.go
@@ -1,0 +1,592 @@
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pod
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
+	"github.com/sirupsen/logrus"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/chaosblade-io/chaosblade-operator/channel"
+	"github.com/chaosblade-io/chaosblade-operator/exec/model"
+	"github.com/chaosblade-io/chaosblade-operator/pkg/apis/chaosblade/v1alpha1"
+)
+
+const (
+	BadResourceSizeCPUFlag = "cpu"
+	BadResourceSizeMemFlag = "mem"
+
+	ChaosBladeOriginalResourcesAnnotation = "chaosblade.io/original-resources"
+	ChaosBladeBadResourceSizeAction       = "badresourcesize"
+)
+
+type BadResourceSizeActionSpec struct {
+	spec.BaseExpActionCommandSpec
+	client *channel.Client
+}
+
+func NewBadResourceSizeActionSpec(client *channel.Client) spec.ExpActionCommandSpec {
+	return &BadResourceSizeActionSpec{
+		BaseExpActionCommandSpec: spec.BaseExpActionCommandSpec{
+			ActionMatchers: []spec.ExpFlagSpec{},
+			ActionFlags: []spec.ExpFlagSpec{
+				&spec.ExpFlag{
+					Name:     "workload-type",
+					Desc:     "Workload type: deployment, daemonset, statefulset. Default: deployment",
+					Required: false,
+					Default:  "deployment",
+				},
+				&spec.ExpFlag{
+					Name:     "workload-name",
+					Desc:     "Workload name to modify resource size",
+					Required: true,
+				},
+				&spec.ExpFlag{
+					Name:     BadResourceSizeCPUFlag,
+					Desc:     "CPU resource limit to set, e.g. 1m, 500m, 1",
+					Required: false,
+				},
+				&spec.ExpFlag{
+					Name:     BadResourceSizeMemFlag,
+					Desc:     "Memory resource limit to set, e.g. 128m, 256Mi, 1Gi",
+					Required: false,
+				},
+			},
+			ActionExecutor: &BadResourceSizeActionExecutor{client: client},
+			ActionExample: `# Set CPU resource limit for a deployment
+blade create k8s pod-pod badresourcesize --namespace default --workload-type deployment --workload-name nginx-app --cpu 1m --kubeconfig ~/.kube/config
+
+# Set memory resource limit for a deployment
+blade create k8s pod-pod badresourcesize --namespace default --workload-type deployment --workload-name nginx-app --mem 128m --kubeconfig ~/.kube/config
+
+# Set both CPU and memory resource limits for a deployment
+blade create k8s pod-pod badresourcesize --namespace default --workload-type deployment --workload-name nginx-app --cpu 1m --mem 128m --kubeconfig ~/.kube/config
+
+# Set resource limits for a statefulset
+blade create k8s pod-pod badresourcesize --namespace default --workload-type statefulset --workload-name redis-app --cpu 500m --mem 256Mi --kubeconfig ~/.kube/config
+
+# Set resource limits for a daemonset
+blade create k8s pod-pod badresourcesize --namespace default --workload-type daemonset --workload-name fluentd --cpu 100m --mem 128Mi --kubeconfig ~/.kube/config
+`,
+			ActionCategories: []string{model.CategorySystemContainer},
+		},
+		client: client,
+	}
+}
+
+func (*BadResourceSizeActionSpec) Name() string {
+	return "badresourcesize"
+}
+
+func (*BadResourceSizeActionSpec) Aliases() []string {
+	return []string{}
+}
+
+func (*BadResourceSizeActionSpec) ShortDesc() string {
+	return "Modify workload pod resource limits to simulate bad resource sizing"
+}
+
+func (*BadResourceSizeActionSpec) LongDesc() string {
+	return "Modify the CPU/Memory resource limits of a workload (Deployment/DaemonSet/StatefulSet) " +
+		"to simulate incorrect resource sizing. The original resource configuration is backed up " +
+		"in an annotation and restored when the experiment is destroyed. " +
+		"Existing container-level and pod-level resource settings are removed, " +
+		"and new pod-level resource limits are applied."
+}
+
+// PreCreate implements model.ActionPreProcessor.
+func (a *BadResourceSizeActionSpec) PreCreate(ctx context.Context, expModel *spec.ExpModel, client *channel.Client) (context.Context, *spec.Response) {
+	namespace := expModel.ActionFlags[model.ResourceNamespaceFlag.Name]
+	workloadType := expModel.ActionFlags["workload-type"]
+	if workloadType == "" {
+		workloadType = "deployment"
+	}
+	workloadName := expModel.ActionFlags["workload-name"]
+
+	if namespace == "" {
+		return ctx, spec.ResponseFailWithFlags(spec.ParameterLess, model.ResourceNamespaceFlag.Name)
+	}
+	if strings.Contains(namespace, ",") {
+		return ctx, spec.ResponseFailWithFlags(spec.ParameterInvalidNSNotOne, model.ResourceNamespaceFlag.Name)
+	}
+	if workloadName == "" {
+		return ctx, spec.ResponseFailWithFlags(spec.ParameterLess, "workload-name")
+	}
+
+	cpuVal := expModel.ActionFlags[BadResourceSizeCPUFlag]
+	memVal := expModel.ActionFlags[BadResourceSizeMemFlag]
+	if cpuVal == "" && memVal == "" {
+		return ctx, spec.ResponseFailWithFlags(spec.ParameterLess, "cpu or mem (at least one is required)")
+	}
+
+	containerObjectMetaList := model.ContainerMatchedList{
+		model.ContainerObjectMeta{
+			Namespace: namespace,
+			PodName:   fmt.Sprintf("chaosblade-brs-%s-%s", workloadType, workloadName),
+		},
+	}
+
+	ctx = model.SetContainerObjectMetaListToContext(ctx, containerObjectMetaList)
+	return ctx, nil
+}
+
+// PreDestroy implements model.ActionPreProcessor.
+func (a *BadResourceSizeActionSpec) PreDestroy(ctx context.Context, expModel *spec.ExpModel, client *channel.Client, oldExpStatus v1alpha1.ExperimentStatus) (context.Context, *spec.Response) {
+	namespace := expModel.ActionFlags[model.ResourceNamespaceFlag.Name]
+	workloadType := expModel.ActionFlags["workload-type"]
+	if workloadType == "" {
+		workloadType = "deployment"
+	}
+	workloadName := expModel.ActionFlags["workload-name"]
+
+	if namespace == "" {
+		return ctx, spec.ResponseFailWithFlags(spec.ParameterLess, model.ResourceNamespaceFlag.Name)
+	}
+	if strings.Contains(namespace, ",") {
+		return ctx, spec.ResponseFailWithFlags(spec.ParameterInvalidNSNotOne, model.ResourceNamespaceFlag.Name)
+	}
+	if workloadName == "" {
+		return ctx, spec.ResponseFailWithFlags(spec.ParameterLess, "workload-name")
+	}
+
+	containerObjectMetaList := model.ContainerMatchedList{
+		model.ContainerObjectMeta{
+			Namespace: namespace,
+			PodName:   fmt.Sprintf("chaosblade-brs-%s-%s", workloadType, workloadName),
+		},
+	}
+
+	ctx = model.SetContainerObjectMetaListToContext(ctx, containerObjectMetaList)
+	return ctx, nil
+}
+
+type BadResourceSizeActionExecutor struct {
+	client *channel.Client
+}
+
+func (*BadResourceSizeActionExecutor) Name() string {
+	return "badresourcesize"
+}
+
+func (*BadResourceSizeActionExecutor) SetChannel(channel spec.Channel) {}
+
+func (d *BadResourceSizeActionExecutor) Exec(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	if _, ok := spec.IsDestroy(ctx); ok {
+		return d.destroy(uid, ctx, expModel)
+	}
+	return d.create(uid, ctx, expModel)
+}
+
+func (d *BadResourceSizeActionExecutor) create(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	experimentId := model.GetExperimentIdFromContext(ctx)
+	logrusField := logrus.WithField("experiment", experimentId)
+
+	namespace := expModel.ActionFlags[model.ResourceNamespaceFlag.Name]
+	workloadType := expModel.ActionFlags["workload-type"]
+	if workloadType == "" {
+		workloadType = "deployment"
+	}
+	workloadName := expModel.ActionFlags["workload-name"]
+	cpuVal := expModel.ActionFlags[BadResourceSizeCPUFlag]
+	memVal := expModel.ActionFlags[BadResourceSizeMemFlag]
+
+	if namespace == "" {
+		util.Errorf(uid, util.GetRunFuncName(), "namespace is required")
+		return spec.ResponseFailWithFlags(spec.ParameterLess, model.ResourceNamespaceFlag.Name)
+	}
+	if workloadName == "" {
+		util.Errorf(uid, util.GetRunFuncName(), "workload-name is required")
+		return spec.ResponseFailWithFlags(spec.ParameterLess, "workload-name")
+	}
+	if cpuVal == "" && memVal == "" {
+		util.Errorf(uid, util.GetRunFuncName(), "at least one of cpu or mem is required")
+		return spec.ResponseFailWithFlags(spec.ParameterLess, "cpu or mem")
+	}
+
+	newLimits, err := buildResourceLimits(cpuVal, memVal)
+	if err != nil {
+		util.Errorf(uid, util.GetRunFuncName(), fmt.Sprintf("parse resource values failed: %v", err))
+		return spec.ResponseFailWithFlags(spec.ParameterIllegal, "cpu/mem", err.Error())
+	}
+
+	status := v1alpha1.ResourceStatus{
+		Kind:       v1alpha1.PodKind,
+		Identifier: fmt.Sprintf("%s//%s//%s", namespace, workloadType, workloadName),
+	}
+
+	switch workloadType {
+	case "deployment":
+		deployment := &appsv1.Deployment{}
+		err := d.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: workloadName}, deployment)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				logrusField.Warningf("deployment %s/%s not found", namespace, workloadName)
+				status = status.CreateFailResourceStatus(fmt.Sprintf("deployment not found: %v", err), spec.K8sExecFailed.Code)
+			} else {
+				logrusField.Warningf("get deployment %s/%s failed: %v", namespace, workloadName, err)
+				status = status.CreateFailResourceStatus(fmt.Sprintf("get deployment failed: %v", err), spec.K8sExecFailed.Code)
+			}
+			return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+		}
+
+		if err := d.injectDeploymentBadResourceSize(ctx, deployment, newLimits, experimentId); err != nil {
+			logrusField.Warningf("inject bad resource size to deployment %s/%s failed: %v", namespace, workloadName, err)
+			status = status.CreateFailResourceStatus(fmt.Sprintf("inject bad resource size failed: %v", err), spec.K8sExecFailed.Code)
+			return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+		}
+		logrusField.Infof("injected bad resource size to deployment %s/%s", namespace, workloadName)
+
+	case "daemonset":
+		daemonset := &appsv1.DaemonSet{}
+		err := d.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: workloadName}, daemonset)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				logrusField.Warningf("daemonset %s/%s not found", namespace, workloadName)
+				status = status.CreateFailResourceStatus(fmt.Sprintf("daemonset not found: %v", err), spec.K8sExecFailed.Code)
+			} else {
+				logrusField.Warningf("get daemonset %s/%s failed: %v", namespace, workloadName, err)
+				status = status.CreateFailResourceStatus(fmt.Sprintf("get daemonset failed: %v", err), spec.K8sExecFailed.Code)
+			}
+			return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+		}
+
+		if err := d.injectDaemonSetBadResourceSize(ctx, daemonset, newLimits, experimentId); err != nil {
+			logrusField.Warningf("inject bad resource size to daemonset %s/%s failed: %v", namespace, workloadName, err)
+			status = status.CreateFailResourceStatus(fmt.Sprintf("inject bad resource size failed: %v", err), spec.K8sExecFailed.Code)
+			return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+		}
+		logrusField.Infof("injected bad resource size to daemonset %s/%s", namespace, workloadName)
+
+	case "statefulset":
+		statefulset := &appsv1.StatefulSet{}
+		err := d.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: workloadName}, statefulset)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				logrusField.Warningf("statefulset %s/%s not found", namespace, workloadName)
+				status = status.CreateFailResourceStatus(fmt.Sprintf("statefulset not found: %v", err), spec.K8sExecFailed.Code)
+			} else {
+				logrusField.Warningf("get statefulset %s/%s failed: %v", namespace, workloadName, err)
+				status = status.CreateFailResourceStatus(fmt.Sprintf("get statefulset failed: %v", err), spec.K8sExecFailed.Code)
+			}
+			return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+		}
+
+		if err := d.injectStatefulSetBadResourceSize(ctx, statefulset, newLimits, experimentId); err != nil {
+			logrusField.Warningf("inject bad resource size to statefulset %s/%s failed: %v", namespace, workloadName, err)
+			status = status.CreateFailResourceStatus(fmt.Sprintf("inject bad resource size failed: %v", err), spec.K8sExecFailed.Code)
+			return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+		}
+		logrusField.Infof("injected bad resource size to statefulset %s/%s", namespace, workloadName)
+
+	default:
+		status = status.CreateFailResourceStatus(fmt.Sprintf("unsupported workload type: %s", workloadType), spec.ParameterIllegal.Code)
+		return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+	}
+
+	status = status.CreateSuccessResourceStatus()
+	return spec.ReturnResultIgnoreCode(v1alpha1.CreateSuccessExperimentStatus([]v1alpha1.ResourceStatus{status}))
+}
+
+func (d *BadResourceSizeActionExecutor) destroy(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	experimentId := model.GetExperimentIdFromContext(ctx)
+	logrusField := logrus.WithField("experiment", experimentId)
+
+	namespace := expModel.ActionFlags[model.ResourceNamespaceFlag.Name]
+	workloadType := expModel.ActionFlags["workload-type"]
+	if workloadType == "" {
+		workloadType = "deployment"
+	}
+	workloadName := expModel.ActionFlags["workload-name"]
+
+	status := v1alpha1.ResourceStatus{
+		Kind:       v1alpha1.PodKind,
+		Identifier: fmt.Sprintf("%s//%s//%s", namespace, workloadType, workloadName),
+	}
+
+	switch workloadType {
+	case "deployment":
+		deployment := &appsv1.Deployment{}
+		err := d.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: workloadName}, deployment)
+		if resp, handled := handleGetError(err, namespace, workloadType, workloadName, &status, logrusField); handled {
+			return resp
+		}
+		if err := d.restoreDeploymentResources(ctx, deployment, experimentId); err != nil {
+			logrusField.Warningf("restore deployment %s/%s resources failed: %v", namespace, workloadName, err)
+			status = status.CreateFailResourceStatus(fmt.Sprintf("restore deployment resources failed: %v", err), spec.K8sExecFailed.Code)
+			return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+		}
+		logrusField.Infof("restored deployment %s/%s resources", namespace, workloadName)
+
+	case "daemonset":
+		daemonset := &appsv1.DaemonSet{}
+		err := d.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: workloadName}, daemonset)
+		if resp, handled := handleGetError(err, namespace, workloadType, workloadName, &status, logrusField); handled {
+			return resp
+		}
+		if err := d.restoreDaemonSetResources(ctx, daemonset, experimentId); err != nil {
+			logrusField.Warningf("restore daemonset %s/%s resources failed: %v", namespace, workloadName, err)
+			status = status.CreateFailResourceStatus(fmt.Sprintf("restore daemonset resources failed: %v", err), spec.K8sExecFailed.Code)
+			return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+		}
+		logrusField.Infof("restored daemonset %s/%s resources", namespace, workloadName)
+
+	case "statefulset":
+		statefulset := &appsv1.StatefulSet{}
+		err := d.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: workloadName}, statefulset)
+		if resp, handled := handleGetError(err, namespace, workloadType, workloadName, &status, logrusField); handled {
+			return resp
+		}
+		if err := d.restoreStatefulSetResources(ctx, statefulset, experimentId); err != nil {
+			logrusField.Warningf("restore statefulset %s/%s resources failed: %v", namespace, workloadName, err)
+			status = status.CreateFailResourceStatus(fmt.Sprintf("restore statefulset resources failed: %v", err), spec.K8sExecFailed.Code)
+			return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+		}
+		logrusField.Infof("restored statefulset %s/%s resources", namespace, workloadName)
+
+	default:
+		status = status.CreateFailResourceStatus(fmt.Sprintf("unsupported workload type: %s", workloadType), spec.ParameterIllegal.Code)
+		return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}))
+	}
+
+	status = status.CreateSuccessResourceStatus()
+	status.State = v1alpha1.DestroyedState
+	return spec.ReturnResultIgnoreCode(v1alpha1.CreateDestroyedExperimentStatus([]v1alpha1.ResourceStatus{status}))
+}
+
+// containerResourcesBackup holds the original resource settings for all containers in a pod template.
+type containerResourcesBackup struct {
+	Resources []v1.ResourceRequirements `json:"resources"`
+}
+
+// buildResourceLimits parses the cpu/mem flag values into a v1.ResourceList for Limits.
+func buildResourceLimits(cpuVal, memVal string) (v1.ResourceList, error) {
+	limits := v1.ResourceList{}
+	if cpuVal != "" {
+		q, err := resource.ParseQuantity(cpuVal)
+		if err != nil {
+			return nil, fmt.Errorf("invalid cpu value %q: %v", cpuVal, err)
+		}
+		limits[v1.ResourceCPU] = q
+	}
+	if memVal != "" {
+		memQuantity := normalizeMemoryValue(memVal)
+		q, err := resource.ParseQuantity(memQuantity)
+		if err != nil {
+			return nil, fmt.Errorf("invalid mem value %q: %v", memVal, err)
+		}
+		limits[v1.ResourceMemory] = q
+	}
+	return limits, nil
+}
+
+// normalizeMemoryValue converts shorthand like "128m" to the Kubernetes-compatible "128Mi".
+// Kubernetes uses binary suffixes (Ki, Mi, Gi) for memory.
+// If the value already uses a standard suffix or is purely numeric, it is returned as-is.
+func normalizeMemoryValue(val string) string {
+	if len(val) == 0 {
+		return val
+	}
+	lastChar := val[len(val)-1]
+	if lastChar == 'm' || lastChar == 'M' {
+		prefix := val[:len(val)-1]
+		if _, err := resource.ParseQuantity(prefix); err == nil {
+			return prefix + "Mi"
+		}
+	}
+	if lastChar == 'g' || lastChar == 'G' {
+		prefix := val[:len(val)-1]
+		if _, err := resource.ParseQuantity(prefix); err == nil {
+			return prefix + "Gi"
+		}
+	}
+	if lastChar == 'k' || lastChar == 'K' {
+		prefix := val[:len(val)-1]
+		if _, err := resource.ParseQuantity(prefix); err == nil {
+			return prefix + "Ki"
+		}
+	}
+	return val
+}
+
+// backupAndInjectResources backs up original container resources and sets new pod-level limits.
+// It removes all existing container-level resource requests/limits and sets pod-level limits
+// on each container's resources.
+func backupAndInjectResources(podSpec *v1.PodSpec, annotations map[string]string, newLimits v1.ResourceList) error {
+	backup := containerResourcesBackup{
+		Resources: make([]v1.ResourceRequirements, len(podSpec.Containers)),
+	}
+	for i, c := range podSpec.Containers {
+		backup.Resources[i] = *c.Resources.DeepCopy()
+	}
+
+	backupBytes, err := json.Marshal(backup)
+	if err != nil {
+		return fmt.Errorf("marshal original resources failed: %v", err)
+	}
+	annotations[ChaosBladeOriginalResourcesAnnotation] = string(backupBytes)
+
+	for i := range podSpec.Containers {
+		podSpec.Containers[i].Resources = v1.ResourceRequirements{
+			Limits: newLimits.DeepCopy(),
+		}
+	}
+
+	return nil
+}
+
+// restoreResources restores original container resources from the backup annotation.
+func restoreResources(podSpec *v1.PodSpec, annotations map[string]string) error {
+	backupStr, ok := annotations[ChaosBladeOriginalResourcesAnnotation]
+	if !ok || backupStr == "" {
+		return fmt.Errorf("original resources backup annotation not found")
+	}
+
+	var backup containerResourcesBackup
+	if err := json.Unmarshal([]byte(backupStr), &backup); err != nil {
+		return fmt.Errorf("unmarshal original resources failed: %v", err)
+	}
+
+	if len(backup.Resources) != len(podSpec.Containers) {
+		return fmt.Errorf("backup container count (%d) does not match current container count (%d)",
+			len(backup.Resources), len(podSpec.Containers))
+	}
+
+	for i := range podSpec.Containers {
+		podSpec.Containers[i].Resources = backup.Resources[i]
+	}
+
+	return nil
+}
+
+func (d *BadResourceSizeActionExecutor) injectDeploymentBadResourceSize(ctx context.Context, deployment *appsv1.Deployment, newLimits v1.ResourceList, experimentId string) error {
+	if deployment.Annotations == nil {
+		deployment.Annotations = make(map[string]string)
+	}
+	if err := ensureNoConflictingExperiment(deployment.Annotations, experimentId); err != nil {
+		return err
+	}
+	if deployment.Annotations[ChaosBladeExperimentAnnotation] == experimentId {
+		return nil
+	}
+	deployment.Annotations[ChaosBladeDeploymentAnnotation] = ChaosBladeBadResourceSizeAction
+	deployment.Annotations[ChaosBladeExperimentAnnotation] = experimentId
+
+	if err := backupAndInjectResources(&deployment.Spec.Template.Spec, deployment.Annotations, newLimits); err != nil {
+		return err
+	}
+
+	return d.client.Update(ctx, deployment)
+}
+
+func (d *BadResourceSizeActionExecutor) injectDaemonSetBadResourceSize(ctx context.Context, daemonset *appsv1.DaemonSet, newLimits v1.ResourceList, experimentId string) error {
+	if daemonset.Annotations == nil {
+		daemonset.Annotations = make(map[string]string)
+	}
+	if err := ensureNoConflictingExperiment(daemonset.Annotations, experimentId); err != nil {
+		return err
+	}
+	if daemonset.Annotations[ChaosBladeExperimentAnnotation] == experimentId {
+		return nil
+	}
+	daemonset.Annotations[ChaosBladeDaemonSetAnnotation] = ChaosBladeBadResourceSizeAction
+	daemonset.Annotations[ChaosBladeExperimentAnnotation] = experimentId
+
+	if err := backupAndInjectResources(&daemonset.Spec.Template.Spec, daemonset.Annotations, newLimits); err != nil {
+		return err
+	}
+
+	return d.client.Update(ctx, daemonset)
+}
+
+func (d *BadResourceSizeActionExecutor) injectStatefulSetBadResourceSize(ctx context.Context, statefulset *appsv1.StatefulSet, newLimits v1.ResourceList, experimentId string) error {
+	if statefulset.Annotations == nil {
+		statefulset.Annotations = make(map[string]string)
+	}
+	if err := ensureNoConflictingExperiment(statefulset.Annotations, experimentId); err != nil {
+		return err
+	}
+	if statefulset.Annotations[ChaosBladeExperimentAnnotation] == experimentId {
+		return nil
+	}
+	statefulset.Annotations[ChaosBladeStatefulSetAnnotation] = ChaosBladeBadResourceSizeAction
+	statefulset.Annotations[ChaosBladeExperimentAnnotation] = experimentId
+
+	if err := backupAndInjectResources(&statefulset.Spec.Template.Spec, statefulset.Annotations, newLimits); err != nil {
+		return err
+	}
+
+	return d.client.Update(ctx, statefulset)
+}
+
+func (d *BadResourceSizeActionExecutor) restoreDeploymentResources(ctx context.Context, deployment *appsv1.Deployment, experimentId string) error {
+	if deployment.Annotations[ChaosBladeExperimentAnnotation] != experimentId {
+		return fmt.Errorf("deployment was not modified by experiment %s", experimentId)
+	}
+
+	if err := restoreResources(&deployment.Spec.Template.Spec, deployment.Annotations); err != nil {
+		return err
+	}
+
+	delete(deployment.Annotations, ChaosBladeDeploymentAnnotation)
+	delete(deployment.Annotations, ChaosBladeExperimentAnnotation)
+	delete(deployment.Annotations, ChaosBladeOriginalResourcesAnnotation)
+
+	return d.client.Update(ctx, deployment)
+}
+
+func (d *BadResourceSizeActionExecutor) restoreDaemonSetResources(ctx context.Context, daemonset *appsv1.DaemonSet, experimentId string) error {
+	if daemonset.Annotations[ChaosBladeExperimentAnnotation] != experimentId {
+		return fmt.Errorf("daemonset was not modified by experiment %s", experimentId)
+	}
+
+	if err := restoreResources(&daemonset.Spec.Template.Spec, daemonset.Annotations); err != nil {
+		return err
+	}
+
+	delete(daemonset.Annotations, ChaosBladeDaemonSetAnnotation)
+	delete(daemonset.Annotations, ChaosBladeExperimentAnnotation)
+	delete(daemonset.Annotations, ChaosBladeOriginalResourcesAnnotation)
+
+	return d.client.Update(ctx, daemonset)
+}
+
+func (d *BadResourceSizeActionExecutor) restoreStatefulSetResources(ctx context.Context, statefulset *appsv1.StatefulSet, experimentId string) error {
+	if statefulset.Annotations[ChaosBladeExperimentAnnotation] != experimentId {
+		return fmt.Errorf("statefulset was not modified by experiment %s", experimentId)
+	}
+
+	if err := restoreResources(&statefulset.Spec.Template.Spec, statefulset.Annotations); err != nil {
+		return err
+	}
+
+	delete(statefulset.Annotations, ChaosBladeStatefulSetAnnotation)
+	delete(statefulset.Annotations, ChaosBladeExperimentAnnotation)
+	delete(statefulset.Annotations, ChaosBladeOriginalResourcesAnnotation)
+
+	return d.client.Update(ctx, statefulset)
+}

--- a/exec/pod/badresourcesize.go
+++ b/exec/pod/badresourcesize.go
@@ -378,9 +378,11 @@ func (d *BadResourceSizeActionExecutor) destroy(uid string, ctx context.Context,
 	return spec.ReturnResultIgnoreCode(v1alpha1.CreateDestroyedExperimentStatus([]v1alpha1.ResourceStatus{status}))
 }
 
-// containerResourcesBackup holds the original resource settings for all containers in a pod template.
+// containerResourcesBackup holds the original resource settings for all containers in a pod template,
+// keyed by container name for resilience against container additions/removals during the experiment.
 type containerResourcesBackup struct {
-	Resources []v1.ResourceRequirements `json:"resources"`
+	// ResourcesByName maps container name to its original ResourceRequirements.
+	ResourcesByName map[string]v1.ResourceRequirements `json:"resourcesByName"`
 }
 
 // buildResourceLimits parses the cpu/mem flag values into a v1.ResourceList for Limits.
@@ -433,15 +435,15 @@ func normalizeMemoryValue(val string) string {
 	return val
 }
 
-// backupAndInjectResources backs up original container resources and sets new pod-level limits.
-// It removes all existing container-level resource requests/limits and sets pod-level limits
-// on each container's resources.
+// backupAndInjectResources backs up original container resources (keyed by container name)
+// and sets new pod-level limits. It removes all existing container-level resource
+// requests/limits and sets pod-level limits on each container's resources.
 func backupAndInjectResources(podSpec *v1.PodSpec, annotations map[string]string, newLimits v1.ResourceList) error {
 	backup := containerResourcesBackup{
-		Resources: make([]v1.ResourceRequirements, len(podSpec.Containers)),
+		ResourcesByName: make(map[string]v1.ResourceRequirements, len(podSpec.Containers)),
 	}
-	for i, c := range podSpec.Containers {
-		backup.Resources[i] = *c.Resources.DeepCopy()
+	for _, c := range podSpec.Containers {
+		backup.ResourcesByName[c.Name] = *c.Resources.DeepCopy()
 	}
 
 	backupBytes, err := json.Marshal(backup)
@@ -460,6 +462,9 @@ func backupAndInjectResources(podSpec *v1.PodSpec, annotations map[string]string
 }
 
 // restoreResources restores original container resources from the backup annotation.
+// It uses best-effort matching by container name: containers that exist in both the
+// backup and the current spec are restored; new containers (not in backup) are left
+// untouched; removed containers (in backup but not in spec) are logged as warnings.
 func restoreResources(podSpec *v1.PodSpec, annotations map[string]string) error {
 	backupStr, ok := annotations[ChaosBladeOriginalResourcesAnnotation]
 	if !ok || backupStr == "" {
@@ -471,13 +476,25 @@ func restoreResources(podSpec *v1.PodSpec, annotations map[string]string) error 
 		return fmt.Errorf("unmarshal original resources failed: %v", err)
 	}
 
-	if len(backup.Resources) != len(podSpec.Containers) {
-		return fmt.Errorf("backup container count (%d) does not match current container count (%d)",
-			len(backup.Resources), len(podSpec.Containers))
+	if len(backup.ResourcesByName) == 0 {
+		return fmt.Errorf("backup contains no container resources")
 	}
 
+	restored := make(map[string]bool, len(backup.ResourcesByName))
 	for i := range podSpec.Containers {
-		podSpec.Containers[i].Resources = backup.Resources[i]
+		name := podSpec.Containers[i].Name
+		if orig, found := backup.ResourcesByName[name]; found {
+			podSpec.Containers[i].Resources = orig
+			restored[name] = true
+		} else {
+			logrus.Warnf("container %q not found in backup, leaving its resources unchanged", name)
+		}
+	}
+
+	for name := range backup.ResourcesByName {
+		if !restored[name] {
+			logrus.Warnf("backed-up container %q no longer exists in pod spec, skipping restore", name)
+		}
 	}
 
 	return nil

--- a/exec/pod/badresourcesize.go
+++ b/exec/pod/badresourcesize.go
@@ -28,8 +28,8 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/chaosblade-io/chaosblade-operator/channel"
@@ -68,12 +68,12 @@ func NewBadResourceSizeActionSpec(client *channel.Client) spec.ExpActionCommandS
 				},
 				&spec.ExpFlag{
 					Name:     BadResourceSizeCPUFlag,
-					Desc:     "CPU resource limit to set, e.g. 1m, 500m, 1",
+					Desc:     "CPU resource limit to set, e.g. 1m, 5m",
 					Required: false,
 				},
 				&spec.ExpFlag{
 					Name:     BadResourceSizeMemFlag,
-					Desc:     "Memory resource limit to set, e.g. 128m, 256Mi, 1Gi",
+					Desc:     "Memory resource limit to set, e.g. 128m, 256m",
 					Required: false,
 				},
 			},
@@ -88,10 +88,10 @@ blade create k8s pod-pod badresourcesize --namespace default --workload-type dep
 blade create k8s pod-pod badresourcesize --namespace default --workload-type deployment --workload-name nginx-app --cpu 1m --mem 128m --kubeconfig ~/.kube/config
 
 # Set resource limits for a statefulset
-blade create k8s pod-pod badresourcesize --namespace default --workload-type statefulset --workload-name redis-app --cpu 500m --mem 256Mi --kubeconfig ~/.kube/config
+blade create k8s pod-pod badresourcesize --namespace default --workload-type statefulset --workload-name redis-app --cpu 1m --mem 128m --kubeconfig ~/.kube/config
 
 # Set resource limits for a daemonset
-blade create k8s pod-pod badresourcesize --namespace default --workload-type daemonset --workload-name fluentd --cpu 100m --mem 128Mi --kubeconfig ~/.kube/config
+blade create k8s pod-pod badresourcesize --namespace default --workload-type daemonset --workload-name fluentd --cpu 1m --mem 128m --kubeconfig ~/.kube/config
 `,
 			ActionCategories: []string{model.CategorySystemContainer},
 		},

--- a/exec/pod/pod.go
+++ b/exec/pod/pod.go
@@ -251,15 +251,26 @@ blade create k8s pod-pod imagepullsecretserror --labels app=nginx --namespace de
 
 # Corrupt only a specific imagePullSecret
 blade create k8s pod-pod imagepullsecretserror --names my-app-pod --namespace default --secret-name my-registry-secret --kubeconfig ~/.kube/config`)
-			case *ConfigMapDeleteActionSpec:
-				action.SetLongDesc("Delete a ConfigMap that a Pod depends on, then restart the Pod to simulate startup failure caused by missing ConfigMap. The original ConfigMap is backed up and restored when the experiment is destroyed.")
-				action.SetExample(
-					`# Delete the auto-selected required ConfigMap for pods matching labels
+		case *ConfigMapDeleteActionSpec:
+			action.SetLongDesc("Delete a ConfigMap that a Pod depends on, then restart the Pod to simulate startup failure caused by missing ConfigMap. The original ConfigMap is backed up and restored when the experiment is destroyed.")
+			action.SetExample(
+				`# Delete the auto-selected required ConfigMap for pods matching labels
 blade create k8s pod-pod configmapdelete --labels "app=test" --namespace default --kubeconfig ~/.kube/config
 
 # Delete a specific ConfigMap
 blade create k8s pod-pod configmapdelete --labels "app=test" --namespace default --configmap-name my-config --kubeconfig ~/.kube/config`)
-			default:
+		case *BadResourceSizeActionSpec:
+			action.SetLongDesc("Modify the CPU/Memory resource limits of a workload (Deployment/DaemonSet/StatefulSet) to simulate incorrect resource sizing. The original resource configuration is backed up and restored when the experiment is destroyed.")
+			action.SetExample(
+				`# Set CPU resource limit for a deployment
+blade create k8s pod-pod badresourcesize --namespace default --workload-type deployment --workload-name nginx-app --cpu 1m --kubeconfig ~/.kube/config
+
+# Set memory resource limit for a deployment
+blade create k8s pod-pod badresourcesize --namespace default --workload-type deployment --workload-name nginx-app --mem 128m --kubeconfig ~/.kube/config
+
+# Set both CPU and memory resource limits for a deployment
+blade create k8s pod-pod badresourcesize --namespace default --workload-type deployment --workload-name nginx-app --cpu 1m --mem 128m --kubeconfig ~/.kube/config`)
+		default:
 				action.SetExample(strings.Replace(action.Example(),
 					fmt.Sprintf("blade create %s %s", expModelSpec.Name(), action.Name()),
 					fmt.Sprintf("blade create k8s pod-%s %s --names nginx-app --kubeconfig ~/.kube/config --namespace default", expModelSpec.Name(), action.Name()),
@@ -301,6 +312,7 @@ func NewSelfExpModelCommandSpec(client *channel.Client) spec.ExpModelCommandSpec
 				NewImageConfigActionSpec(client),
 				NewImagePullSecretsErrorActionSpec(client),
 				NewConfigMapDeleteActionSpec(client),
+				NewBadResourceSizeActionSpec(client),
 			},
 		},
 	}

--- a/exec/pod/pod.go
+++ b/exec/pod/pod.go
@@ -251,18 +251,18 @@ blade create k8s pod-pod imagepullsecretserror --labels app=nginx --namespace de
 
 # Corrupt only a specific imagePullSecret
 blade create k8s pod-pod imagepullsecretserror --names my-app-pod --namespace default --secret-name my-registry-secret --kubeconfig ~/.kube/config`)
-		case *ConfigMapDeleteActionSpec:
-			action.SetLongDesc("Delete a ConfigMap that a Pod depends on, then restart the Pod to simulate startup failure caused by missing ConfigMap. The original ConfigMap is backed up and restored when the experiment is destroyed.")
-			action.SetExample(
-				`# Delete the auto-selected required ConfigMap for pods matching labels
+			case *ConfigMapDeleteActionSpec:
+				action.SetLongDesc("Delete a ConfigMap that a Pod depends on, then restart the Pod to simulate startup failure caused by missing ConfigMap. The original ConfigMap is backed up and restored when the experiment is destroyed.")
+				action.SetExample(
+					`# Delete the auto-selected required ConfigMap for pods matching labels
 blade create k8s pod-pod configmapdelete --labels "app=test" --namespace default --kubeconfig ~/.kube/config
 
 # Delete a specific ConfigMap
 blade create k8s pod-pod configmapdelete --labels "app=test" --namespace default --configmap-name my-config --kubeconfig ~/.kube/config`)
-		case *BadResourceSizeActionSpec:
-			action.SetLongDesc("Modify the CPU/Memory resource limits of a workload (Deployment/DaemonSet/StatefulSet) to simulate incorrect resource sizing. The original resource configuration is backed up and restored when the experiment is destroyed.")
-			action.SetExample(
-				`# Set CPU resource limit for a deployment
+			case *BadResourceSizeActionSpec:
+				action.SetLongDesc("Modify the CPU/Memory resource limits of a workload (Deployment/DaemonSet/StatefulSet) to simulate incorrect resource sizing. The original resource configuration is backed up and restored when the experiment is destroyed.")
+				action.SetExample(
+					`# Set CPU resource limit for a deployment
 blade create k8s pod-pod badresourcesize --namespace default --workload-type deployment --workload-name nginx-app --cpu 1m --kubeconfig ~/.kube/config
 
 # Set memory resource limit for a deployment
@@ -270,7 +270,7 @@ blade create k8s pod-pod badresourcesize --namespace default --workload-type dep
 
 # Set both CPU and memory resource limits for a deployment
 blade create k8s pod-pod badresourcesize --namespace default --workload-type deployment --workload-name nginx-app --cpu 1m --mem 128m --kubeconfig ~/.kube/config`)
-		default:
+			default:
 				action.SetExample(strings.Replace(action.Example(),
 					fmt.Sprintf("blade create %s %s", expModelSpec.Name(), action.Name()),
 					fmt.Sprintf("blade create k8s pod-%s %s --names nginx-app --kubeconfig ~/.kube/config --namespace default", expModelSpec.Name(), action.Name()),

--- a/exec/pod/pod.go
+++ b/exec/pod/pod.go
@@ -269,7 +269,13 @@ blade create k8s pod-pod badresourcesize --namespace default --workload-type dep
 blade create k8s pod-pod badresourcesize --namespace default --workload-type deployment --workload-name nginx-app --mem 128m --kubeconfig ~/.kube/config
 
 # Set both CPU and memory resource limits for a deployment
-blade create k8s pod-pod badresourcesize --namespace default --workload-type deployment --workload-name nginx-app --cpu 1m --mem 128m --kubeconfig ~/.kube/config`)
+blade create k8s pod-pod badresourcesize --namespace default --workload-type deployment --workload-name nginx-app --cpu 1m --mem 128m --kubeconfig ~/.kube/config
+
+# Set CPU resource limit for a daemonset
+blade create k8s pod-pod badresourcesize --namespace default --workload-type daemonset --workload-name nginx-ds --cpu 1m --kubeconfig ~/.kube/config
+
+# Set memory resource limit for a statefulset
+blade create k8s pod-pod badresourcesize --namespace default --workload-type statefulset --workload-name nginx-sts --mem 128m --kubeconfig ~/.kube/config`)
 			default:
 				action.SetExample(strings.Replace(action.Example(),
 					fmt.Sprintf("blade create %s %s", expModelSpec.Name(), action.Name()),


### PR DESCRIPTION
新增 Pod 故障注入场景 badresourcesize，可修改 Deployment/DaemonSet/StatefulSet 的 CPU/Memory 资源限制来模拟资源配置异常。支持以下能力：
- 通过 --cpu 和 --mem 参数设置资源 limits，至少需指定其一
- 注入前自动备份原始资源配置到 annotation，销毁时自动还原
- 支持幂等注入及实验冲突检测，防止多个实验互相覆盖
- 新增三个 example YAML 用例（仅CPU、仅内存、CPU+内存）
- 更新 README.md 和 README_CN.md 的实验场景说明

支持的 blade 命令：

```shell
# Set CPU resource limit for a deployment
blade create k8s pod-pod badresourcesize --namespace default --workload-type deployment --workload-name nginx-app --cpu 1m --kubeconfig ~/.kube/config

# Set memory resource limit for a deployment
blade create k8s pod-pod badresourcesize --namespace default --workload-type deployment --workload-name nginx-app --mem 128m --kubeconfig ~/.kube/config

# Set both CPU and memory resource limits for a deployment
blade create k8s pod-pod badresourcesize --namespace default --workload-type deployment --workload-name nginx-app --cpu 1m --mem 128m --kubeconfig ~/.kube/config

# Set resource limits for a statefulset
blade create k8s pod-pod badresourcesize --namespace default --workload-type statefulset --workload-name redis-app --cpu 1m --mem 128m --kubeconfig ~/.kube/config

# Set resource limits for a daemonset
blade create k8s pod-pod badresourcesize --namespace default --workload-type daemonset --workload-name fluentd --cpu 1m --mem 128m --kubeconfig ~/.kube/config
```

Made-with: Cursor
