### PR TITLE
fix(ci): reformat code with gofumpt v0.10.0 and pin version

### DIFF
--- a/channel/client.go
+++ b/channel/client.go
@@ -100,7 +100,8 @@ func (c *Client) Exec(options *ExecOptions) interface{} {
 				Stdout:    true,
 				Stderr:    true,
 				TTY:       options.TTY,
-			}, scheme.ParameterCodec)
+			}, scheme.ParameterCodec,
+		)
 	output := bytes.NewBuffer([]byte{})
 	options.Out = output
 	errput := bytes.NewBuffer([]byte{})

--- a/exec/container/container.go
+++ b/exec/container/container.go
@@ -80,7 +80,8 @@ blade create k8s container-process kill --process nginx --names nginx-app --cont
 
 # Use blade CLI
 # Specifies the signal and local port to kill the process in the container
-blade create k8s container-process kill --local-port 8080 --signal 15 --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default`)
+blade create k8s container-process kill --local-port 8080 --signal 15 --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default`,
+				)
 
 			case *process.StopProcessActionCommandSpec:
 				action.SetLongDesc("The process scenario in container is the same as the basic resource process scenario")
@@ -90,7 +91,8 @@ blade create k8s container-process kill --local-port 8080 --signal 15 --names ng
 blade create k8s container-process stop --process nginx --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default
 
 # Pause the Java process in the container
-blade create k8s container-process stop --process-cmd java --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default`)
+blade create k8s container-process stop --process-cmd java --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default`,
+				)
 
 			case *cpu.FullLoadActionCommand:
 				action.SetLongDesc("The CPU load experiment scenario in container is the same as the CPU scenario of basic resources")
@@ -109,7 +111,8 @@ blade create k8s container-cpu load --cpu-list 0,3 --names nginx-app --container
 blade create k8s container-cpu load --cpu-list 1-3 --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default
 
 # Specified percentage load in the container
-blade create k8s container-cpu load --cpu-percent 60 --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default`)
+blade create k8s container-cpu load --cpu-percent 60 --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default`,
+				)
 
 			case *disk.FillActionSpec:
 				action.SetLongDesc("The disk fill scenario experiment in the container")
@@ -123,7 +126,8 @@ blade create k8s container-disk fill --path /home --percent 80 --retain-handle -
 
 # Perform a fixed-size experimental scenario in the container
 blade c k8s container-disk fill --path /home --reserve 1024 --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default
-`)
+`,
+				)
 			case *disk.BurnActionSpec:
 				action.SetLongDesc("Disk read and write IO load experiment in the container")
 				action.SetExample(
@@ -134,7 +138,8 @@ blade create k8s container-disk burn --read --path /home --names nginx-app --con
 blade create k8s container-disk burn --write --path /home --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default8
 
 # Read and write IO load scenarios are performed at the same time. Path is not specified. The default is /
-blade create k8s container-disk burn --read --write --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default`)
+blade create k8s container-disk burn --read --write --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default`,
+				)
 
 			case *mem.MemLoadActionCommand:
 				action.SetLongDesc("The memory fill experiment scenario in container")
@@ -152,7 +157,8 @@ blade create k8s container-mem load --mode ram --mem-percent 50 --include-buffer
 blade create k8s container-mem load --mode ram --mem-percent 50 --timeout 200 --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default
 
 # 200M memory is reserved
-blade create k8s container-mem load --mode ram --reserve 200 --rate 100 --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default`)
+blade create k8s container-mem load --mode ram --reserve 200 --rate 100 --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default`,
+				)
 			case *file.FileAppendActionSpec:
 				action.SetLongDesc("The file append experiment scenario in container")
 				action.SetExample(
@@ -167,7 +173,8 @@ blade create k8s container-file append --filepath=/home/logs/nginx.log --content
 
 # mock interface timeout exception
 blade create k8s container-file append --filepath=/home/logs/nginx.log --content="@{DATE:+%Y-%m-%d %H:%M:%S} ERROR invoke getUser timeout [@{RANDOM:100-200}]ms abc  mock exception" --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default
-`)
+`,
+				)
 			case *file.FileAddActionSpec:
 				action.SetLongDesc("The file add experiment scenario in container")
 				action.SetExample(
@@ -182,7 +189,8 @@ blade create k8s container-file add --filepath /temp/nginx.log --auto-create-dir
 
 # Create a directory named /nginx in the /temp directory and automatically create directories that don't exist
 blade create k8s container-file add --directory --filepath /temp/nginx --auto-create-dir --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default
-`)
+`,
+				)
 
 			case *file.FileChmodActionSpec:
 				action.SetLongDesc("The file permission modification scenario in container")
@@ -197,7 +205,8 @@ blade create k8s container-file delete --filepath /home/logs/nginx.log --names n
 
 # Force delete the file /home/logs/nginx.log unrecoverable
 blade create k8s container-file delete --filepath /home/logs/nginx.log --force --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default
-`)
+`,
+				)
 			case *file.FileMoveActionSpec:
 				action.SetExample("The file move scenario in container")
 				action.SetExample(`# Move the file /home/logs/nginx.log to /tmp
@@ -218,15 +227,18 @@ blade create k8s container-network delay --time 3000 --offset 1000 --interface e
 blade create k8s container-network delay --time 3000 --interface eth0 --remote-port 80 --destination-ip 14.215.177.39 --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default
 
 # Do a 5 second delay for the entire network card eth0, excluding ports 22 and 8000 to 8080
-blade create k8s container-network delay --time 5000 --interface eth0 --exclude-port 22,8000-8080 --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default`)
+blade create k8s container-network delay --time 5000 --interface eth0 --exclude-port 22,8000-8080 --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default`,
+				)
 			case *network.DropActionSpec:
 				action.SetExample(
 					`# Experimental scenario of network shielding
-blade create k8s container-network drop --source-port 80 --network-traffic in --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default`)
+blade create k8s container-network drop --source-port 80 --network-traffic in --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default`,
+				)
 			case *network.DnsActionSpec:
 				action.SetExample(
 					`# The domain name www.baidu.com is not accessible
-blade create k8s container-network dns --domain www.baidu.com --ip 10.0.0.0 --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default`)
+blade create k8s container-network dns --domain www.baidu.com --ip 10.0.0.0 --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default`,
+				)
 			case *tc.LossActionSpec:
 				action.SetExample(`# Access to native 8080 and 8081 ports lost 70% of packets
 blade create k8s container-network loss --percent 70 --interface eth0 --local-port 8080,8081 --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default
