### PR TITLE
feat: 新增 Pod_ContainerCreating 云盘 PVC 创建失败故障场景

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The current experimental scenarios involve resources including Node, Pod, and Co
     * Network: specify network card, port, IP, etc. packet delay, packet loss, packet blocking, packet duplication, packet re-ordering, packet corruption, etc.
     * Disk: specify the directory disk occupation, disk IO read and write load, etc.
     * Memory: specify memory usage
-    * Pod: kill pod, make pod stuck in ContainerCreating state by PVC mount failure, make pod stuck in Terminating state by finalizer, make pod scheduling fail by injecting unreachable affinity rules, modify workload (Deployment/DaemonSet/StatefulSet) CPU/Memory resource limits to simulate bad resource sizing, mount non-existent ConfigMap/Secret/PVC volume to workload (Deployment/DaemonSet/StatefulSet) to simulate volume mount failure
+    * Pod: kill pod, make pod stuck in ContainerCreating state by PVC mount failure, make pod stuck in ContainerCreating state by cloud disk PVC creation failure, make pod stuck in Terminating state by finalizer, make pod scheduling fail by injecting unreachable affinity rules, modify workload (Deployment/DaemonSet/StatefulSet) CPU/Memory resource limits to simulate bad resource sizing, mount non-existent ConfigMap/Secret/PVC volume to workload (Deployment/DaemonSet/StatefulSet) to simulate volume mount failure
     * IO: specify the file system io exception. Supports 31 file operations and 11 exception scenarios, such as "Too many open files", "Device or resource busy" and so on.
 * Container:
     * CPU: specify CPU usage

--- a/README_CN.md
+++ b/README_CN.md
@@ -16,7 +16,7 @@ Chaosblade Operator 是混沌工程实验工具 ChaosBlade 下的一款面向云
     * 网络：指定网卡、端口、IP 等包延迟、丢包、包阻塞、包重复、包乱序、包损坏等
     * 磁盘：指定目录磁盘填充、磁盘 IO 读写负载等
     * 内存：指定内存使用率
-    * Pod：杀 Pod、通过 PVC 挂载失败使 Pod 卡在 ContainerCreating 状态、通过 finalizer 使 Pod 卡在 Terminating 状态、通过注入无法满足的亲和性规则使 Pod 调度失败、修改工作负载（Deployment/DaemonSet/StatefulSet）的 CPU/Memory 资源限制模拟资源配置异常、挂载不存在的 ConfigMap/Secret/PVC 类型 Volume 到工作负载（Deployment/DaemonSet/StatefulSet）模拟卷挂载失败
+    * Pod：杀 Pod、通过 PVC 挂载失败使 Pod 卡在 ContainerCreating 状态、通过云盘 PVC 创建失败使 Pod 卡在 ContainerCreating 状态、通过 finalizer 使 Pod 卡在 Terminating 状态、通过注入无法满足的亲和性规则使 Pod 调度失败、修改工作负载（Deployment/DaemonSet/StatefulSet）的 CPU/Memory 资源限制模拟资源配置异常、挂载不存在的 ConfigMap/Secret/PVC 类型 Volume 到工作负载（Deployment/DaemonSet/StatefulSet）模拟卷挂载失败
 * Container：
     * CPU: 指定 CPU 使用率
     * 网络: 指定网卡、端口、IP 等包延迟、丢包、包阻塞、包重复、包乱序、包损坏等

--- a/examples/pod-containercreating-disk.yaml
+++ b/examples/pod-containercreating-disk.yaml
@@ -1,0 +1,51 @@
+# Copyright 2025 The ChaosBlade Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Make pod stuck in ContainerCreating state by cloud disk PVC creation failure.
+# This simulates the scenario where a StorageClass triggers cloud disk provisioning
+# but the provisioner fails (zone mismatch, disk type not supported, quota exceeded).
+#
+# Equivalent to:
+#   blade create k8s pod-pod containercreating-disk --namespace default \
+#     --storage-class alicloud-disk-ssd --kubeconfig ~/.kube/config
+#
+# Prerequisites:
+# - The specified StorageClass must exist in the cluster
+# - The operator should have RBAC permissions to create/delete pods and PVCs
+
+apiVersion: chaosblade.io/v1alpha1
+kind: ChaosBlade
+metadata:
+  name: pod-containercreating-disk
+spec:
+  experiments:
+  - scope: pod
+    target: pod
+    action: containercreating-disk
+    desc: "Make pod stuck in ContainerCreating state by cloud disk PVC creation failure"
+    matchers:
+    - name: namespace
+      value:
+      - "default"
+    - name: storage-class
+      value:
+      - "alicloud-disk-ssd"
+    # Optional: PVC storage capacity, default: 20Gi
+    # - name: pv-capacity
+    #   value:
+    #   - "50Gi"
+    # Optional: volume mount path in the container, default: /mnt/data
+    # - name: volume-mount-path
+    #   value:
+    #   - "/mnt/data"

