### PR TITLE
feat(node): add disk unmount_stuck action description and examples

### DIFF
--- a/exec/node/node.go
+++ b/exec/node/node.go
@@ -274,6 +274,14 @@ blade create k8s node-disk burn --write --path /home --names izbp1a4jchbdwkwi5hk
 blade create k8s node-disk burn --read --write --channel ssh --ssh-host 192.168.1.100 --ssh-user root
 ## using DaemonSet
 blade create k8s node-disk burn --read --write --names izbp1a4jchbdwkwi5hk7ekz --kubeconfig ~/.kube/config --timeout 30`)
+			case *disk.UnmountStuckActionSpec:
+				action.SetLongDesc("Simulate volume unmount stuck by holding file handles in the node")
+				action.SetExample(
+					`# Simulate volume unmount stuck on /mnt/data in the node
+## using SSH channel
+blade create k8s node-disk unmount_stuck --path /mnt/data --channel ssh --ssh-host 192.168.1.100 --ssh-user root
+## using DaemonSet
+blade create k8s node-disk unmount_stuck --path /mnt/data --names izbp1a4jchbdwkwi5hk7ekz --kubeconfig ~/.kube/config --timeout 30`)
 			case *mem.MemLoadActionCommand:
 				action.SetLongDesc("The memory fill experiment scenario in container")
 				action.SetExample(


### PR DESCRIPTION
## Summary
- Add long description and usage examples for the `disk unmount_stuck` action in the node executor
- This action simulates volume unmount stuck by holding file handles on the specified mount point, causing `umount` to fail with "device busy"
- Only added to node scope, as pod/container level unmount_stuck has no practical effect (container processes are killed before kubelet unmounts volumes)
- Depends on chaosblade-exec-os PR: https://github.com/chaosblade-io/chaosblade-exec-os/pull/210

## Test plan
- [x] `go build ./...` passes
- [ ] Verify `blade create k8s node-disk unmount_stuck --path /mnt/data` works on a K8s cluster
- [ ] Verify pod stuck in Terminating when targeting kubelet volume mount path

🤖 Generated with [Qoder][https://qoder.com]