@@ -267,17 +279,20 @@ blade create k8s container-script exit --exit-code 1 --exit-message this-is-erro
 # Remove container in pod
 blade create k8s container-container remove --names cart-redis-77 --container-names cart-redis --namespace default --kubeconfig ~/.kube/config`)
 			default:
-				action.SetExample(strings.Replace(action.Example(),
+				action.SetExample(strings.Replace(
+					action.Example(),
 					fmt.Sprintf("blade create %s %s", expModelSpec.Name(), action.Name()),
 					fmt.Sprintf("blade create k8s container-%s %s --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default", expModelSpec.Name(), action.Name()),
 					-1,
 				))
-				action.SetExample(strings.Replace(action.Example(),
+				action.SetExample(strings.Replace(
+					action.Example(),
 					fmt.Sprintf("blade c %s %s", expModelSpec.Name(), action.Name()),
 					fmt.Sprintf("blade c k8s container-%s %s --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default", expModelSpec.Name(), action.Name()),
 					-1,
 				))
-				action.SetExample(strings.Replace(action.Example(),
+				action.SetExample(strings.Replace(
+					action.Example(),
 					fmt.Sprintf("blade create docker %s %s", expModelSpec.Name(), action.Name()),
 					fmt.Sprintf("blade create k8s container-%s %s --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default", expModelSpec.Name(), action.Name()),
 					-1,

--- a/exec/container/controller.go
+++ b/exec/container/controller.go
@@ -83,14 +83,16 @@ func (e *ExpController) Create(ctx context.Context, expSpec v1alpha1.ExperimentS
 		errMsg := spec.ParameterInvalid.Sprintf(
 			strings.Join([]string{model.ContainerIdsFlag.Name, model.ContainerNamesFlag.Name, model.ContainerIndexFlag.Name}, "|"),
 			strings.Join([]string{containerIdsValue, containerNamesValue, containerIndexValue}, "|"),
-			"cannot find the containers")
+			"cannot find the containers",
+		)
 		logrusField.Errorln(errMsg)
 		response := spec.ResponseFailWithResult(
 			spec.ParameterInvalid,
 			v1alpha1.CreateFailExperimentStatus(errMsg, []v1alpha1.ResourceStatus{}),
 			strings.Join([]string{model.ContainerIdsFlag.Name, model.ContainerNamesFlag.Name, model.ContainerIndexFlag.Name}, "|"),
 			strings.Join([]string{containerIdsValue, containerNamesValue, containerIndexValue}, "|"),
-			"cannot find the containers")
+			"cannot find the containers",
+		)
 		return response
 	}
 	ctx = model.SetContainerObjectMetaListToContext(ctx, containerObjectMetaList)

--- a/exec/model/download.go
+++ b/exec/model/download.go
@@ -84,7 +84,8 @@ func (d *DownloadOptions) DeployToPod(experimentId, src, dest string) error {
 			"container":    d.Container,
 			"command":      command,
 			"result":       statusCode,
-		}).Infof("download to the target container")
+		},
+	).Infof("download to the target container")
 	code, err := strconv.Atoi(strings.TrimSpace(statusCode))
 	if err != nil {
 		return errors.New(statusCode)
@@ -124,7 +125,8 @@ func (d *DownloadOptions) uncompress(experimentId, file string) error {
 			"container":    d.Container,
 			"command":      command,
 			"result":       error,
-		}).Infof("uncompress in the target container")
+		},
+	).Infof("uncompress in the target container")
 	if error == nil {
 		return nil
 	}

--- a/exec/model/executor_copy.go
+++ b/exec/model/executor_copy.go
@@ -412,7 +412,8 @@ func getNewContainerIdByPod(podName, podNamespace, containerName, experimentId s
 			logrus.Fields{
 				"experiment":    experimentId,
 				"containerName": containerName,
-			}).Warningf("can not find the pod by %s name in %s namespace, %v", podName, podNamespace, err)
+			},
+		).Warningf("can not find the pod by %s name in %s namespace, %v", podName, podNamespace, err)
 		return "", err
 	}
 	containerStatuses := pod.Status.ContainerStatuses

--- a/exec/node/node.go
+++ b/exec/node/node.go
@@ -90,7 +90,8 @@ blade create k8s node-cpu load --cpu-list 1-3 --names izbp1a4jchbdwkwi5hk7ekz --
 ## using SSH channel
 blade create k8s node-cpu load --cpu-percent 60 --channel ssh --ssh-host 192.168.1.100 --ssh-user root
 ## using DaemonSet
-blade create k8s node-cpu load --cpu-percent 60 --names izbp1a4jchbdwkwi5hk7ekz --kubeconfig ~/.kube/config --timeout 30`)
+blade create k8s node-cpu load --cpu-percent 60 --names izbp1a4jchbdwkwi5hk7ekz --kubeconfig ~/.kube/config --timeout 30`,
+				)
 			case *tc.DelayActionSpec:
 				action.SetLongDesc(` The network delay experiment scenario for k8s node.
 !!! Using DaemonSet may result in failure to use the kubernetes API for destroy experiment.
@@ -113,7 +114,8 @@ blade create k8s node-network delay --time 3000 --interface eth0 --remote-port 8
 ## using SSH channel
 blade create k8s node-network delay --time 5000 --interface eth0 --exclude-port 22,8000-8080 --channel ssh --ssh-host 192.168.1.100 --ssh-user root
 ## using DaemonSet
-blade create k8s node-network delay --time 5000 --interface eth0 --exclude-port 22,8000-8080 --names izbp1a4jchbdwkwi5hk7ekz --kubeconfig ~/.kube/config --timeout 30`)
+blade create k8s node-network delay --time 5000 --interface eth0 --exclude-port 22,8000-8080 --names izbp1a4jchbdwkwi5hk7ekz --kubeconfig ~/.kube/config --timeout 30`,
+				)
 			case *network.DropActionSpec:
 				action.SetLongDesc(`!!! Using DaemonSet may result in failure to use the kubernetes API for destroy experiment.
 !!! Please use caution, add a timeout parameter for automatic destroy, or use the SSH channel.`)
@@ -122,7 +124,8 @@ blade create k8s node-network delay --time 5000 --interface eth0 --exclude-port 
 ## using SSH channel
 blade create k8s node-network drop --source-port 80 --network-traffic in --channel ssh --ssh-host 192.168.1.100 --ssh-user root
 ## using DaemonSet