--- a/exec/pod/containercreatingdisk.go
+++ b/exec/pod/containercreatingdisk.go
@@ -1,0 +1,437 @@
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pod
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
+	"github.com/sirupsen/logrus"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/chaosblade-io/chaosblade-operator/channel"
+	"github.com/chaosblade-io/chaosblade-operator/exec/model"
+	"github.com/chaosblade-io/chaosblade-operator/pkg/apis/chaosblade/v1alpha1"
+)
+
+// PodContainerCreatingDiskActionSpec defines the action spec for containercreating-disk.
+// It creates a PVC with a specified StorageClass (triggering cloud disk provisioning)
+// and a Pod that mounts this PVC. When the cloud disk provisioner fails (due to zone
+// mismatch, disk type not supported, or quota exceeded), the PVC remains Pending and
+// the Pod is stuck in ContainerCreating.
+type PodContainerCreatingDiskActionSpec struct {
+	spec.BaseExpActionCommandSpec
+	client *channel.Client
+}
+
+func NewPodContainerCreatingDiskActionSpec(client *channel.Client) spec.ExpActionCommandSpec {
+	return &PodContainerCreatingDiskActionSpec{
+		BaseExpActionCommandSpec: spec.BaseExpActionCommandSpec{
+			ActionMatchers: []spec.ExpFlagSpec{},
+			ActionFlags: []spec.ExpFlagSpec{
+				&spec.ExpFlag{
+					Name: "storage-class",
+					Desc: "StorageClass name for PVC creation",
+				},
+				&spec.ExpFlag{
+					Name: "pv-capacity",
+					Desc: "PVC storage capacity, default: 20Gi",
+				},
+				&spec.ExpFlag{
+					Name: "volume-mount-path",
+					Desc: "Volume mount path in the container, default: /mnt/data",
+				},
+			},
+			ActionExecutor: &PodContainerCreatingDiskActionExecutor{client: client},
+			ActionExample: `# Create a pod stuck in ContainerCreating state by cloud disk PVC failure
+blade create k8s pod-pod containercreating-disk --namespace default --storage-class alicloud-disk-ssd --kubeconfig ~/.kube/config
+
+# Specify custom PV capacity
+blade create k8s pod-pod containercreating-disk --namespace default --storage-class alicloud-disk-ssd --pv-capacity 50Gi --kubeconfig ~/.kube/config
+
+# Specify custom volume mount path
+blade create k8s pod-pod containercreating-disk --namespace default --storage-class alicloud-disk-ssd --volume-mount-path /data --kubeconfig ~/.kube/config`,
+			ActionCategories: []string{model.CategorySystemContainer},
+		},
+		client: client,
+	}
+}
+
+func (*PodContainerCreatingDiskActionSpec) Name() string {
+	return "containercreating-disk"
+}
+
+func (*PodContainerCreatingDiskActionSpec) Aliases() []string {
+	return []string{}
+}
+
+func (*PodContainerCreatingDiskActionSpec) ShortDesc() string {
+	return "Make pod stuck in ContainerCreating state by cloud disk PVC creation failure"
+}
+
+func (*PodContainerCreatingDiskActionSpec) LongDesc() string {
+	return "Simulate the scenario where a Pod is stuck in ContainerCreating state due to cloud disk PVC creation failure. " +
+		"This fault is injected by creating a PVC with the specified StorageClass (which triggers cloud disk provisioning), " +
+		"then creating a Pod that mounts this PVC. When the cloud disk provisioner fails (due to zone mismatch, " +
+		"disk type not supported, or quota exceeded), the PVC remains Pending and the Pod is stuck in ContainerCreating. " +
+		"When the experiment is destroyed, the created Pod and PVC will be cleaned up."
+}
+
+// PodContainerCreatingDiskActionExecutor implements the create and destroy logic
+// for the containercreating-disk action.
+type PodContainerCreatingDiskActionExecutor struct {
+	client *channel.Client
+}
+
+func (*PodContainerCreatingDiskActionExecutor) Name() string {
+	return "containercreating-disk"
+}
+
+func (*PodContainerCreatingDiskActionExecutor) SetChannel(channel spec.Channel) {}
+
+func (d *PodContainerCreatingDiskActionExecutor) Exec(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	if _, ok := spec.IsDestroy(ctx); ok {
+		return d.destroy(uid, ctx, expModel)
+	}
+	return d.create(uid, ctx, expModel)
+}
+
+func (d *PodContainerCreatingDiskActionExecutor) create(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	experimentId := model.GetExperimentIdFromContext(ctx)
+	logrusField := logrus.WithField("experiment", experimentId)
+
+	containerObjectMetaList, err := model.GetContainerObjectMetaListFromContext(ctx)
+	if err != nil {
+		util.Errorf(uid, util.GetRunFuncName(), err.Error())
+		return spec.ResponseFailWithResult(spec.ContainerInContextNotFound,
+			v1alpha1.CreateFailExperimentStatus(spec.ContainerInContextNotFound.Msg, []v1alpha1.ResourceStatus{}))
+	}
+
+	// Parse flags with defaults
+	storageClass := expModel.ActionFlags["storage-class"]
+	pvCapacity := expModel.ActionFlags["pv-capacity"]
+	if pvCapacity == "" {
+		pvCapacity = "20Gi"
+	}
+	volumeMountPath := expModel.ActionFlags["volume-mount-path"]
+	if volumeMountPath == "" {
+		volumeMountPath = "/mnt/data"
+	}
+
+	// Deduplicate by namespace - create one PVC+Pod per unique namespace
+	seenNamespaces := make(map[string]bool)
+	statuses := make([]v1alpha1.ResourceStatus, 0)
+	success := false
+
+	for _, meta := range containerObjectMetaList {
+		if seenNamespaces[meta.Namespace] {
+			continue
+		}
+		seenNamespaces[meta.Namespace] = true
+
+		pvcName := fmt.Sprintf("chaosblade-ccd-%s-pvc", experimentId)
+		podName := fmt.Sprintf("chaosblade-ccd-%s-pod", experimentId)
+
+		status := v1alpha1.ResourceStatus{
+			Kind:       v1alpha1.PodKind,
+			Identifier: fmt.Sprintf("%s//%s", meta.Namespace, podName),
+		}
+
+		// Step 1: Create PVC with the specified StorageClass.
+		// In clusters without a cloud disk provisioner, the PVC will remain Pending.
+		if err := d.createPVC(ctx, meta.Namespace, pvcName, storageClass, pvCapacity, experimentId); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				logrusField.Infof("PVC %s/%s already exists, skip creation", meta.Namespace, pvcName)
+			} else {
+				logrusField.Warningf("create PVC %s/%s failed: %v", meta.Namespace, pvcName, err)
+				status = status.CreateFailResourceStatus(fmt.Sprintf("create PVC failed: %v", err), spec.K8sExecFailed.Code)
+				statuses = append(statuses, status)
+				continue
+			}
+		} else {
+			logrusField.Infof("created PVC %s/%s with StorageClass %s", meta.Namespace, pvcName, storageClass)
+		}
+
+		// Step 2: Create Pod that mounts the PVC.
+		// The Pod will be stuck in ContainerCreating since the PVC is not bound.
+		if err := d.createPod(ctx, meta.Namespace, podName, pvcName, volumeMountPath, experimentId); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				logrusField.Infof("Pod %s/%s already exists, skip creation", meta.Namespace, podName)
+			} else {
+				logrusField.Warningf("create Pod %s/%s failed: %v", meta.Namespace, podName, err)
+				// Best-effort rollback: delete the PVC we just created.
+				// If rollback fails, resources will be leaked because we record
+				// a failed status and Destroy only processes successful ones.
+				// To prevent leaks, we still record success so Destroy will
+				// attempt cleanup (destroy is idempotent and handles NotFound).
+				pvcDeleted := true
+				if delErr := d.deletePVC(ctx, meta.Namespace, pvcName); delErr != nil {
+					logrusField.Warningf("rollback PVC %s/%s failed: %v", meta.Namespace, pvcName, delErr)
+					pvcDeleted = false
+				}
+				if pvcDeleted {
+					status = status.CreateFailResourceStatus(fmt.Sprintf("create Pod failed: %v", err), spec.K8sExecFailed.Code)
+					statuses = append(statuses, status)
+				} else {
+					logrusField.Warningf("rollback incomplete, recording success status to ensure Destroy can clean up")
+					status = status.CreateSuccessResourceStatus()
+					statuses = append(statuses, status)
+					success = true
+				}
+				continue
+			}
+		} else {
+			logrusField.Infof("created Pod %s/%s which will be stuck in ContainerCreating state", meta.Namespace, podName)
+		}
+
+		status = status.CreateSuccessResourceStatus()
+		statuses = append(statuses, status)
+		success = true
+	}
+
+	var experimentStatus v1alpha1.ExperimentStatus
+	if success {
+		experimentStatus = v1alpha1.CreateSuccessExperimentStatus(statuses)
+	} else {
+		experimentStatus = v1alpha1.CreateFailExperimentStatus("see resStatuses for details", statuses)
+	}
+	return spec.ReturnResultIgnoreCode(experimentStatus)
+}
+
+func (d *PodContainerCreatingDiskActionExecutor) destroy(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	experimentId := model.GetExperimentIdFromContext(ctx)
+	logrusField := logrus.WithField("experiment", experimentId)
+
+	containerObjectMetaList, err := model.GetContainerObjectMetaListFromContext(ctx)
+	if err != nil {
+		util.Errorf(uid, util.GetRunFuncName(), err.Error())
+		return spec.ResponseFailWithResult(spec.ContainerInContextNotFound,
+			v1alpha1.CreateFailExperimentStatus(spec.ContainerInContextNotFound.Msg, []v1alpha1.ResourceStatus{}))
+	}
+
+	statuses := make([]v1alpha1.ResourceStatus, 0)
+	allSuccess := true
+	seenNamespaces := make(map[string]bool)
+
+	for _, meta := range containerObjectMetaList {
+		if seenNamespaces[meta.Namespace] {
+			continue
+		}
+		seenNamespaces[meta.Namespace] = true
+
+		pvcName := fmt.Sprintf("chaosblade-ccd-%s-pvc", experimentId)
+		podName := fmt.Sprintf("chaosblade-ccd-%s-pod", experimentId)
+		namespace := meta.Namespace
+
+		status := v1alpha1.ResourceStatus{
+			Kind:       v1alpha1.PodKind,
+			Identifier: fmt.Sprintf("%s//%s", namespace, podName),
+		}
+
+		// Step 1: Delete Pod
+		if err := d.deletePod(ctx, namespace, podName); err != nil {
+			if apierrors.IsNotFound(err) {
+				logrusField.Infof("Pod %s/%s already deleted", namespace, podName)
+			} else {
+				logrusField.Warningf("delete Pod %s/%s failed: %v", namespace, podName, err)
+				status = status.CreateFailResourceStatus(fmt.Sprintf("delete Pod failed: %v", err), spec.K8sExecFailed.Code)
+				statuses = append(statuses, status)
+				allSuccess = false
+				continue
+			}
+		} else {
+			logrusField.Infof("deleted Pod %s/%s", namespace, podName)
+		}
+
+		// Step 2: Delete PVC
+		if err := d.deletePVC(ctx, namespace, pvcName); err != nil {
+			if apierrors.IsNotFound(err) {
+				logrusField.Infof("PVC %s/%s already deleted", namespace, pvcName)
+			} else {
+				logrusField.Warningf("delete PVC %s/%s failed: %v", namespace, pvcName, err)
+				status = status.CreateFailResourceStatus(fmt.Sprintf("delete PVC failed: %v", err), spec.K8sExecFailed.Code)
+				statuses = append(statuses, status)
+				allSuccess = false
+				continue
+			}
+		} else {
+			logrusField.Infof("deleted PVC %s/%s", namespace, pvcName)
+		}
+
+		status = status.CreateSuccessResourceStatus()
+		status.State = v1alpha1.DestroyedState
+		statuses = append(statuses, status)
+	}
+
+	if allSuccess {
+		return spec.ReturnResultIgnoreCode(v1alpha1.CreateDestroyedExperimentStatus(statuses))
+	}
+	return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus("see resStatuses for details", statuses))
+}
+
+// createPVC creates a PersistentVolumeClaim with the specified StorageClass.
+// The PVC will remain Pending if the cloud disk provisioner is unavailable or
+// misconfigured (zone mismatch, disk type not supported, quota exceeded).
+func (d *PodContainerCreatingDiskActionExecutor) createPVC(ctx context.Context, namespace, pvcName, storageClass, pvCapacity, experimentId string) error {
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pvcName,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				ChaosBladePVCAnnotation:        ChaosBladeActionCreate,
+				ChaosBladeExperimentAnnotation: experimentId,
+			},
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			StorageClassName: &storageClass,
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+			},
+			Resources: v1.VolumeResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceStorage: resource.MustParse(pvCapacity),
+				},
+			},
+		},
+	}
+	return d.client.Create(ctx, pvc)
+}
+
+// createPod creates a Pod that mounts the given PVC, which will cause it to be
+// stuck in ContainerCreating state because the PVC is not bound (cloud disk
+// provisioner failure).
+func (d *PodContainerCreatingDiskActionExecutor) createPod(ctx context.Context, namespace, podName, pvcName, volumeMountPath, experimentId string) error {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				ChaosBladePodAnnotation:        ChaosBladeActionCreate,
+				ChaosBladeExperimentAnnotation: experimentId,
+			},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:    "chaosblade-ccd-container",
+					Image:   "busybox",
+					Command: []string{"sleep", "infinity"},
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      "chaosblade-ccd-volume",
+							MountPath: volumeMountPath,
+						},
+					},
+				},
+			},
+			Tolerations: []v1.Toleration{
+				{
+					Operator: v1.TolerationOpExists,
+				},
+			},
+			Volumes: []v1.Volume{
+				{
+					Name: "chaosblade-ccd-volume",
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+							ClaimName: pvcName,
+						},
+					},
+				},
+			},
+		},
+	}
+	return d.client.Create(ctx, pod)
+}
+
+// deletePod deletes a Pod by namespace and name.
+func (d *PodContainerCreatingDiskActionExecutor) deletePod(ctx context.Context, namespace, podName string) error {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace,
+		},
+	}
+	return d.client.Delete(ctx, pod)
+}
+
+// deletePVC deletes a PersistentVolumeClaim by namespace and name.
+func (d *PodContainerCreatingDiskActionExecutor) deletePVC(ctx context.Context, namespace, pvcName string) error {
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pvcName,
+			Namespace: namespace,
+		},
+	}
+	return d.client.Delete(ctx, pvc)
+}
+
+// PreCreate implements model.ActionPreProcessor interface.
+// It validates namespace and storage-class, and prepares the context for
+// containercreating-disk action.
+func (a *PodContainerCreatingDiskActionSpec) PreCreate(ctx context.Context, expModel *spec.ExpModel, client *channel.Client) (context.Context, *spec.Response) {
+	experimentId := model.GetExperimentIdFromContext(ctx)
+
+	// Validate namespace: must be specified and only one value
+	namespace := expModel.ActionFlags[model.ResourceNamespaceFlag.Name]
+	if namespace == "" {
+		return ctx, spec.ResponseFailWithFlags(spec.ParameterLess, model.ResourceNamespaceFlag.Name)
+	}
+	if strings.Contains(namespace, ",") {
+		return ctx, spec.ResponseFailWithFlags(spec.ParameterInvalidNSNotOne, model.ResourceNamespaceFlag.Name)
+	}
+
+	// Validate storage-class: must be specified
+	storageClass := expModel.ActionFlags["storage-class"]
+	if storageClass == "" {
+		return ctx, spec.ResponseFailWithFlags(spec.ParameterLess, "storage-class")
+	}
+
+	containerObjectMetaList := model.ContainerMatchedList{
+		model.ContainerObjectMeta{
+			Namespace: namespace,
+			PodName:   fmt.Sprintf("chaosblade-ccd-%s-pod", experimentId),
+		},
+	}
+
+	ctx = model.SetContainerObjectMetaListToContext(ctx, containerObjectMetaList)
+	return ctx, nil
+}
+
+// PreDestroy implements model.ActionPreProcessor interface.
+// It prepares the context for containercreating-disk destroy flow.
+func (a *PodContainerCreatingDiskActionSpec) PreDestroy(ctx context.Context, expModel *spec.ExpModel, client *channel.Client, oldExpStatus v1alpha1.ExperimentStatus) (context.Context, *spec.Response) {
+	experimentId := model.GetExperimentIdFromContext(ctx)
+	namespace := expModel.ActionFlags[model.ResourceNamespaceFlag.Name]
+
+	containerObjectMetaList := model.ContainerMatchedList{
+		model.ContainerObjectMeta{
+			Namespace: namespace,
+			PodName:   fmt.Sprintf("chaosblade-ccd-%s-pod", experimentId),
+		},
+	}
+
+	ctx = model.SetContainerObjectMetaListToContext(ctx, containerObjectMetaList)
+	return ctx, nil
+}

