### PR TITLE
chore: update DOCKER_API_VERSION to 1.44 in daemonset template

### DIFF
--- a/deploy/helm/chaosblade-operator/templates/daemonset.yaml
+++ b/deploy/helm/chaosblade-operator/templates/daemonset.yaml
@@ -52,7 +52,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: DOCKER_API_VERSION
-              value: "1.14.0"
+              value: "1.44"
             - name: CGROUP_ROOT
               value: "/host-sys/fs/cgroup/"
           securityContext:


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

fixed the following issue:
Support for docker with version later than 29.0.0 https://github.com/chaosblade-io/chaosblade/issues/1284