-blade create k8s node-network drop --source-port 80 --network-traffic in --names izbp1a4jchbdwkwi5hk7ekz --kubeconfig ~/.kube/config --timeout 30`)
+blade create k8s node-network drop --source-port 80 --network-traffic in --names izbp1a4jchbdwkwi5hk7ekz --kubeconfig ~/.kube/config --timeout 30`,
+				)
 			case *network.DnsActionSpec:
 				action.SetLongDesc(`
 !!! Using DaemonSet may result in failure to use the kubernetes API for destroy experiment.
@@ -132,7 +135,8 @@ blade create k8s node-network drop --source-port 80 --network-traffic in --names
 ## using SSH channel
 blade create k8s node-network dns --domain www.baidu.com --ip 10.0.0.0 --channel ssh --ssh-host 192.168.1.100 --ssh-user root
 ## using DaemonSet
-blade create k8s node-network dns --domain www.baidu.com --ip 10.0.0.0 --channel ssh --names izbp1a4jchbdwkwi5hk7ekz --kubeconfig ~/.kube/config --timeout 30`)
+blade create k8s node-network dns --domain www.baidu.com --ip 10.0.0.0 --channel ssh --names izbp1a4jchbdwkwi5hk7ekz --kubeconfig ~/.kube/config --timeout 30`,
+				)
 			case *tc.LossActionSpec:
 				action.SetLongDesc(`
 !!! Using DaemonSet may result in failure to use the kubernetes API for destroy experiment.
@@ -216,7 +220,8 @@ blade create k8s node-process kill --process nginx --names izbp1a4jchbdwkwi5hk7e
 ## using SSH channel
 blade create k8s node-process kill --local-port 8080 --signal 15 --channel ssh --ssh-host 192.168.1.100 --ssh-user root
 ## using DaemonSet
-blade create k8s node-process kill --local-port 8080 --signal 15 --names izbp1a4jchbdwkwi5hk7ekz --kubeconfig ~/.kube/config --timeout 30`)
+blade create k8s node-process kill --local-port 8080 --signal 15 --names izbp1a4jchbdwkwi5hk7ekz --kubeconfig ~/.kube/config --timeout 30`,
+				)
 
 			case *process.StopProcessActionCommandSpec:
 				action.SetLongDesc("The process scenario in container is the same as the basic resource process scenario")
@@ -232,7 +237,8 @@ blade create k8s node-process stop --process nginx --names izbp1a4jchbdwkwi5hk7e
 ## using SSH channel
 blade create k8s node-process stop --process-cmd java --channel ssh --ssh-host 192.168.1.100 --ssh-user root
 ## using DaemonSet
-blade create k8s node-process stop --process-cmd java --names izbp1a4jchbdwkwi5hk7ekz --kubeconfig ~/.kube/config --timeout 30`)
+blade create k8s node-process stop --process-cmd java --names izbp1a4jchbdwkwi5hk7ekz --kubeconfig ~/.kube/config --timeout 30`,
+				)
 			case *disk.FillActionSpec:
 				action.SetLongDesc("The disk fill scenario experiment in the node")
 				action.SetExample(
@@ -253,7 +259,8 @@ blade create k8s node-disk fill --path /home --percent 80 --retain-handle --name
 ## using SSH channel
 blade c k8s node-disk fill --path /home --reserve 1024 --channel ssh --ssh-host 192.168.1.100 --ssh-user root
 ## using DaemonSet
-blade c k8s node-disk fill --path /home --reserve 1024 --names izbp1a4jchbdwkwi5hk7ekz --kubeconfig ~/.kube/config --timeout 30`)
+blade c k8s node-disk fill --path /home --reserve 1024 --names izbp1a4jchbdwkwi5hk7ekz --kubeconfig ~/.kube/config --timeout 30`,
+				)
 			case *disk.BurnActionSpec:
 				action.SetLongDesc("Disk read and write IO load experiment in the node")
 				action.SetExample(
@@ -273,7 +280,8 @@ blade create k8s node-disk burn --write --path /home --names izbp1a4jchbdwkwi5hk
 ## using SSH channel
 blade create k8s node-disk burn --read --write --channel ssh --ssh-host 192.168.1.100 --ssh-user root
 ## using DaemonSet
-blade create k8s node-disk burn --read --write --names izbp1a4jchbdwkwi5hk7ekz --kubeconfig ~/.kube/config --timeout 30`)
+blade create k8s node-disk burn --read --write --names izbp1a4jchbdwkwi5hk7ekz --kubeconfig ~/.kube/config --timeout 30`,
+				)
 			case *disk.UnmountStuckActionSpec:
 				action.SetLongDesc("Simulate volume unmount stuck by holding file handles in the node")
 				action.SetExample(
@@ -281,7 +289,8 @@ blade create k8s node-disk burn --read --write --names izbp1a4jchbdwkwi5hk7ekz -
 ## using SSH channel
 blade create k8s node-disk unmount_stuck --path /mnt/data --channel ssh --ssh-host 192.168.1.100 --ssh-user root
 ## using DaemonSet
-blade create k8s node-disk unmount_stuck --path /mnt/data --names izbp1a4jchbdwkwi5hk7ekz --kubeconfig ~/.kube/config --timeout 30`)
+blade create k8s node-disk unmount_stuck --path /mnt/data --names izbp1a4jchbdwkwi5hk7ekz --kubeconfig ~/.kube/config --timeout 30`,
+				)
 			case *mem.MemLoadActionCommand:
 				action.SetLongDesc("The memory fill experiment scenario in container")
 				action.SetExample(
@@ -313,7 +322,8 @@ blade create k8s node-mem load --mode ram --mem-percent 50 --timeout 200 --names
 ## using SSH channel
 blade create k8s node-mem load --mode ram --reserve 200 --rate 100 --channel ssh --ssh-host 192.168.1.100 --ssh-user root
 ## using DaemonSet
-blade create k8s node-mem load --mode ram --reserve 200 --rate 100 --names izbp1a4jchbdwkwi5hk7ekz --kubeconfig ~/.kube/config --timeout 30`)
+blade create k8s node-mem load --mode ram --reserve 200 --rate 100 --names izbp1a4jchbdwkwi5hk7ekz --kubeconfig ~/.kube/config --timeout 30`,
+				)
 			case *file.FileAppendActionSpec:
 				action.SetLongDesc("The file append experiment scenario in container")
 				action.SetExample(
@@ -327,7 +337,8 @@ blade create k8s node-file append --filepath=/home/logs/nginx.log --content=SEVM
 
 # mock interface timeout exception
 blade create k8s node-file append --filepath=/home/logs/nginx.log --content="@{DATE:+%Y-%m-%d %H:%M:%S} ERROR invoke getUser timeout [@{RANDOM:100-200}]ms abc  mock exception" --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default
-`)
+`,
+				)
 			case *file.FileAddActionSpec:
 				action.SetLongDesc("The file add experiment scenario in container")
 				action.SetExample(
@@ -342,7 +353,8 @@ blade create k8s node-file add --filepath /temp/nginx.log --auto-create-dir --na
 
 # Create a directory named /nginx in the /temp directory and automatically create directories that don't exist
 blade create k8s node-file add --directory --filepath /temp/nginx --auto-create-dir --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default
-`)
+`,
+				)
 			case *file.FileChmodActionSpec:
 				action.SetLongDesc("The file permission modification scenario in container")
 				action.SetExample(`# Modify /home/logs/nginx.log file permissions to 777
@@ -356,7 +368,8 @@ blade create k8s node-file delete --filepath /home/logs/nginx.log --names nginx-
 
 # Force delete the file /home/logs/nginx.log unrecoverable
 blade create k8s node-file delete --filepath /home/logs/nginx.log --force --names nginx-app --container-ids f1de335b4eeaf --kubeconfig ~/.kube/config --namespace default
-`)
+`,
+				)
 			case *file.FileMoveActionSpec:
 				action.SetExample("The file move scenario in container")
 				action.SetExample(`# Move the file /home/logs/nginx.log to /tmp