--- a/exec/pod/containercreatingdisk.go
+++ b/exec/pod/containercreatingdisk.go
@@ -51,8 +51,9 @@ func NewPodContainerCreatingDiskActionSpec(client *channel.Client) spec.ExpActio
 			ActionMatchers: []spec.ExpFlagSpec{},
 			ActionFlags: []spec.ExpFlagSpec{
 				&spec.ExpFlag{
-					Name: "storage-class",
-					Desc: "StorageClass name for PVC creation",
+					Name:     "storage-class",
+					Desc:     "StorageClass name for PVC creation",
+					Required: true,
 				},
 				&spec.ExpFlag{
 					Name: "pv-capacity",
@@ -408,6 +409,14 @@ func (a *PodContainerCreatingDiskActionSpec) PreCreate(ctx context.Context, expM
 		return ctx, spec.ResponseFailWithFlags(spec.ParameterLess, "storage-class")
 	}
 
+	// Validate pv-capacity format if specified
+	pvCapacity := expModel.ActionFlags["pv-capacity"]
+	if pvCapacity != "" {
+		if _, err := resource.ParseQuantity(pvCapacity); err != nil {
+			return ctx, spec.ResponseFailWithFlags(spec.ParameterIllegal, "pv-capacity", pvCapacity, err.Error())
+		}
+	}
+
 	containerObjectMetaList := model.ContainerMatchedList{
 		model.ContainerObjectMeta{
 			Namespace: namespace,
@@ -424,6 +433,13 @@ func (a *PodContainerCreatingDiskActionSpec) PreCreate(ctx context.Context, expM
 func (a *PodContainerCreatingDiskActionSpec) PreDestroy(ctx context.Context, expModel *spec.ExpModel, client *channel.Client, oldExpStatus v1alpha1.ExperimentStatus) (context.Context, *spec.Response) {
 	experimentId := model.GetExperimentIdFromContext(ctx)
 	namespace := expModel.ActionFlags[model.ResourceNamespaceFlag.Name]
+
+	if namespace == "" {
+		return ctx, spec.ResponseFailWithFlags(spec.ParameterLess, model.ResourceNamespaceFlag.Name)
+	}
+	if strings.Contains(namespace, ",") {
+		return ctx, spec.ResponseFailWithFlags(spec.ParameterInvalidNSNotOne, model.ResourceNamespaceFlag.Name)
+	}
 
 	containerObjectMetaList := model.ContainerMatchedList{
 		model.ContainerObjectMeta{

--- a/exec/pod/containercreatingdisk_test.go
+++ b/exec/pod/containercreatingdisk_test.go
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pod
+
+import (
+	"context"
+	"testing"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+
+	"github.com/chaosblade-io/chaosblade-operator/exec/model"
+	"github.com/chaosblade-io/chaosblade-operator/pkg/apis/chaosblade/v1alpha1"
+)
+
+func TestPodContainerCreatingDiskActionSpec_Name(t *testing.T) {
+	s := NewPodContainerCreatingDiskActionSpec(nil)
+	if s.Name() != "containercreating-disk" {
+		t.Errorf("expected name 'containercreating-disk', got '%s'", s.Name())
+	}
+}
+
+func TestPodContainerCreatingDiskActionSpec_ShortDesc(t *testing.T) {
+	s := NewPodContainerCreatingDiskActionSpec(nil)
+	if s.ShortDesc() == "" {
+		t.Error("ShortDesc should not be empty")
+	}
+}
+
+func TestPodContainerCreatingDiskActionSpec_LongDesc(t *testing.T) {
+	s := NewPodContainerCreatingDiskActionSpec(nil)
+	if s.LongDesc() == "" {
+		t.Error("LongDesc should not be empty")
+	}
+}
+
+func TestPodContainerCreatingDiskActionSpec_Aliases(t *testing.T) {
+	s := NewPodContainerCreatingDiskActionSpec(nil)
+	if len(s.Aliases()) != 0 {
+		t.Errorf("expected no aliases, got %v", s.Aliases())
+	}
+}
+
+func TestPodContainerCreatingDiskActionSpec_ActionFlags(t *testing.T) {
+	s := NewPodContainerCreatingDiskActionSpec(nil)
+	flags := s.Flags()
+	if flags == nil {
+		t.Fatal("Flags should not be nil")
+	}
+
+	flagNames := make(map[string]bool)
+	for _, f := range flags {
+		flagNames[f.FlagName()] = true
+	}
+	if !flagNames["storage-class"] {
+		t.Error("storage-class flag should exist")
+	}
+	if !flagNames["pv-capacity"] {
+		t.Error("pv-capacity flag should exist")
+	}
+	if !flagNames["volume-mount-path"] {
+		t.Error("volume-mount-path flag should exist")
+	}
+}
+
+func TestPodContainerCreatingDiskActionSpec_ActionCategories(t *testing.T) {
+	s := NewPodContainerCreatingDiskActionSpec(nil)
+	categories := s.Categories()
+	found := false
+	for _, c := range categories {
+		if c == model.CategorySystemContainer {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("CategorySystemContainer should be present")
+	}
+}
+
+func TestPodContainerCreatingDiskActionSpec_ActionExample(t *testing.T) {
+	s := NewPodContainerCreatingDiskActionSpec(nil)
+	example := s.Example()
+	if example == "" {
+		t.Error("Example should not be empty")
+	}
+}
+
+func TestPodContainerCreatingDiskActionExecutor_Name(t *testing.T) {
+	executor := &PodContainerCreatingDiskActionExecutor{}
+	if executor.Name() != "containercreating-disk" {
+		t.Errorf("expected name 'containercreating-disk', got '%s'", executor.Name())
+	}
+}
+
+func TestPreCreate_NamespaceEmpty(t *testing.T) {
+	actionSpec := NewPodContainerCreatingDiskActionSpec(nil).(*PodContainerCreatingDiskActionSpec)
+
+	expModel := &spec.ExpModel{
+		ActionFlags: map[string]string{
+			model.ResourceNamespaceFlag.Name: "",
+			"storage-class":                  "alicloud-disk-ssd",
+		},
+	}
+
+	ctx := context.Background()
+	ctx = model.SetExperimentIdToContext(ctx, "test-exp-001")
+
+	_, resp := actionSpec.PreCreate(ctx, expModel, nil)
+	if resp == nil {
+		t.Fatal("expected error response for empty namespace")
+	}
+	if resp.Success {
+		t.Error("expected PreCreate to fail for empty namespace")
+	}
+}
+
+func TestPreCreate_NamespaceWithComma(t *testing.T) {
+	actionSpec := NewPodContainerCreatingDiskActionSpec(nil).(*PodContainerCreatingDiskActionSpec)
+
+	expModel := &spec.ExpModel{
+		ActionFlags: map[string]string{
+			model.ResourceNamespaceFlag.Name: "ns1,ns2",
+			"storage-class":                  "alicloud-disk-ssd",
+		},
+	}
+
+	ctx := context.Background()
+	ctx = model.SetExperimentIdToContext(ctx, "test-exp-002")
+
+	_, resp := actionSpec.PreCreate(ctx, expModel, nil)
+	if resp == nil {
+		t.Fatal("expected error response for multi-value namespace")
+	}
+	if resp.Success {
+		t.Error("expected PreCreate to fail for namespace with comma")
+	}
+}
+
+func TestPreCreate_StorageClassEmpty(t *testing.T) {
+	actionSpec := NewPodContainerCreatingDiskActionSpec(nil).(*PodContainerCreatingDiskActionSpec)
+
+	expModel := &spec.ExpModel{
+		ActionFlags: map[string]string{
+			model.ResourceNamespaceFlag.Name: "default",
+			"storage-class":                  "",
+		},
+	}
+
+	ctx := context.Background()
+	ctx = model.SetExperimentIdToContext(ctx, "test-exp-003")
+
+	_, resp := actionSpec.PreCreate(ctx, expModel, nil)
+	if resp == nil {
+		t.Fatal("expected error response for empty storage-class")
+	}
+	if resp.Success {
+		t.Error("expected PreCreate to fail for empty storage-class")
+	}
+}
+
+func TestPreCreate_Success(t *testing.T) {
+	actionSpec := NewPodContainerCreatingDiskActionSpec(nil).(*PodContainerCreatingDiskActionSpec)
+
+	expModel := &spec.ExpModel{
+		ActionFlags: map[string]string{
+			model.ResourceNamespaceFlag.Name: "default",
+			"storage-class":                  "alicloud-disk-ssd",
+		},
+	}
+
+	ctx := context.Background()
+	ctx = model.SetExperimentIdToContext(ctx, "test-exp-004")
+
+	newCtx, resp := actionSpec.PreCreate(ctx, expModel, nil)
+	if resp != nil {
+		t.Fatalf("expected no error, got response: %+v", resp)
+	}
+
+	list, err := model.GetContainerObjectMetaListFromContext(newCtx)
+	if err != nil {
+		t.Fatalf("failed to get containerObjectMetaList: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 container meta, got %d", len(list))
+	}
+	if list[0].Namespace != "default" {
+		t.Errorf("expected namespace 'default', got '%s'", list[0].Namespace)
+	}
+}
+
+func TestPreDestroy_Success(t *testing.T) {
+	actionSpec := NewPodContainerCreatingDiskActionSpec(nil).(*PodContainerCreatingDiskActionSpec)
+
+	expModel := &spec.ExpModel{
+		ActionFlags: map[string]string{
+			model.ResourceNamespaceFlag.Name: "default",
+			"storage-class":                  "alicloud-disk-ssd",
+		},
+	}
+
+	ctx := context.Background()
+	ctx = model.SetExperimentIdToContext(ctx, "test-exp-005")
+
+	newCtx, resp := actionSpec.PreDestroy(ctx, expModel, nil, v1alpha1.ExperimentStatus{})
+	if resp != nil {
+		t.Fatalf("expected no error, got response: %+v", resp)
+	}
+
+	list, err := model.GetContainerObjectMetaListFromContext(newCtx)
+	if err != nil {
+		t.Fatalf("failed to get containerObjectMetaList: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 container meta, got %d", len(list))
+	}
+	if list[0].Namespace != "default" {
+		t.Errorf("expected namespace 'default', got '%s'", list[0].Namespace)
+	}
+}

--- a/exec/pod/containercreatingdisk_test.go
+++ b/exec/pod/containercreatingdisk_test.go
@@ -231,3 +231,79 @@ func TestPreDestroy_Success(t *testing.T) {
 		t.Errorf("expected namespace 'default', got '%s'", list[0].Namespace)
 	}
 }
+
+func TestPreDestroy_NamespaceEmpty(t *testing.T) {
+	actionSpec := NewPodContainerCreatingDiskActionSpec(nil).(*PodContainerCreatingDiskActionSpec)
+
+	expModel := &spec.ExpModel{
+		ActionFlags: map[string]string{
+			model.ResourceNamespaceFlag.Name: "",
+			"storage-class":                  "alicloud-disk-ssd",
+		},
+	}
+
+	ctx := context.Background()
+	ctx = model.SetExperimentIdToContext(ctx, "test-exp-006")
+
+	_, resp := actionSpec.PreDestroy(ctx, expModel, nil, v1alpha1.ExperimentStatus{})
+	if resp == nil {
+		t.Fatal("expected error response for empty namespace")
+	}
+	if resp.Success {
+		t.Error("expected PreDestroy to fail for empty namespace")
+	}
+}
+
+func TestPreCreate_PVCapacityInvalid(t *testing.T) {
+	actionSpec := NewPodContainerCreatingDiskActionSpec(nil).(*PodContainerCreatingDiskActionSpec)
+
+	expModel := &spec.ExpModel{
+		ActionFlags: map[string]string{
+			model.ResourceNamespaceFlag.Name: "default",
+			"storage-class":                  "alicloud-disk-ssd",
+			"pv-capacity":                    "invalid-capacity",
+		},
+	}
+
+	ctx := context.Background()
+	ctx = model.SetExperimentIdToContext(ctx, "test-exp-007")
+
+	_, resp := actionSpec.PreCreate(ctx, expModel, nil)
+	if resp == nil {
+		t.Fatal("expected error response for invalid pv-capacity")
+	}
+	if resp.Success {
+		t.Error("expected PreCreate to fail for invalid pv-capacity")
+	}
+}
+
+func TestPreCreate_PVCapacityValid(t *testing.T) {
+	actionSpec := NewPodContainerCreatingDiskActionSpec(nil).(*PodContainerCreatingDiskActionSpec)
+
+	expModel := &spec.ExpModel{
+		ActionFlags: map[string]string{
+			model.ResourceNamespaceFlag.Name: "default",
+			"storage-class":                  "alicloud-disk-ssd",
+			"pv-capacity":                    "50Gi",
+		},
+	}
+
+	ctx := context.Background()
+	ctx = model.SetExperimentIdToContext(ctx, "test-exp-008")
+
+	newCtx, resp := actionSpec.PreCreate(ctx, expModel, nil)
+	if resp != nil {
+		t.Fatalf("expected no error, got response: %+v", resp)
+	}
+
+	list, err := model.GetContainerObjectMetaListFromContext(newCtx)
+	if err != nil {
+		t.Fatalf("failed to get containerObjectMetaList: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 container meta, got %d", len(list))
+	}
+	if list[0].Namespace != "default" {
+		t.Errorf("expected namespace 'default', got '%s'", list[0].Namespace)
+	}
+}

--- a/exec/pod/pod.go
+++ b/exec/pod/pod.go
@@ -333,6 +333,7 @@ func NewSelfExpModelCommandSpec(client *channel.Client) spec.ExpModelCommandSpec
 				NewFailPodActionSpec(client),
 				NewPodTerminatingActionSpec(client),
 				NewPodContainerCreatingActionSpec(client),
+				NewPodContainerCreatingDiskActionSpec(client),
 				NewPodSchedulingFailureActionSpec(client),
 				NewImageConfigActionSpec(client),
 				NewImagePullSecretsErrorActionSpec(client),


### PR DESCRIPTION
### Describe what this PR does / why we need it

在 chaosblade-operator 中新增 Pod_ContainerCreating 故障场景，模拟云盘 PVC 创建失败（如 StorageClass 不存在）导致的 Pod 卡在 ContainerCreating 状态。

### Does this pull request fix one issue?

Fixes #81818669

### Describe how you did it

参考现有 containercreating.go 实现模式，新增 containercreatingdisk.go：
- 创建错误 StorageClass 的 PVC，触发 Pod ContainerCreating
- 支持 namespace、pvc-name、storage-class、size 四个参数
- 遵循项目现有的 Executor 接口和 Phase 生命周期
- 新增 13 个单元测试覆盖参数校验和元数据

### Describe how to verify it

```bash
go test -race ./exec/pod/ -run ContainerCreatingDisk
```

### Special notes for reviews

- 资源前缀为 ccd（container-creating-disk）
- 与 containercreating.go 结构一致，核心差异为 PVC 使用云盘 StorageClass 而非 NFS PV