@@ -381,7 +394,8 @@ blade create k8s node-file fdleak --percent 50 --names izbp1a4jchbdwkwi5hk7ekz -
 ## using SSH channel
 blade create k8s node-file fdleak --percent 80 --directory /tmp --channel ssh --ssh-host 192.168.1.100 --ssh-user root
 ## using DaemonSet
-blade create k8s node-file fdleak --percent 80 --directory /tmp --names izbp1a4jchbdwkwi5hk7ekz --kubeconfig ~/.kube/config --timeout 30`)
+blade create k8s node-file fdleak --percent 80 --directory /tmp --names izbp1a4jchbdwkwi5hk7ekz --kubeconfig ~/.kube/config --timeout 30`,
+				)
 			case *script.ScriptDelayActionCommand:
 				action.SetExample(`
 # Add commands to the script "start0() { sleep 10.000000 ...}"
@@ -397,12 +411,14 @@ blade create k8s node-script exit --exit-code 1 --exit-message this-is-error-mes
 ## using DaemonSet
 blade create k8s node-script exit --exit-code 1 --exit-message this-is-error-message --file test.sh --function-name start0 --names izbp1a4jchbdwkwi5hk7ekz --kubeconfig ~/.kube/config --timeout 30`)
 			default:
-				action.SetExample(strings.Replace(action.Example(),
+				action.SetExample(strings.Replace(
+					action.Example(),
 					fmt.Sprintf("blade create %s %s", expModelSpec.Name(), action.Name()),
 					fmt.Sprintf("blade create k8s node-%s %s --names nginx-app --channel ssh --ssh-host 192.168.1.100 --ssh-user root", expModelSpec.Name(), action.Name()),
 					-1,
 				))
-				action.SetExample(strings.Replace(action.Example(),
+				action.SetExample(strings.Replace(
+					action.Example(),
 					fmt.Sprintf("blade c %s %s", expModelSpec.Name(), action.Name()),
 					fmt.Sprintf("blade c k8s node-%s %s --names nginx-app --channel ssh --ssh-host 192.168.1.100 --ssh-user root", expModelSpec.Name(), action.Name()),
 					-1,

--- a/exec/pod/configmapdeleteexp.go
+++ b/exec/pod/configmapdeleteexp.go
@@ -144,7 +144,8 @@ func (d *ConfigMapDeleteActionExecutor) create(ctx context.Context, expModel *sp
 		if !isPodReady(pod) {
 			logrusField.Infof("pod %s/%s is not ready, skip", c.Namespace, c.PodName)
 			status = status.CreateFailResourceStatus(
-				fmt.Sprintf("pod %s is not ready", c.PodName), spec.K8sExecFailed.Code)
+				fmt.Sprintf("pod %s is not ready", c.PodName), spec.K8sExecFailed.Code,
+			)
 			statuses = append(statuses, status)
 			continue
 		}
@@ -167,7 +168,8 @@ func (d *ConfigMapDeleteActionExecutor) create(ctx context.Context, expModel *sp
 			if err := d.client.Get(ctx, types.NamespacedName{Name: resolvedCMName, Namespace: c.Namespace}, originalCM); err != nil {
 				logrusField.Errorf("get configmap %s/%s failed: %v", c.Namespace, resolvedCMName, err)
 				status = status.CreateFailResourceStatus(
-					fmt.Sprintf("configmap %s not found in namespace %s", resolvedCMName, c.Namespace), spec.K8sExecFailed.Code)
+					fmt.Sprintf("configmap %s not found in namespace %s", resolvedCMName, c.Namespace), spec.K8sExecFailed.Code,
+				)
 				statuses = append(statuses, status)
 				continue
 			}
@@ -176,7 +178,8 @@ func (d *ConfigMapDeleteActionExecutor) create(ctx context.Context, expModel *sp
 			if err := d.createBackupConfigMap(ctx, experimentId, originalCM); err != nil {
 				logrusField.Errorf("create backup configmap for %s/%s failed: %v", c.Namespace, resolvedCMName, err)
 				status = status.CreateFailResourceStatus(
-					fmt.Sprintf("create backup configmap failed: %v", err), spec.K8sExecFailed.Code)
+					fmt.Sprintf("create backup configmap failed: %v", err), spec.K8sExecFailed.Code,
+				)
 				statuses = append(statuses, status)
 				continue
 			}
@@ -193,7 +196,8 @@ func (d *ConfigMapDeleteActionExecutor) create(ctx context.Context, expModel *sp
 					logrusField.Warningf("rollback: delete backup configmap %s failed: %v", backupName, rbErr)
 				}
 				status = status.CreateFailResourceStatus(
-					fmt.Sprintf("delete configmap %s failed: %v", resolvedCMName, err), spec.K8sExecFailed.Code)
+					fmt.Sprintf("delete configmap %s failed: %v", resolvedCMName, err), spec.K8sExecFailed.Code,
+				)
 				statuses = append(statuses, status)
 				continue
 			}
@@ -212,12 +216,14 @@ func (d *ConfigMapDeleteActionExecutor) create(ctx context.Context, expModel *sp
 				logrusField.Errorf("rollback: restore configmap from backup %s failed: %v, manual intervention required", backupName, restoreErr)
 				status = status.CreateFailResourceStatus(
 					fmt.Sprintf("configmap %s has been deleted but restore failed: %v, manual intervention required", resolvedCMName, restoreErr),
-					spec.K8sExecFailed.Code)
+					spec.K8sExecFailed.Code,
+				)
 				statuses = append(statuses, status)
 				continue
 			}
 			status = status.CreateFailResourceStatus(
-				fmt.Sprintf("delete pod %s failed: %v", c.PodName, err), spec.K8sExecFailed.Code)
+				fmt.Sprintf("delete pod %s failed: %v", c.PodName, err), spec.K8sExecFailed.Code,
+			)
 			statuses = append(statuses, status)
 			continue
 		}
@@ -321,7 +327,8 @@ func (d *ConfigMapDeleteActionExecutor) destroy(ctx context.Context, expModel *s
 			} else {
 				logrusField.Errorf("delete pod %s/%s failed: %v", c.Namespace, c.PodName, err)
 				status = status.CreateFailResourceStatus(
-					fmt.Sprintf("delete pod %s failed: %v", c.PodName, err), spec.K8sExecFailed.Code)
+					fmt.Sprintf("delete pod %s failed: %v", c.PodName, err), spec.K8sExecFailed.Code,
+				)
 				statuses = append(statuses, status)
 				allSuccess = false
 				continue

--- a/exec/pod/fsexp.go
+++ b/exec/pod/fsexp.go
@@ -135,7 +135,8 @@ func (d *PodIOActionExecutor) create(ctx context.Context, expModel *spec.ExpMode
 		if err != nil {
 			logrusField.Errorf("get pod %s err, %v", c.PodName, err)
 			statuses = append(statuses, status.CreateFailResourceStatus(
-				spec.K8sExecFailed.Sprintf("get", err), spec.K8sExecFailed.Code))
+				spec.K8sExecFailed.Sprintf("get", err), spec.K8sExecFailed.Code,
+			))
 			continue
 		}
 		if !isPodReady(pod) {
@@ -147,7 +148,8 @@ func (d *PodIOActionExecutor) create(ctx context.Context, expModel *spec.ExpMode
 		if !ok && len(methods) != 0 {
 			logrusField.Error("method cannot be empty")
 			statuses = append(statuses, status.CreateFailResourceStatus(
-				spec.ParameterLess.Sprintf("method"), spec.ParameterLess.Code))
+				spec.ParameterLess.Sprintf("method"), spec.ParameterLess.Code,
+			))
 			continue
 		}
 
@@ -158,7 +160,8 @@ func (d *PodIOActionExecutor) create(ctx context.Context, expModel *spec.ExpMode
 			if err != nil {
 				logrusField.Error("delay must be integer")
 				statuses = append(statuses, status.CreateFailResourceStatus(
-					spec.ParameterIllegal.Sprintf("delay", delayStr, err), spec.ParameterIllegal.Code))
+					spec.ParameterIllegal.Sprintf("delay", delayStr, err), spec.ParameterIllegal.Code,
+				))
 				continue
 			}
 		}
@@ -167,7 +170,8 @@ func (d *PodIOActionExecutor) create(ctx context.Context, expModel *spec.ExpMode
 			if percent, err = strconv.Atoi(percentStr); err != nil {
 				logrusField.Error("percent must be integer")
 				statuses = append(statuses, status.CreateFailResourceStatus(
-					spec.ParameterIllegal.Sprintf("percent", percentStr, err), spec.ParameterIllegal.Code))
+					spec.ParameterIllegal.Sprintf("percent", percentStr, err), spec.ParameterIllegal.Code,
+				))
 				continue
 			}
 		}
@@ -177,7 +181,8 @@ func (d *PodIOActionExecutor) create(ctx context.Context, expModel *spec.ExpMode
 			if errno, err = strconv.Atoi(errnoStr); err != nil {
 				logrusField.Error("errno must be integer")
 				statuses = append(statuses, status.CreateFailResourceStatus(
-					spec.ParameterIllegal.Sprintf("errno", errnoStr, err), spec.ParameterIllegal.Code))
+					spec.ParameterIllegal.Sprintf("errno", errnoStr, err), spec.ParameterIllegal.Code,
+				))
 				continue
 			}
 		}
@@ -202,14 +207,16 @@ func (d *PodIOActionExecutor) create(ctx context.Context, expModel *spec.ExpMode
 			logrusField.WithField("pod", c.PodName).WithField("request", request).
 				Errorf("init chaosfs client failed: %v", err)
 			statuses = append(statuses, status.CreateFailResourceStatus(
-				spec.ChaosfsClientFailed.Sprintf(pod.Name, err), spec.ChaosfsClientFailed.Code))
+				spec.ChaosfsClientFailed.Sprintf(pod.Name, err), spec.ChaosfsClientFailed.Code,
+			))
 			continue
 		}
 		err = chaosfsClient.InjectFault(ctx, request)
 		if err != nil {
 			logrusField.Errorf("inject io exception in pod %s failed, request %v, err: %v", c.PodName, request, err)
 			statuses = append(statuses, status.CreateFailResourceStatus(
-				spec.ChaosfsInjectFailed.Sprintf(pod.Name, request, err), spec.ChaosfsInjectFailed.Code))
+				spec.ChaosfsInjectFailed.Sprintf(pod.Name, request, err), spec.ChaosfsInjectFailed.Code,
+			))
 			continue
 		}
 		statuses = append(statuses, status.CreateSuccessResourceStatus())
@@ -255,14 +262,16 @@ func (d *PodIOActionExecutor) destroy(ctx context.Context, expModel *spec.ExpMod
 		if err != nil {
 			logrusField.Errorf("init chaosfs client failed in pod %v, err: %v", pod.Name, err)
 			statuses = append(statuses, status.CreateFailResourceStatus(
-				spec.ChaosfsClientFailed.Sprintf(pod.Name, err), spec.ChaosfsClientFailed.Code))
+				spec.ChaosfsClientFailed.Sprintf(pod.Name, err), spec.ChaosfsClientFailed.Code,
+			))
 			continue
 		}
 		err = chaosfsClient.Revoke(ctx)
 		if err != nil {
 			logrusField.Errorf("recover io exception failed in pod  %v, err: %v", c.PodName, err)
 			statuses = append(statuses, status.CreateFailResourceStatus(
-				spec.ChaosfsRecoverFailed.Sprintf(pod.Name, err), spec.ChaosfsRecoverFailed.Code))
+				spec.ChaosfsRecoverFailed.Sprintf(pod.Name, err), spec.ChaosfsRecoverFailed.Code,
+			))
 			continue
 		}
 	}

--- a/exec/pod/imagepullsecretserror.go
+++ b/exec/pod/imagepullsecretserror.go
@@ -168,7 +168,8 @@ func (d *ImagePullSecretsErrorActionExecutor) create(uid string, ctx context.Con
 			if len(targetSecretRefs) == 0 {
 				logrusField.Warningf("pod %s/%s does not have imagePullSecret %s", meta.Namespace, meta.PodName, secretNameFilter)
 				status = status.CreateFailResourceStatus(
-					fmt.Sprintf("pod does not have imagePullSecret %s", secretNameFilter), spec.K8sExecFailed.Code)
+					fmt.Sprintf("pod does not have imagePullSecret %s", secretNameFilter), spec.K8sExecFailed.Code,
+				)
 				statuses = append(statuses, status)
 				continue
 			}

--- a/exec/pod/pod.go
+++ b/exec/pod/pod.go
@@ -70,7 +70,8 @@ blade create k8s pod-disk fill --path /home --percent 80 --retain-handle --names
 
 # Perform a fixed-size experimental scenario in the pod
 blade c k8s pod-disk fill --path /home --reserve 1024 --names nginx-app --kubeconfig ~/.kube/config --namespace default
-`)
+`,
+				)
 			case *disk.BurnActionSpec:
 				action.SetLongDesc("Disk read and write IO load experiment in the pod")
 				action.SetExample(
@@ -81,7 +82,8 @@ blade create k8s pod-disk burn --read --path /home --names nginx-app --kubeconfi
 blade create k8s pod-disk burn --write --path /home --names nginx-app --kubeconfig ~/.kube/config --namespace default8
 
 # Read and write IO load scenarios are performed at the same time. Path is not specified. The default is /
-blade create k8s pod-disk burn --read --write --names nginx-app --kubeconfig ~/.kube/config --namespace default`)
+blade create k8s pod-disk burn --read --write --names nginx-app --kubeconfig ~/.kube/config --namespace default`,
+				)
 			case *mem.MemLoadActionCommand:
 				action.SetLongDesc("The memory fill experiment scenario in the pod")
 				action.SetExample(
@@ -98,7 +100,8 @@ blade create k8s pod-mem load --mode ram --mem-percent 50 --include-buffer-cache
 blade create k8s pod-mem load --mode ram --mem-percent 50 --timeout 200 --names nginx-app --kubeconfig ~/.kube/config --namespace default
 
 # 200M memory is reserved
-blade create k8s pod-mem load --mode ram --reserve 200 --rate 100 --names nginx-app --kubeconfig ~/.kube/config --namespace default`)
+blade create k8s pod-mem load --mode ram --reserve 200 --rate 100 --names nginx-app --kubeconfig ~/.kube/config --namespace default`,
+				)
 			case *file.FileAppendActionSpec:
 				action.SetLongDesc("The file append experiment scenario in the pod")
 				action.SetExample(
@@ -113,7 +116,8 @@ blade create k8s pod-file append --filepath=/home/logs/nginx.log --content=SEVMT
 
 # mock interface timeout exception
 blade create k8s pod-file append --filepath=/home/logs/nginx.log --content="@{DATE:+%Y-%m-%d %H:%M:%S} ERROR invoke getUser timeout [@{RANDOM:100-200}]ms abc  mock exception" --names nginx-app --kubeconfig ~/.kube/config --namespace default
-`)
+`,
+				)
 			case *file.FileAddActionSpec:
 				action.SetLongDesc("The file add experiment scenario in the pod")
 				action.SetExample(
@@ -128,7 +132,8 @@ blade create k8s pod-file add --filepath /temp/nginx.log --auto-create-dir --nam
 
 # Create a directory named /nginx in the /temp directory and automatically create directories that don't exist
 blade create k8s pod-file add --directory --filepath /temp/nginx --auto-create-dir --names nginx-app --kubeconfig ~/.kube/config --namespace default
-`)
+`,
+				)
 
 			case *file.FileChmodActionSpec:
 				action.SetLongDesc("The file permission modification scenario in the pod")
@@ -143,7 +148,8 @@ blade create k8s pod-file delete --filepath /home/logs/nginx.log --names nginx-a
 
 # Force delete the file /home/logs/nginx.log unrecoverable
 blade create k8s pod-file delete --filepath /home/logs/nginx.log --force --names nginx-app --kubeconfig ~/.kube/config --namespace default
-`)
+`,
+				)
 			case *file.FileMoveActionSpec:
 				action.SetExample("The file move scenario in the pod")
 				action.SetExample(`# Move the file /home/logs/nginx.log to /tmp
@@ -164,15 +170,18 @@ blade create k8s pod-network delay --time 3000 --offset 1000 --interface eth0 --
 blade create k8s pod-network delay --time 3000 --interface eth0 --remote-port 80 --destination-ip 14.215.177.39 --names nginx-app --kubeconfig ~/.kube/config --namespace default
 
 # Do a 5 second delay for the entire network card eth0, excluding ports 22 and 8000 to 8080
-blade create k8s pod-network delay --time 5000 --interface eth0 --exclude-port 22,8000-8080 --names nginx-app --kubeconfig ~/.kube/config --namespace default`)
+blade create k8s pod-network delay --time 5000 --interface eth0 --exclude-port 22,8000-8080 --names nginx-app --kubeconfig ~/.kube/config --namespace default`,
+				)
 			case *network.DropActionSpec:
 				action.SetExample(
 					`# Experimental scenario of network shielding
-blade create k8s pod-network drop --names nginx-app --kubeconfig ~/.kube/config --namespace default`)
+blade create k8s pod-network drop --names nginx-app --kubeconfig ~/.kube/config --namespace default`,
+				)
 			case *network.DnsActionSpec:
 				action.SetExample(
 					`# The domain name www.baidu.com is not accessible
-blade create k8s pod-network dns --domain www.baidu.com --ip 10.0.0.0 --names nginx-app --kubeconfig ~/.kube/config --namespace default`)
+blade create k8s pod-network dns --domain www.baidu.com --ip 10.0.0.0 --names nginx-app --kubeconfig ~/.kube/config --namespace default`,
+				)
 			case *tc.LossActionSpec:
 				action.SetExample(`# Access to native 8080 and 8081 ports lost 70% of packets
 blade create k8s pod-network loss --percent 70 --interface eth0 --local-port 8080,8081 --names nginx-app --kubeconfig ~/.kube/config --namespace default
@@ -231,7 +240,8 @@ blade create k8s pod-script exit --exit-code 1 --exit-message this-is-error-mess
 blade create k8s pod-pod containercreating --namespace default --kubeconfig ~/.kube/config
 
 # Create a pod stuck in ContainerCreating state with custom volume mount path
-blade create k8s pod-pod containercreating --namespace default --volume-mount-path /data --kubeconfig ~/.kube/config`)
+blade create k8s pod-pod containercreating --namespace default --volume-mount-path /data --kubeconfig ~/.kube/config`,
+				)
 			case *PodSchedulingFailureActionSpec:
 				action.SetLongDesc("Make pod scheduling fail by injecting unreachable affinity rules to the target workload (Deployment/DaemonSet/StatefulSet). The scheduler will not find any node matching the rules, causing the Pod to remain in Pending state.")
 				action.SetExample(
@@ -239,7 +249,8 @@ blade create k8s pod-pod containercreating --namespace default --volume-mount-pa
 blade create k8s pod-pod schedulingfailure --namespace default --workload-type deployment --workload-name nginx-deployment --kubeconfig ~/.kube/config
 
 # Inject scheduling failure using node-selector
-blade create k8s pod-pod schedulingfailure --namespace default --workload-type deployment --workload-name nginx-deployment --affinity-type node-selector --kubeconfig ~/.kube/config`)
+blade create k8s pod-pod schedulingfailure --namespace default --workload-type deployment --workload-name nginx-deployment --affinity-type node-selector --kubeconfig ~/.kube/config`,
+				)
 			case *ImagePullSecretsErrorActionSpec:
 				action.SetLongDesc("Simulate image pull authentication failure by corrupting the credentials in the Secret referenced by the Pod's imagePullSecrets. The original Secret is backed up and restored when the experiment is destroyed.")
 				action.SetExample(
@@ -250,7 +261,8 @@ blade create k8s pod-pod imagepullsecretserror --names my-app-pod --namespace de
 blade create k8s pod-pod imagepullsecretserror --labels app=nginx --namespace default --kubeconfig ~/.kube/config
 
 # Corrupt only a specific imagePullSecret
-blade create k8s pod-pod imagepullsecretserror --names my-app-pod --namespace default --secret-name my-registry-secret --kubeconfig ~/.kube/config`)
+blade create k8s pod-pod imagepullsecretserror --names my-app-pod --namespace default --secret-name my-registry-secret --kubeconfig ~/.kube/config`,
+				)
 			case *PodTaintNodeActionSpec:
 				action.SetLongDesc("Make pod scheduling fail by adding unreachable taint to nodes. The scheduler will not schedule Pods without matching tolerations to the tainted nodes, causing the Pods to remain in Pending state.")
 				action.SetExample(
@@ -258,7 +270,8 @@ blade create k8s pod-pod imagepullsecretserror --names my-app-pod --namespace de
 blade create k8s pod-pod taintnode --nodes node1,node2 --kubeconfig ~/.kube/config
 
 # Add taint with NoExecute effect (will evict running pods)
-blade create k8s pod-pod taintnode --nodes node1 --taint-effect NoExecute --kubeconfig ~/.kube/config`)
+blade create k8s pod-pod taintnode --nodes node1 --taint-effect NoExecute --kubeconfig ~/.kube/config`,
+				)
 			case *ConfigMapDeleteActionSpec:
 				action.SetLongDesc("Delete a ConfigMap that a Pod depends on, then restart the Pod to simulate startup failure caused by missing ConfigMap. The original ConfigMap is backed up and restored when the experiment is destroyed.")
 				action.SetExample(
@@ -266,7 +279,8 @@ blade create k8s pod-pod taintnode --nodes node1 --taint-effect NoExecute --kube
 blade create k8s pod-pod configmapdelete --labels "app=test" --namespace default --kubeconfig ~/.kube/config
 
 # Delete a specific ConfigMap
-blade create k8s pod-pod configmapdelete --labels "app=test" --namespace default --configmap-name my-config --kubeconfig ~/.kube/config`)
+blade create k8s pod-pod configmapdelete --labels "app=test" --namespace default --configmap-name my-config --kubeconfig ~/.kube/config`,
+				)
 			case *BadResourceSizeActionSpec:
 				action.SetLongDesc("Modify the CPU/Memory resource limits of a workload (Deployment/DaemonSet/StatefulSet) to simulate incorrect resource sizing. The original resource configuration is backed up and restored when the experiment is destroyed.")
 				action.SetExample(
@@ -283,7 +297,8 @@ blade create k8s pod-pod badresourcesize --namespace default --workload-type dep
 blade create k8s pod-pod badresourcesize --namespace default --workload-type daemonset --workload-name nginx-ds --cpu 1m --kubeconfig ~/.kube/config
 
 # Set memory resource limit for a statefulset
-blade create k8s pod-pod badresourcesize --namespace default --workload-type statefulset --workload-name nginx-sts --mem 128m --kubeconfig ~/.kube/config`)
+blade create k8s pod-pod badresourcesize --namespace default --workload-type statefulset --workload-name nginx-sts --mem 128m --kubeconfig ~/.kube/config`,
+				)
 			case *FailedMountActionSpec:
 				action.SetLongDesc("Mount a non-existent ConfigMap/Secret/PVC volume to the target workload (Deployment/DaemonSet/StatefulSet) to simulate volume mount failure. The injected volume configuration is tracked and removed when the experiment is destroyed.")
 				action.SetExample(
@@ -294,14 +309,17 @@ blade create k8s pod-pod failedmount --namespace default --workload-type deploym
 blade create k8s pod-pod failedmount --namespace default --workload-type deployment --workload-name nginx-app --volume-type secret --with-initcontainer true --kubeconfig ~/.kube/config
 
 # Mount a non-existent pvc volume to a statefulset
-blade create k8s pod-pod failedmount --namespace default --workload-type statefulset --workload-name redis-app --volume-type pvc --kubeconfig ~/.kube/config`)
+blade create k8s pod-pod failedmount --namespace default --workload-type statefulset --workload-name redis-app --volume-type pvc --kubeconfig ~/.kube/config`,
+				)
 			default:
-				action.SetExample(strings.Replace(action.Example(),
+				action.SetExample(strings.Replace(
+					action.Example(),
 					fmt.Sprintf("blade create %s %s", expModelSpec.Name(), action.Name()),
 					fmt.Sprintf("blade create k8s pod-%s %s --names nginx-app --kubeconfig ~/.kube/config --namespace default", expModelSpec.Name(), action.Name()),
 					-1,
 				))
-				action.SetExample(strings.Replace(action.Example(),
+				action.SetExample(strings.Replace(
+					action.Example(),
 					fmt.Sprintf("blade c %s %s", expModelSpec.Name(), action.Name()),
 					fmt.Sprintf("blade c k8s pod-%s %s --names nginx-app --kubeconfig ~/.kube/config --namespace default", expModelSpec.Name(), action.Name()),
 					-1,

--- a/exec/service/modify.go
+++ b/exec/service/modify.go
@@ -164,7 +164,8 @@ func (d *ModifyServiceActionExecutor) create(uid string, ctx context.Context, ex
 		logrusField.Errorf("get service %s err, %v", serviceName, err)
 		status = status.CreateFailResourceStatus(err.Error(), spec.K8sExecFailed.Code)
 		return spec.ReturnResultIgnoreCode(
-			v1alpha1.CreateFailExperimentStatus(err.Error(), []v1alpha1.ResourceStatus{status}))
+			v1alpha1.CreateFailExperimentStatus(err.Error(), []v1alpha1.ResourceStatus{status}),
+		)
 	}
 
 	if existing, ok := svc.Annotations[ServiceAnnotation]; ok && existing != "" {
@@ -173,7 +174,8 @@ func (d *ModifyServiceActionExecutor) create(uid string, ctx context.Context, ex
 		logrusField.Warningf("%v", err)
 		status = status.CreateFailResourceStatus(err.Error(), spec.K8sExecFailed.Code)
 		return spec.ReturnResultIgnoreCode(
-			v1alpha1.CreateFailExperimentStatus(err.Error(), []v1alpha1.ResourceStatus{status}))
+			v1alpha1.CreateFailExperimentStatus(err.Error(), []v1alpha1.ResourceStatus{status}),
+		)
 	}
 
 	if svc.Annotations == nil {
@@ -197,7 +199,8 @@ func (d *ModifyServiceActionExecutor) create(uid string, ctx context.Context, ex
 			logrusField.Errorf("modify service %s err, %v", serviceName, err)
 			status = status.CreateFailResourceStatus(err.Error(), spec.K8sExecFailed.Code)
 			return spec.ReturnResultIgnoreCode(
-				v1alpha1.CreateFailExperimentStatus(err.Error(), []v1alpha1.ResourceStatus{status}))
+				v1alpha1.CreateFailExperimentStatus(err.Error(), []v1alpha1.ResourceStatus{status}),
+			)
 		}
 	}
 
@@ -216,7 +219,8 @@ func (d *ModifyServiceActionExecutor) create(uid string, ctx context.Context, ex
 		logrusField.Errorf("marshal modify history for service %s err, %v", serviceName, err)
 		status = status.CreateFailResourceStatus(err.Error(), spec.K8sExecFailed.Code)
 		return spec.ReturnResultIgnoreCode(
-			v1alpha1.CreateFailExperimentStatus(err.Error(), []v1alpha1.ResourceStatus{status}))
+			v1alpha1.CreateFailExperimentStatus(err.Error(), []v1alpha1.ResourceStatus{status}),
+		)
 	}
 	svc.Annotations[ServiceAnnotation] = fmt.Sprintf("modify-%s", uid)
 	svc.Annotations[ServiceModifyHistoryAnnotation] = string(historyBytes)
@@ -225,7 +229,8 @@ func (d *ModifyServiceActionExecutor) create(uid string, ctx context.Context, ex
 		logrusField.Errorf("update service %s err, %v", serviceName, err)
 		status = status.CreateFailResourceStatus(err.Error(), spec.K8sExecFailed.Code)
 		return spec.ReturnResultIgnoreCode(
-			v1alpha1.CreateFailExperimentStatus(err.Error(), []v1alpha1.ResourceStatus{status}))
+			v1alpha1.CreateFailExperimentStatus(err.Error(), []v1alpha1.ResourceStatus{status}),
+		)
 	}
 
 	status = status.CreateSuccessResourceStatus()

--- a/hack/update-gofmt.sh
+++ b/hack/update-gofmt.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 source "$(dirname "$0")/init.sh"
-go install mvdan.cc/gofumpt@latest
+go install mvdan.cc/gofumpt@v0.10.0
 
 # Serially process each file to avoid concurrent write issues
 for f in $(git_find); do

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 source "$(dirname "$0")/init.sh"
-go install mvdan.cc/gofumpt@latest
+go install mvdan.cc/gofumpt@v0.10.0
 
 # gofmt exits with non-zero exit code if it finds a problem unrelated to
 # formatting (e.g., a file does not parse correctly). Without "|| true" this

--- a/pkg/controller/chaosblade/controller.go
+++ b/pkg/controller/chaosblade/controller.go
@@ -151,7 +151,8 @@ func periodicallyCleanUpBlade(ctx context.Context, cli client.Client, interval t
 		if item.Status.Phase == v1alpha1.ClusterPhaseDestroying && sub.Seconds() > interval.Seconds() {
 			logrus.Infof("periodically clean up blade %s, deletion time: %s", item.Name, item.DeletionTimestamp.String())
 			// patch blade
-			if err := cli.Patch(ctx,
+			if err := cli.Patch(
+				ctx,
 				&v1alpha1.ChaosBlade{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "chaosblade.io/v1alpha1",

--- a/pkg/webhook/pod/mutator.go
+++ b/pkg/webhook/pod/mutator.go
@@ -103,8 +103,8 @@ func (v *Mutator) mutatePodsFn(pod *corev1.Pod) error {
 			if volumeMount.MountPropagation == nil {
 				return fmt.Errorf("target volume mount propagation must be HostToContainer or Bidirectional")
 			}
-			if *(volumeMount.MountPropagation) != corev1.MountPropagationHostToContainer &&
-				*(volumeMount.MountPropagation) != corev1.MountPropagationBidirectional {
+			if *volumeMount.MountPropagation != corev1.MountPropagationHostToContainer &&
+				*volumeMount.MountPropagation != corev1.MountPropagationBidirectional {
 				return fmt.Errorf("target volume mount propagation is not support")
 			}
 			targetVolumeMount = volumeMount


### PR DESCRIPTION
## Summary
- Reformat all 13 affected source files to comply with `gofumpt v0.10.0` rules
- Pin `gofumpt` version to `v0.10.0` in `hack/verify-gofmt.sh` and `hack/update-gofmt.sh` to prevent future unexpected CI breakage from upstream version bumps

## Root Cause
CI script (`hack/verify-gofmt.sh`) used `go install mvdan.cc/gofumpt@latest`. Between Apr 24 and May 8, gofumpt released v0.10.0 which introduced stricter formatting rules (trailing commas in multi-line function calls). This caused all new PRs to fail CI.

Evidence:
- Master CI (Apr 24, passed): `gofumpt v0.9.2`
- PR CI (May 8, failed): `gofumpt v0.10.0`

Fixes #301

## Test plan
- [x] `gofumpt -d` produces no diff on all `.go` files
- [x] `go build ./...` passes
- [x] `go vet ./...` passes

	🤖 Generated with [Qoder][https://qoder.com]