### PR TITLE
feat: 新增 Cluster/Pod 级 DNS Server 故障注入场景

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The current experimental scenarios involve resources including Node, Pod, and Co
     * Disk: specify the directory disk occupation, disk IO read and write load, etc.
     * Memory: specify memory usage
     * Pod: kill pod, make pod stuck in ContainerCreating state by PVC mount failure, make pod stuck in ContainerCreating state by cloud disk PVC creation failure, make pod stuck in Terminating state by finalizer, make pod scheduling fail by injecting unreachable affinity rules, modify workload (Deployment/DaemonSet/StatefulSet) CPU/Memory resource limits to simulate bad resource sizing, mount non-existent ConfigMap/Secret/PVC volume to workload (Deployment/DaemonSet/StatefulSet) to simulate volume mount failure
+    * DNS: locate the pod's DNS configuration by pod name (and an optional nameserver IP), then make the pod's DNS resolution completely unavailable by overriding its owning workload (Deployment/DaemonSet/StatefulSet) PodSpec with an unreachable nameserver. The original DNS settings are restored when the experiment is destroyed.
     * IO: specify the file system io exception. Supports 31 file operations and 11 exception scenarios, such as "Too many open files", "Device or resource busy" and so on.
 * Container:
     * CPU: specify CPU usage
@@ -28,6 +29,8 @@ The current experimental scenarios involve resources including Node, Pod, and Co
     * Container: remove container
 * Service:
     * Service: create, modify service
+* Cluster:
+    * DNS: reverse-resolve the cluster DNS server workload from the DNS Service address (kube-dns / CoreDNS by default) and inject a complete unavailability fault by scaling the workload to 0 replicas. The original replica count is restored when the experiment is destroyed.
 
 ## Local Build & Installation
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -17,6 +17,7 @@ Chaosblade Operator 是混沌工程实验工具 ChaosBlade 下的一款面向云
     * 磁盘：指定目录磁盘填充、磁盘 IO 读写负载等
     * 内存：指定内存使用率
     * Pod：杀 Pod、通过 PVC 挂载失败使 Pod 卡在 ContainerCreating 状态、通过云盘 PVC 创建失败使 Pod 卡在 ContainerCreating 状态、通过 finalizer 使 Pod 卡在 Terminating 状态、通过注入无法满足的亲和性规则使 Pod 调度失败、修改工作负载（Deployment/DaemonSet/StatefulSet）的 CPU/Memory 资源限制模拟资源配置异常、挂载不存在的 ConfigMap/Secret/PVC 类型 Volume 到工作负载（Deployment/DaemonSet/StatefulSet）模拟卷挂载失败
+    * DNS：根据指定的 Pod 名称（以及可选的 nameserver IP）查找 Pod 的 DNS 配置，并通过覆盖其所属工作负载（Deployment/DaemonSet/StatefulSet）的 PodSpec，注入不可达的 nameserver，使该 Pod 的 DNS 解析完全不可用，实验销毁时自动恢复原始 DNS 配置
 * Container：
     * CPU: 指定 CPU 使用率
     * 网络: 指定网卡、端口、IP 等包延迟、丢包、包阻塞、包重复、包乱序、包损坏等
@@ -26,6 +27,8 @@ Chaosblade Operator 是混沌工程实验工具 ChaosBlade 下的一款面向云
     * Container: 杀 Container
 * Service：
     * Service: 创建、修改Service
+* Cluster：
+    * DNS：根据 K8s 集群 DNS Service 地址（默认 kube-dns / CoreDNS）反推出 DNS Server 工作负载，并通过将其副本数缩容至 0 注入完全不可用故障，实验销毁时自动恢复原始副本数
 
 ## 本地构建&安装
 

--- a/build/spec.go
+++ b/build/spec.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/chaosblade-io/chaosblade-operator/exec/cluster"
 	"github.com/chaosblade-io/chaosblade-operator/exec/container"
 	"github.com/chaosblade-io/chaosblade-operator/exec/node"
 	"github.com/chaosblade-io/chaosblade-operator/exec/pod"
@@ -63,6 +64,11 @@ func getModels() *spec.Models {
 	serviceResourceModelSpec := service.NewResourceModelSpec(nil)
 	for _, modelSpec := range serviceResourceModelSpec.ExpModels() {
 		model := util.ConvertSpecToModels(modelSpec, spec.ExpPrepareModel{}, serviceResourceModelSpec.Scope())
+		models = append(models, model)
+	}
+	clusterResourceModelSpec := cluster.NewResourceModelSpec(nil)
+	for _, modelSpec := range clusterResourceModelSpec.ExpModels() {
+		model := util.ConvertSpecToModels(modelSpec, spec.ExpPrepareModel{}, clusterResourceModelSpec.Scope())
 		models = append(models, model)
 	}
 	return util.MergeModels(models...)

--- a/examples/cluster-dns-failure.yaml
+++ b/examples/cluster-dns-failure.yaml
@@ -1,0 +1,51 @@
+# Copyright 2025 The ChaosBlade Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Inject a complete unavailability fault to the cluster DNS server.
+#
+# Behavior:
+# - The action looks up the configured DNS Service (default: kube-dns in kube-system).
+# - It reverse-resolves the underlying Deployment by matching the Service's
+#   selector against Deployment pod template labels.
+# - It backs up the Deployment's replica count and scales it to 0, making the
+#   cluster DNS completely unavailable.
+# - On destroy, the original replica count is restored.
+#
+# Prerequisites:
+# - The operator must have RBAC permissions to get/list/update the DNS Service
+#   and the underlying Deployment in the chosen namespace (default: kube-system).
+#
+# WARNING: This stops cluster-wide name resolution. Workloads that rely on DNS
+# (including the operator itself if its kube-apiserver address is resolved via
+# DNS) will be affected. Use only on test clusters.
+
+apiVersion: chaosblade.io/v1alpha1
+kind: ChaosBlade
+metadata:
+  name: cluster-dns-failure
+spec:
+  experiments:
+  - scope: cluster
+    target: dns
+    action: dnsfailure
+    desc: "Make the cluster DNS server completely unavailable"
+    matchers:
+    # Optional: DNS Service name. Default: kube-dns
+    # - name: dns-service
+    #   value:
+    #   - "kube-dns"
+    # Optional: namespace of the DNS Service. Default: kube-system
+    # - name: dns-service-namespace
+    #   value:
+    #   - "kube-system"

--- a/examples/pod-dns-failure.yaml
+++ b/examples/pod-dns-failure.yaml
@@ -1,0 +1,56 @@
+# Copyright 2025 The ChaosBlade Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Inject a complete DNS unavailability fault to a specific Pod.
+#
+# Behavior:
+# - The action locates the target Pod by name and namespace.
+# - When the optional `nameserver` flag is set, it validates that the Pod's
+#   DNS configuration references that nameserver IP.
+# - It walks the Pod's owner references to find the top-level workload
+#   (Deployment / DaemonSet / StatefulSet), backs up the workload PodSpec's
+#   DNSPolicy and DNSConfig as JSON-encoded annotations, then overrides the
+#   PodSpec to use DNSPolicy=None and a non-routable nameserver (127.0.0.255).
+# - The Pod is deleted so the owning controller recreates it with the faulty
+#   DNS configuration. From the Pod's point of view, all DNS queries fail.
+# - On destroy, the workload's original DNS configuration is restored.
+#
+# Prerequisites:
+# - The operator must have RBAC permissions to get/update the Pod's
+#   Deployment/DaemonSet/StatefulSet and to delete the Pod itself.
+# - The Pod must be controlled by a Deployment, DaemonSet or StatefulSet.
+
+apiVersion: chaosblade.io/v1alpha1
+kind: ChaosBlade
+metadata:
+  name: pod-dns-failure
+spec:
+  experiments:
+  - scope: pod
+    target: pod
+    action: dnsfailure
+    desc: "Make a Pod's DNS resolution completely unavailable"
+    matchers:
+    - name: namespace
+      value:
+      - "default"
+    - name: names
+      value:
+      - "nginx-app-xxx"
+    # Optional: nameserver IP that the Pod must currently use. When set, the
+    # action verifies the Pod's DNS config contains this IP before injecting
+    # the fault.
+    # - name: nameserver
+    #   value:
+    #   - "10.96.0.10"

--- a/exec/cluster/cluster.go
+++ b/exec/cluster/cluster.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cluster
+
+import (
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+
+	"github.com/chaosblade-io/chaosblade-operator/channel"
+	"github.com/chaosblade-io/chaosblade-operator/exec/model"
+)
+
+// ResourceModelSpec describes cluster-level chaos experiment models.
+// Cluster-level experiments operate on cluster-wide infrastructure components,
+// such as the cluster DNS server (CoreDNS / kube-dns).
+type ResourceModelSpec struct {
+	model.BaseResourceExpModelSpec
+}
+
+func NewResourceModelSpec(client *channel.Client) model.ResourceExpModelSpec {
+	modelSpec := &ResourceModelSpec{
+		model.NewBaseResourceExpModelSpec("cluster", client),
+	}
+	expModels := []spec.ExpModelCommandSpec{
+		NewSelfExpModelCommandSpec(client),
+	}
+	modelSpec.RegisterExpModels(expModels...)
+	return modelSpec
+}
+
+type SelfExpModelCommandSpec struct {
+	spec.BaseExpModelCommandSpec
+}
+
+func NewSelfExpModelCommandSpec(client *channel.Client) spec.ExpModelCommandSpec {
+	return &SelfExpModelCommandSpec{
+		spec.BaseExpModelCommandSpec{
+			ExpFlags: []spec.ExpFlagSpec{},
+			ExpActions: []spec.ExpActionCommandSpec{
+				NewClusterDnsFailureActionSpec(client),
+			},
+		},
+	}
+}
+
+func (*SelfExpModelCommandSpec) Name() string {
+	return "dns"
+}
+
+func (*SelfExpModelCommandSpec) ShortDesc() string {
+	return "Cluster-level DNS server experiments"
+}
+
+func (*SelfExpModelCommandSpec) LongDesc() string {
+	return "Cluster-level DNS server experiments. Inject faults into the cluster DNS " +
+		"server (e.g. CoreDNS / kube-dns) workload to make cluster name resolution " +
+		"completely unavailable. The experiment can be recovered by destroying the " +
+		"ChaosBlade resource."
+}
+
+func (*SelfExpModelCommandSpec) Example() string {
+	return "blade create k8s cluster-dns dnsfailure --dns-service kube-dns --dns-service-namespace kube-system --kubeconfig ~/.kube/config"
+}

--- a/exec/cluster/controller.go
+++ b/exec/cluster/controller.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cluster
+
+import (
+	"context"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/sirupsen/logrus"
+
+	"github.com/chaosblade-io/chaosblade-operator/channel"
+	"github.com/chaosblade-io/chaosblade-operator/exec/model"
+	"github.com/chaosblade-io/chaosblade-operator/pkg/apis/chaosblade/v1alpha1"
+)
+
+type ExpController struct {
+	model.BaseExperimentController
+}
+
+func NewExpController(client *channel.Client) model.ExperimentController {
+	return &ExpController{
+		model.BaseExperimentController{
+			Client:            client,
+			ResourceModelSpec: NewResourceModelSpec(client),
+		},
+	}
+}
+
+func (*ExpController) Name() string {
+	return "cluster"
+}
+
+func (e *ExpController) Create(ctx context.Context, expSpec v1alpha1.ExperimentSpec) *spec.Response {
+	expModel := model.ExtractExpModelFromExperimentSpec(expSpec)
+	experimentId := model.GetExperimentIdFromContext(ctx)
+	logrus.WithField("experiment", experimentId).Infof("creating cluster experiment")
+	return e.Exec(ctx, expModel)
+}
+
+func (e *ExpController) Destroy(ctx context.Context, expSpec v1alpha1.ExperimentSpec, oldExpStatus v1alpha1.ExperimentStatus) *spec.Response {
+	experimentId := model.GetExperimentIdFromContext(ctx)
+	logrus.WithField("experiment", experimentId).Infoln("start to destroy cluster experiment")
+	expModel := model.ExtractExpModelFromExperimentSpec(expSpec)
+	return e.Exec(ctx, expModel)
+}

--- a/exec/cluster/dnsfailure.go
+++ b/exec/cluster/dnsfailure.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
 	"github.com/chaosblade-io/chaosblade-spec-go/util"
@@ -41,8 +43,16 @@ import (
 const (
 	// DnsServiceFlag is the flag name for the cluster DNS service.
 	DnsServiceFlag = "dns-service"
-	// DnsServiceNamespaceFlag is the flag name for the cluster DNS service's namespace.
+	// DnsServiceNamespaceFlag is the flag name for the cluster DNS service /
+	// deployment namespace. The DNS Service and the Deployment backing it are
+	// assumed to live in the same namespace.
 	DnsServiceNamespaceFlag = "dns-service-namespace"
+	// DnsDeploymentFlag explicitly names the Deployment backing the DNS Service.
+	// When provided, the reverse-resolution from the Service selector is
+	// skipped and the named Deployment is used directly. This is the supported
+	// way to disambiguate when multiple Deployments match the DNS Service's
+	// selector (for example, CoreDNS coexisting with node-local-dns).
+	DnsDeploymentFlag = "dns-deployment"
 
 	// DefaultDnsServiceName is the default cluster DNS service name (CoreDNS / kube-dns).
 	DefaultDnsServiceName = "kube-dns"
@@ -86,8 +96,16 @@ func NewClusterDnsFailureActionSpec(client *channel.Client) spec.ExpActionComman
 				},
 				&spec.ExpFlag{
 					Name:    DnsServiceNamespaceFlag,
-					Desc:    "The namespace of the cluster DNS service. Default: kube-system",
+					Desc:    "The namespace of the cluster DNS service / deployment. Default: kube-system",
 					Default: DefaultDnsServiceNamespace,
+				},
+				&spec.ExpFlag{
+					Name: DnsDeploymentFlag,
+					Desc: "Explicitly name the Deployment backing the DNS service. When set, " +
+						"reverse-resolution from the Service selector is skipped. Use this to " +
+						"disambiguate when multiple Deployments match the DNS Service selector " +
+						"(e.g. CoreDNS coexisting with node-local-dns).",
+					Required: false,
 				},
 			},
 			ActionExecutor: &ClusterDnsFailureActionExecutor{client: client},
@@ -96,6 +114,9 @@ blade create k8s cluster-dns dnsfailure --kubeconfig ~/.kube/config
 
 # Specify a custom DNS service name and namespace
 blade create k8s cluster-dns dnsfailure --dns-service coredns --dns-service-namespace kube-system --kubeconfig ~/.kube/config
+
+# Skip reverse-resolution and target the DNS Deployment by name (use this when multiple Deployments share the Service selector)
+blade create k8s cluster-dns dnsfailure --dns-deployment coredns --dns-service-namespace kube-system --kubeconfig ~/.kube/config
 `,
 			ActionCategories: []string{model.CategorySystemContainer},
 		},
@@ -120,7 +141,9 @@ func (*ClusterDnsFailureActionSpec) LongDesc() string {
 		"The action resolves the underlying DNS workload (Deployment) from the " +
 		"DNS service's selector, backs up its replica count, and scales it to 0 " +
 		"so that no DNS query can be answered cluster-wide. When the experiment " +
-		"is destroyed, the original replica count is restored."
+		"is destroyed, the original replica count is restored. If multiple " +
+		"Deployments match the DNS Service selector, the action refuses to guess " +
+		"and asks the user to disambiguate with --" + DnsDeploymentFlag + "."
 }
 
 type ClusterDnsFailureActionExecutor struct {
@@ -144,14 +167,14 @@ func (d *ClusterDnsFailureActionExecutor) create(uid string, ctx context.Context
 	experimentId := model.GetExperimentIdFromContext(ctx)
 	logrusField := logrus.WithField("experiment", experimentId)
 
-	dnsService, dnsNamespace := resolveDnsServiceFlags(expModel)
+	dnsService, dnsNamespace, explicitDeployment := resolveDnsFlags(expModel)
 
 	status := v1alpha1.ResourceStatus{
 		Kind:       ClusterDnsKind,
-		Identifier: fmt.Sprintf("%s/%s", dnsNamespace, dnsService),
+		Identifier: initialDnsIdentifier(dnsNamespace, dnsService, explicitDeployment),
 	}
 
-	deployment, err := d.findDnsDeployment(ctx, dnsNamespace, dnsService)
+	deployment, err := d.resolveTargetDnsDeployment(ctx, dnsNamespace, dnsService, explicitDeployment)
 	if err != nil {
 		util.Errorf(uid, util.GetRunFuncName(), err.Error())
 		logrusField.Warningf("locate cluster DNS deployment failed: %v", err)
@@ -161,7 +184,7 @@ func (d *ClusterDnsFailureActionExecutor) create(uid string, ctx context.Context
 		)
 	}
 
-	status.Identifier = fmt.Sprintf("%s/%s/%s", dnsNamespace, dnsService, deployment.Name)
+	status.Identifier = resolvedDnsIdentifier(dnsNamespace, dnsService, explicitDeployment, deployment.Name)
 
 	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		latest := &appsv1.Deployment{}
@@ -186,14 +209,14 @@ func (d *ClusterDnsFailureActionExecutor) destroy(uid string, ctx context.Contex
 	experimentId := model.GetExperimentIdFromContext(ctx)
 	logrusField := logrus.WithField("experiment", experimentId)
 
-	dnsService, dnsNamespace := resolveDnsServiceFlags(expModel)
+	dnsService, dnsNamespace, explicitDeployment := resolveDnsFlags(expModel)
 
 	status := v1alpha1.ResourceStatus{
 		Kind:       ClusterDnsKind,
-		Identifier: fmt.Sprintf("%s/%s", dnsNamespace, dnsService),
+		Identifier: initialDnsIdentifier(dnsNamespace, dnsService, explicitDeployment),
 	}
 
-	deployment, err := d.findDnsDeployment(ctx, dnsNamespace, dnsService)
+	deployment, err := d.resolveTargetDnsDeployment(ctx, dnsNamespace, dnsService, explicitDeployment)
 	if err != nil {
 		util.Errorf(uid, util.GetRunFuncName(), err.Error())
 		logrusField.Warningf("locate cluster DNS deployment for restore failed: %v", err)
@@ -203,7 +226,7 @@ func (d *ClusterDnsFailureActionExecutor) destroy(uid string, ctx context.Contex
 		)
 	}
 
-	status.Identifier = fmt.Sprintf("%s/%s/%s", dnsNamespace, dnsService, deployment.Name)
+	status.Identifier = resolvedDnsIdentifier(dnsNamespace, dnsService, explicitDeployment, deployment.Name)
 
 	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		latest := &appsv1.Deployment{}
@@ -225,23 +248,46 @@ func (d *ClusterDnsFailureActionExecutor) destroy(uid string, ctx context.Contex
 	return spec.ReturnResultIgnoreCode(v1alpha1.CreateDestroyedExperimentStatus([]v1alpha1.ResourceStatus{status}))
 }
 
-// findDnsDeployment locates the Deployment that backs the given DNS service.
+// resolveTargetDnsDeployment locates the Deployment that the action will scale.
+// When explicitDeployment is non-empty, it is looked up directly by name and
+// reverse-resolution from the DNS Service is skipped. Otherwise the function
+// delegates to findDnsDeployment which inspects the Service's selector.
+func (d *ClusterDnsFailureActionExecutor) resolveTargetDnsDeployment(ctx context.Context, namespace, serviceName, explicitDeployment string) (*appsv1.Deployment, error) {
+	if explicitDeployment != "" {
+		dep := &appsv1.Deployment{}
+		if err := d.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: explicitDeployment}, dep); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, fmt.Errorf("DNS deployment %s/%s not found", namespace, explicitDeployment)
+			}
+			return nil, fmt.Errorf("get DNS deployment %s/%s failed: %v", namespace, explicitDeployment, err)
+		}
+		return dep, nil
+	}
+	return d.findDnsDeployment(ctx, namespace, serviceName)
+}
+
+// findDnsDeployment locates the Deployment that backs the given DNS service by
+// reverse-resolving the Service selector.
 //
-// It first reads the Service to discover its selector, then lists Deployments in
-// the same namespace and returns the first one whose pod template labels match
-// the Service selector. This works for the standard CoreDNS / kube-dns layout
-// where a Service of type ClusterIP fronts a Deployment.
+// It reads the Service to discover its selector, then lists Deployments in the
+// same namespace and collects every one whose pod template labels match the
+// Service selector. To avoid scaling the wrong workload (which would silently
+// take cluster DNS offline), the function returns an error when zero or more
+// than one Deployment match — in the ambiguous case the error lists every
+// candidate so the operator can disambiguate via --dns-deployment.
 func (d *ClusterDnsFailureActionExecutor) findDnsDeployment(ctx context.Context, namespace, serviceName string) (*appsv1.Deployment, error) {
 	svc := &v1.Service{}
 	if err := d.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: serviceName}, svc); err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil, fmt.Errorf("DNS service %s/%s not found", namespace, serviceName)
+			return nil, fmt.Errorf("DNS service %s/%s not found (use --%s to name the workload directly)",
+				namespace, serviceName, DnsDeploymentFlag)
 		}
 		return nil, fmt.Errorf("get DNS service %s/%s failed: %v", namespace, serviceName, err)
 	}
 
 	if len(svc.Spec.Selector) == 0 {
-		return nil, fmt.Errorf("DNS service %s/%s has no selector, cannot reverse-resolve workload", namespace, serviceName)
+		return nil, fmt.Errorf("DNS service %s/%s has no selector, cannot reverse-resolve workload "+
+			"(use --%s to name it explicitly)", namespace, serviceName, DnsDeploymentFlag)
 	}
 
 	selector := pkglabels.SelectorFromSet(svc.Spec.Selector)
@@ -250,14 +296,31 @@ func (d *ClusterDnsFailureActionExecutor) findDnsDeployment(ctx context.Context,
 		return nil, fmt.Errorf("list deployments in namespace %s failed: %v", namespace, err)
 	}
 
+	matches := make([]*appsv1.Deployment, 0)
 	for i := range deployments.Items {
 		dep := &deployments.Items[i]
 		if selector.Matches(pkglabels.Set(dep.Spec.Template.Labels)) {
-			return dep, nil
+			matches = append(matches, dep)
 		}
 	}
-	return nil, fmt.Errorf("no Deployment in namespace %s matches DNS service %s selector %v",
-		namespace, serviceName, svc.Spec.Selector)
+
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		return nil, fmt.Errorf("no Deployment in namespace %s matches DNS service %s selector %v "+
+			"(use --%s to name the workload directly)",
+			namespace, serviceName, svc.Spec.Selector, DnsDeploymentFlag)
+	default:
+		names := make([]string, 0, len(matches))
+		for _, m := range matches {
+			names = append(names, m.Name)
+		}
+		sort.Strings(names)
+		return nil, fmt.Errorf("DNS service %s/%s selector %v matches %d Deployments [%s]; "+
+			"refusing to choose to avoid scaling down an unintended workload — pass --%s to disambiguate",
+			namespace, serviceName, svc.Spec.Selector, len(matches), strings.Join(names, ", "), DnsDeploymentFlag)
+	}
 }
 
 // injectClusterDnsFailure backs up the deployment's replica count and scales it to 0.
@@ -343,4 +406,35 @@ func resolveDnsServiceFlags(expModel *spec.ExpModel) (string, string) {
 		dnsNamespace = DefaultDnsServiceNamespace
 	}
 	return dnsService, dnsNamespace
+}
+
+// resolveDnsFlags returns the DNS Service name, namespace, and the optional
+// explicit Deployment name. An explicit Deployment, when provided, bypasses
+// the reverse-resolution from the Service selector.
+func resolveDnsFlags(expModel *spec.ExpModel) (service, namespace, deployment string) {
+	service, namespace = resolveDnsServiceFlags(expModel)
+	deployment = strings.TrimSpace(expModel.ActionFlags[DnsDeploymentFlag])
+	return service, namespace, deployment
+}
+
+// initialDnsIdentifier returns the ChaosBlade resource identifier used before
+// resolution succeeds. It reflects which input the user provided (service name
+// vs. explicit deployment name) so failure statuses point at the right input.
+func initialDnsIdentifier(namespace, serviceName, explicitDeployment string) string {
+	target := serviceName
+	if explicitDeployment != "" {
+		target = explicitDeployment
+	}
+	return fmt.Sprintf("%s/%s", namespace, target)
+}
+
+// resolvedDnsIdentifier returns the ChaosBlade resource identifier used after
+// the Deployment has been located. When the user provided --dns-deployment we
+// emit only the namespace/deployment pair to avoid implying a Service was
+// consulted; otherwise the Service name remains for traceability.
+func resolvedDnsIdentifier(namespace, serviceName, explicitDeployment, resolvedDeployment string) string {
+	if explicitDeployment != "" {
+		return fmt.Sprintf("%s/%s", namespace, resolvedDeployment)
+	}
+	return fmt.Sprintf("%s/%s/%s", namespace, serviceName, resolvedDeployment)
 }

--- a/exec/cluster/dnsfailure.go
+++ b/exec/cluster/dnsfailure.go
@@ -1,0 +1,346 @@
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cluster
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
+	"github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	pkglabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	sigsclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/chaosblade-io/chaosblade-operator/channel"
+	"github.com/chaosblade-io/chaosblade-operator/exec/model"
+	"github.com/chaosblade-io/chaosblade-operator/pkg/apis/chaosblade/v1alpha1"
+)
+
+const (
+	// DnsServiceFlag is the flag name for the cluster DNS service.
+	DnsServiceFlag = "dns-service"
+	// DnsServiceNamespaceFlag is the flag name for the cluster DNS service's namespace.
+	DnsServiceNamespaceFlag = "dns-service-namespace"
+
+	// DefaultDnsServiceName is the default cluster DNS service name (CoreDNS / kube-dns).
+	DefaultDnsServiceName = "kube-dns"
+	// DefaultDnsServiceNamespace is the default namespace where the cluster DNS service lives.
+	DefaultDnsServiceNamespace = "kube-system"
+
+	// ClusterDnsKind is the resource kind exposed in ChaosBlade status for cluster DNS faults.
+	ClusterDnsKind = "cluster-dns"
+
+	// ChaosBladeClusterDnsAnnotation indicates that the deployment was modified by a cluster DNS experiment.
+	ChaosBladeClusterDnsAnnotation = "chaosblade.io/cluster-dns"
+	// ChaosBladeOriginalReplicasAnnotation stores the original replica count of the DNS workload.
+	ChaosBladeOriginalReplicasAnnotation = "chaosblade.io/original-replicas"
+	// ChaosBladeExperimentAnnotation is the annotation key recording the experiment id.
+	ChaosBladeExperimentAnnotation = "chaosblade.io/experiment"
+	// ChaosBladeClusterDnsAction is the annotation value of the cluster DNS action.
+	ChaosBladeClusterDnsAction = "dnsfailure"
+)
+
+// ClusterDnsFailureActionSpec implements DNS server outage at the cluster level.
+//
+// The action looks up the configured DNS Service, finds the underlying Deployment
+// by matching the Service's selector against Deployment pod template labels, then
+// scales the Deployment to zero replicas to make the cluster DNS completely
+// unavailable. The original replica count is backed up in an annotation so the
+// destroy flow can recover the workload.
+type ClusterDnsFailureActionSpec struct {
+	spec.BaseExpActionCommandSpec
+	client *channel.Client
+}
+
+func NewClusterDnsFailureActionSpec(client *channel.Client) spec.ExpActionCommandSpec {
+	return &ClusterDnsFailureActionSpec{
+		BaseExpActionCommandSpec: spec.BaseExpActionCommandSpec{
+			ActionMatchers: []spec.ExpFlagSpec{},
+			ActionFlags: []spec.ExpFlagSpec{
+				&spec.ExpFlag{
+					Name:    DnsServiceFlag,
+					Desc:    "The cluster DNS service name. Default: kube-dns",
+					Default: DefaultDnsServiceName,
+				},
+				&spec.ExpFlag{
+					Name:    DnsServiceNamespaceFlag,
+					Desc:    "The namespace of the cluster DNS service. Default: kube-system",
+					Default: DefaultDnsServiceNamespace,
+				},
+			},
+			ActionExecutor: &ClusterDnsFailureActionExecutor{client: client},
+			ActionExample: `# Make the cluster DNS server completely unavailable by scaling the kube-dns / CoreDNS deployment to 0
+blade create k8s cluster-dns dnsfailure --kubeconfig ~/.kube/config
+
+# Specify a custom DNS service name and namespace
+blade create k8s cluster-dns dnsfailure --dns-service coredns --dns-service-namespace kube-system --kubeconfig ~/.kube/config
+`,
+			ActionCategories: []string{model.CategorySystemContainer},
+		},
+		client: client,
+	}
+}
+
+func (*ClusterDnsFailureActionSpec) Name() string {
+	return "dnsfailure"
+}
+
+func (*ClusterDnsFailureActionSpec) Aliases() []string {
+	return []string{}
+}
+
+func (*ClusterDnsFailureActionSpec) ShortDesc() string {
+	return "Make the cluster DNS server completely unavailable"
+}
+
+func (*ClusterDnsFailureActionSpec) LongDesc() string {
+	return "Inject a complete unavailability fault to the cluster DNS server. " +
+		"The action resolves the underlying DNS workload (Deployment) from the " +
+		"DNS service's selector, backs up its replica count, and scales it to 0 " +
+		"so that no DNS query can be answered cluster-wide. When the experiment " +
+		"is destroyed, the original replica count is restored."
+}
+
+type ClusterDnsFailureActionExecutor struct {
+	client *channel.Client
+}
+
+func (*ClusterDnsFailureActionExecutor) Name() string {
+	return "dnsfailure"
+}
+
+func (*ClusterDnsFailureActionExecutor) SetChannel(channel spec.Channel) {}
+
+func (d *ClusterDnsFailureActionExecutor) Exec(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	if _, ok := spec.IsDestroy(ctx); ok {
+		return d.destroy(uid, ctx, expModel)
+	}
+	return d.create(uid, ctx, expModel)
+}
+
+func (d *ClusterDnsFailureActionExecutor) create(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	experimentId := model.GetExperimentIdFromContext(ctx)
+	logrusField := logrus.WithField("experiment", experimentId)
+
+	dnsService, dnsNamespace := resolveDnsServiceFlags(expModel)
+
+	status := v1alpha1.ResourceStatus{
+		Kind:       ClusterDnsKind,
+		Identifier: fmt.Sprintf("%s/%s", dnsNamespace, dnsService),
+	}
+
+	deployment, err := d.findDnsDeployment(ctx, dnsNamespace, dnsService)
+	if err != nil {
+		util.Errorf(uid, util.GetRunFuncName(), err.Error())
+		logrusField.Warningf("locate cluster DNS deployment failed: %v", err)
+		status = status.CreateFailResourceStatus(err.Error(), spec.K8sExecFailed.Code)
+		return spec.ReturnResultIgnoreCode(
+			v1alpha1.CreateFailExperimentStatus(err.Error(), []v1alpha1.ResourceStatus{status}),
+		)
+	}
+
+	status.Identifier = fmt.Sprintf("%s/%s/%s", dnsNamespace, dnsService, deployment.Name)
+
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		latest := &appsv1.Deployment{}
+		if err := d.client.Get(ctx, types.NamespacedName{Namespace: deployment.Namespace, Name: deployment.Name}, latest); err != nil {
+			return err
+		}
+		return d.injectClusterDnsFailure(ctx, latest, experimentId)
+	}); err != nil {
+		logrusField.Warningf("inject cluster DNS failure to %s/%s failed: %v", deployment.Namespace, deployment.Name, err)
+		status = status.CreateFailResourceStatus(fmt.Sprintf("inject cluster DNS failure failed: %v", err), spec.K8sExecFailed.Code)
+		return spec.ReturnResultIgnoreCode(
+			v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}),
+		)
+	}
+
+	logrusField.Infof("scaled cluster DNS deployment %s/%s to 0 replicas", deployment.Namespace, deployment.Name)
+	status = status.CreateSuccessResourceStatus()
+	return spec.ReturnResultIgnoreCode(v1alpha1.CreateSuccessExperimentStatus([]v1alpha1.ResourceStatus{status}))
+}
+
+func (d *ClusterDnsFailureActionExecutor) destroy(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	experimentId := model.GetExperimentIdFromContext(ctx)
+	logrusField := logrus.WithField("experiment", experimentId)
+
+	dnsService, dnsNamespace := resolveDnsServiceFlags(expModel)
+
+	status := v1alpha1.ResourceStatus{
+		Kind:       ClusterDnsKind,
+		Identifier: fmt.Sprintf("%s/%s", dnsNamespace, dnsService),
+	}
+
+	deployment, err := d.findDnsDeployment(ctx, dnsNamespace, dnsService)
+	if err != nil {
+		util.Errorf(uid, util.GetRunFuncName(), err.Error())
+		logrusField.Warningf("locate cluster DNS deployment for restore failed: %v", err)
+		status = status.CreateFailResourceStatus(err.Error(), spec.K8sExecFailed.Code)
+		return spec.ReturnResultIgnoreCode(
+			v1alpha1.CreateFailExperimentStatus(err.Error(), []v1alpha1.ResourceStatus{status}),
+		)
+	}
+
+	status.Identifier = fmt.Sprintf("%s/%s/%s", dnsNamespace, dnsService, deployment.Name)
+
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		latest := &appsv1.Deployment{}
+		if err := d.client.Get(ctx, types.NamespacedName{Namespace: deployment.Namespace, Name: deployment.Name}, latest); err != nil {
+			return err
+		}
+		return d.restoreClusterDnsDeployment(ctx, latest, experimentId)
+	}); err != nil {
+		logrusField.Warningf("restore cluster DNS deployment %s/%s failed: %v", deployment.Namespace, deployment.Name, err)
+		status = status.CreateFailResourceStatus(fmt.Sprintf("restore cluster DNS deployment failed: %v", err), spec.K8sExecFailed.Code)
+		return spec.ReturnResultIgnoreCode(
+			v1alpha1.CreateFailExperimentStatus(status.Error, []v1alpha1.ResourceStatus{status}),
+		)
+	}
+
+	logrusField.Infof("restored cluster DNS deployment %s/%s", deployment.Namespace, deployment.Name)
+	status = status.CreateSuccessResourceStatus()
+	status.State = v1alpha1.DestroyedState
+	return spec.ReturnResultIgnoreCode(v1alpha1.CreateDestroyedExperimentStatus([]v1alpha1.ResourceStatus{status}))
+}
+
+// findDnsDeployment locates the Deployment that backs the given DNS service.
+//
+// It first reads the Service to discover its selector, then lists Deployments in
+// the same namespace and returns the first one whose pod template labels match
+// the Service selector. This works for the standard CoreDNS / kube-dns layout
+// where a Service of type ClusterIP fronts a Deployment.
+func (d *ClusterDnsFailureActionExecutor) findDnsDeployment(ctx context.Context, namespace, serviceName string) (*appsv1.Deployment, error) {
+	svc := &v1.Service{}
+	if err := d.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: serviceName}, svc); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("DNS service %s/%s not found", namespace, serviceName)
+		}
+		return nil, fmt.Errorf("get DNS service %s/%s failed: %v", namespace, serviceName, err)
+	}
+
+	if len(svc.Spec.Selector) == 0 {
+		return nil, fmt.Errorf("DNS service %s/%s has no selector, cannot reverse-resolve workload", namespace, serviceName)
+	}
+
+	selector := pkglabels.SelectorFromSet(svc.Spec.Selector)
+	deployments := &appsv1.DeploymentList{}
+	if err := d.client.List(ctx, deployments, &sigsclient.ListOptions{Namespace: namespace}); err != nil {
+		return nil, fmt.Errorf("list deployments in namespace %s failed: %v", namespace, err)
+	}
+
+	for i := range deployments.Items {
+		dep := &deployments.Items[i]
+		if selector.Matches(pkglabels.Set(dep.Spec.Template.Labels)) {
+			return dep, nil
+		}
+	}
+	return nil, fmt.Errorf("no Deployment in namespace %s matches DNS service %s selector %v",
+		namespace, serviceName, svc.Spec.Selector)
+}
+
+// injectClusterDnsFailure backs up the deployment's replica count and scales it to 0.
+// The function is idempotent: if the deployment is already modified by the same
+// experiment id, no further changes are made.
+func (d *ClusterDnsFailureActionExecutor) injectClusterDnsFailure(ctx context.Context, deployment *appsv1.Deployment, experimentId string) error {
+	if deployment.Annotations == nil {
+		deployment.Annotations = make(map[string]string)
+	}
+
+	if existingId, ok := deployment.Annotations[ChaosBladeExperimentAnnotation]; ok && existingId != "" && existingId != experimentId {
+		return fmt.Errorf("deployment is already modified by another chaosblade experiment: %s", existingId)
+	}
+	if deployment.Annotations[ChaosBladeExperimentAnnotation] == experimentId {
+		return nil
+	}
+
+	originalReplicas := int32(1)
+	if deployment.Spec.Replicas != nil {
+		originalReplicas = *deployment.Spec.Replicas
+	}
+
+	originalBytes, err := json.Marshal(originalReplicas)
+	if err != nil {
+		return fmt.Errorf("marshal original replicas failed: %v", err)
+	}
+	deployment.Annotations[ChaosBladeOriginalReplicasAnnotation] = string(originalBytes)
+	deployment.Annotations[ChaosBladeClusterDnsAnnotation] = ChaosBladeClusterDnsAction
+	deployment.Annotations[ChaosBladeExperimentAnnotation] = experimentId
+
+	zero := int32(0)
+	deployment.Spec.Replicas = &zero
+
+	return d.client.Update(ctx, deployment)
+}
+
+// restoreClusterDnsDeployment restores the deployment's original replica count.
+// If the deployment was not modified by this experiment id, the call is a no-op.
+func (d *ClusterDnsFailureActionExecutor) restoreClusterDnsDeployment(ctx context.Context, deployment *appsv1.Deployment, experimentId string) error {
+	if deployment.Annotations == nil {
+		return nil
+	}
+	if deployment.Annotations[ChaosBladeExperimentAnnotation] != experimentId {
+		return nil
+	}
+
+	originalReplicas, err := readOriginalReplicas(deployment.Annotations[ChaosBladeOriginalReplicasAnnotation])
+	if err != nil {
+		return err
+	}
+	deployment.Spec.Replicas = &originalReplicas
+
+	delete(deployment.Annotations, ChaosBladeOriginalReplicasAnnotation)
+	delete(deployment.Annotations, ChaosBladeClusterDnsAnnotation)
+	delete(deployment.Annotations, ChaosBladeExperimentAnnotation)
+
+	return d.client.Update(ctx, deployment)
+}
+
+// readOriginalReplicas decodes the backed-up replica count, supporting both a
+// raw integer string (e.g. "2") and a JSON-encoded integer (e.g. "2").
+func readOriginalReplicas(raw string) (int32, error) {
+	if raw == "" {
+		return 1, nil
+	}
+	if n, err := strconv.Atoi(raw); err == nil {
+		return int32(n), nil
+	}
+	var n int32
+	if err := json.Unmarshal([]byte(raw), &n); err != nil {
+		return 0, fmt.Errorf("decode original replicas %q failed: %v", raw, err)
+	}
+	return n, nil
+}
+
+func resolveDnsServiceFlags(expModel *spec.ExpModel) (string, string) {
+	dnsService := expModel.ActionFlags[DnsServiceFlag]
+	if dnsService == "" {
+		dnsService = DefaultDnsServiceName
+	}
+	dnsNamespace := expModel.ActionFlags[DnsServiceNamespaceFlag]
+	if dnsNamespace == "" {
+		dnsNamespace = DefaultDnsServiceNamespace
+	}
+	return dnsService, dnsNamespace
+}

--- a/exec/cluster/dnsfailure_test.go
+++ b/exec/cluster/dnsfailure_test.go
@@ -1,0 +1,882 @@
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cluster
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	sigsclient "sigs.k8s.io/controller-runtime/pkg/client"
+	sigsfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/chaosblade-io/chaosblade-operator/channel"
+	"github.com/chaosblade-io/chaosblade-operator/exec/model"
+	"github.com/chaosblade-io/chaosblade-operator/pkg/apis/chaosblade/v1alpha1"
+)
+
+// newTestScheme builds a runtime.Scheme registered with the api groups the
+// cluster DNS action touches. We avoid pulling in the full kubernetes scheme
+// to keep this test package's dependency surface small.
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := v1.AddToScheme(scheme); err != nil {
+		t.Fatalf("register corev1 scheme: %v", err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("register appsv1 scheme: %v", err)
+	}
+	return scheme
+}
+
+// newTestClient wraps a controller-runtime fake client into the operator's
+// channel.Client. The kubernetes.Interface field stays nil because the cluster
+// DNS action only uses the controller-runtime Client surface (Get/List/Update).
+func newTestClient(t *testing.T, objs ...sigsclient.Object) *channel.Client {
+	t.Helper()
+	fake := sigsfake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithObjects(objs...).
+		Build()
+	return &channel.Client{Client: fake}
+}
+
+func int32Ptr(i int32) *int32 { return &i }
+
+// dnsService builds a kube-dns-shaped Service object pointing at the given
+// selector labels.
+func dnsService(name, namespace string, selector map[string]string) *v1.Service {
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: v1.ServiceSpec{
+			Selector: selector,
+		},
+	}
+}
+
+// dnsDeployment builds a Deployment whose pod template carries the given
+// labels and replica count.
+func dnsDeployment(name, namespace string, templateLabels map[string]string, replicas *int32, annotations map[string]string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: replicas,
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: templateLabels},
+			},
+		},
+	}
+}
+
+func TestReadOriginalReplicas(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    int32
+		wantErr bool
+	}{
+		{name: "empty defaults to 1", raw: "", want: 1},
+		{name: "raw integer string", raw: "3", want: 3},
+		{name: "raw zero", raw: "0", want: 0},
+		{name: "negative integer accepted", raw: "-1", want: -1},
+		{name: "json-encoded integer", raw: "2", want: 2},
+		{name: "invalid value returns error", raw: "not-a-number", wantErr: true},
+		{name: "invalid json object returns error", raw: `{"x":1}`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := readOriginalReplicas(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("readOriginalReplicas(%q) expected error, got nil", tt.raw)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("readOriginalReplicas(%q) unexpected error: %v", tt.raw, err)
+			}
+			if got != tt.want {
+				t.Errorf("readOriginalReplicas(%q) = %d, want %d", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveDnsServiceFlags(t *testing.T) {
+	tests := []struct {
+		name          string
+		flags         map[string]string
+		wantService   string
+		wantNamespace string
+	}{
+		{
+			name:          "defaults when flags missing",
+			flags:         map[string]string{},
+			wantService:   DefaultDnsServiceName,
+			wantNamespace: DefaultDnsServiceNamespace,
+		},
+		{
+			name:          "defaults when flags empty",
+			flags:         map[string]string{DnsServiceFlag: "", DnsServiceNamespaceFlag: ""},
+			wantService:   DefaultDnsServiceName,
+			wantNamespace: DefaultDnsServiceNamespace,
+		},
+		{
+			name: "custom service and namespace honored",
+			flags: map[string]string{
+				DnsServiceFlag:          "coredns",
+				DnsServiceNamespaceFlag: "dns-system",
+			},
+			wantService:   "coredns",
+			wantNamespace: "dns-system",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, ns := resolveDnsServiceFlags(&spec.ExpModel{ActionFlags: tt.flags})
+			if svc != tt.wantService {
+				t.Errorf("service = %q, want %q", svc, tt.wantService)
+			}
+			if ns != tt.wantNamespace {
+				t.Errorf("namespace = %q, want %q", ns, tt.wantNamespace)
+			}
+		})
+	}
+}
+
+func TestFindDnsDeployment(t *testing.T) {
+	const ns = "kube-system"
+
+	t.Run("service not found returns descriptive error", func(t *testing.T) {
+		c := newTestClient(t)
+		exec := &ClusterDnsFailureActionExecutor{client: c}
+		_, err := exec.findDnsDeployment(context.Background(), ns, "kube-dns")
+		if err == nil || !strings.Contains(err.Error(), "not found") {
+			t.Fatalf("expected not-found error, got: %v", err)
+		}
+	})
+
+	t.Run("service without selector cannot be reverse-resolved", func(t *testing.T) {
+		c := newTestClient(t, dnsService("kube-dns", ns, nil))
+		exec := &ClusterDnsFailureActionExecutor{client: c}
+		_, err := exec.findDnsDeployment(context.Background(), ns, "kube-dns")
+		if err == nil || !strings.Contains(err.Error(), "no selector") {
+			t.Fatalf("expected no-selector error, got: %v", err)
+		}
+	})
+
+	t.Run("matches deployment by pod template labels", func(t *testing.T) {
+		svc := dnsService("kube-dns", ns, map[string]string{"k8s-app": "kube-dns"})
+		matching := dnsDeployment("coredns", ns,
+			map[string]string{"k8s-app": "kube-dns", "tier": "control-plane"},
+			int32Ptr(2), nil)
+		other := dnsDeployment("nginx", ns,
+			map[string]string{"app": "nginx"}, int32Ptr(3), nil)
+
+		c := newTestClient(t, svc, matching, other)
+		exec := &ClusterDnsFailureActionExecutor{client: c}
+
+		got, err := exec.findDnsDeployment(context.Background(), ns, "kube-dns")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Name != "coredns" {
+			t.Errorf("got deployment %q, want %q", got.Name, "coredns")
+		}
+	})
+
+	t.Run("ignores deployments whose template labels do not match", func(t *testing.T) {
+		// Deployment has matching top-level labels but pod template labels do not.
+		// The reverse-resolution must rely on pod template labels (what the
+		// Service selector actually filters on).
+		svc := dnsService("kube-dns", ns, map[string]string{"k8s-app": "kube-dns"})
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "coredns",
+				Namespace: ns,
+				Labels:    map[string]string{"k8s-app": "kube-dns"},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: int32Ptr(1),
+				Template: v1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "other"}},
+				},
+			},
+		}
+
+		c := newTestClient(t, svc, dep)
+		exec := &ClusterDnsFailureActionExecutor{client: c}
+
+		_, err := exec.findDnsDeployment(context.Background(), ns, "kube-dns")
+		if err == nil || !strings.Contains(err.Error(), "no Deployment") {
+			t.Fatalf("expected no-deployment error, got: %v", err)
+		}
+	})
+
+	t.Run("ignores deployments in other namespaces", func(t *testing.T) {
+		svc := dnsService("kube-dns", ns, map[string]string{"k8s-app": "kube-dns"})
+		other := dnsDeployment("coredns", "other-ns",
+			map[string]string{"k8s-app": "kube-dns"}, int32Ptr(2), nil)
+
+		c := newTestClient(t, svc, other)
+		exec := &ClusterDnsFailureActionExecutor{client: c}
+
+		_, err := exec.findDnsDeployment(context.Background(), ns, "kube-dns")
+		if err == nil || !strings.Contains(err.Error(), "no Deployment") {
+			t.Fatalf("expected no-deployment error for cross-namespace match, got: %v", err)
+		}
+	})
+
+	t.Run("multiple matches refuse to choose and list candidates", func(t *testing.T) {
+		// This is the exact footgun the code review flagged: two Deployments
+		// (e.g. CoreDNS + node-local-dns) share the kube-dns Service selector.
+		// Picking either one silently would risk a cluster-wide DNS outage.
+		svc := dnsService("kube-dns", ns, map[string]string{"k8s-app": "kube-dns"})
+		coredns := dnsDeployment("coredns", ns,
+			map[string]string{"k8s-app": "kube-dns", "name": "coredns"}, int32Ptr(2), nil)
+		nodeLocal := dnsDeployment("node-local-dns", ns,
+			map[string]string{"k8s-app": "kube-dns", "name": "node-local-dns"}, int32Ptr(2), nil)
+
+		c := newTestClient(t, svc, coredns, nodeLocal)
+		exec := &ClusterDnsFailureActionExecutor{client: c}
+
+		_, err := exec.findDnsDeployment(context.Background(), ns, "kube-dns")
+		if err == nil {
+			t.Fatal("expected ambiguous-match error, got nil")
+		}
+		msg := err.Error()
+		for _, want := range []string{"coredns", "node-local-dns", "matches 2 Deployments", DnsDeploymentFlag} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("ambiguous-match error %q must mention %q", msg, want)
+			}
+		}
+	})
+
+	t.Run("ambiguous-match candidate list is sorted for stable output", func(t *testing.T) {
+		// Build the conflicting deployments in non-alphabetical order to make
+		// sure sorting (not insertion order) drives the printed list. This
+		// keeps the error message stable across List() iteration ordering.
+		svc := dnsService("kube-dns", ns, map[string]string{"k8s-app": "kube-dns"})
+		z := dnsDeployment("z-dns", ns, map[string]string{"k8s-app": "kube-dns"}, int32Ptr(1), nil)
+		a := dnsDeployment("a-dns", ns, map[string]string{"k8s-app": "kube-dns"}, int32Ptr(1), nil)
+		m := dnsDeployment("m-dns", ns, map[string]string{"k8s-app": "kube-dns"}, int32Ptr(1), nil)
+
+		c := newTestClient(t, svc, z, a, m)
+		exec := &ClusterDnsFailureActionExecutor{client: c}
+
+		_, err := exec.findDnsDeployment(context.Background(), ns, "kube-dns")
+		if err == nil {
+			t.Fatal("expected ambiguous-match error, got nil")
+		}
+		// Whichever order the fake client returns, the error string must
+		// contain the candidates in lexicographic order.
+		if !strings.Contains(err.Error(), "[a-dns, m-dns, z-dns]") {
+			t.Errorf("expected sorted candidate list in error, got: %s", err.Error())
+		}
+	})
+}
+
+func TestResolveTargetDnsDeployment(t *testing.T) {
+	const ns = "kube-system"
+
+	t.Run("explicit deployment bypasses reverse-resolution", func(t *testing.T) {
+		// Service has an ambiguous selector that would normally fail. The
+		// explicit --dns-deployment flag must short-circuit the selector logic
+		// entirely so the user can recover from the ambiguity.
+		svc := dnsService("kube-dns", ns, map[string]string{"k8s-app": "kube-dns"})
+		coredns := dnsDeployment("coredns", ns,
+			map[string]string{"k8s-app": "kube-dns"}, int32Ptr(2), nil)
+		nodeLocal := dnsDeployment("node-local-dns", ns,
+			map[string]string{"k8s-app": "kube-dns"}, int32Ptr(2), nil)
+
+		c := newTestClient(t, svc, coredns, nodeLocal)
+		exec := &ClusterDnsFailureActionExecutor{client: c}
+
+		got, err := exec.resolveTargetDnsDeployment(context.Background(), ns, "kube-dns", "coredns")
+		if err != nil {
+			t.Fatalf("explicit deployment lookup failed: %v", err)
+		}
+		if got.Name != "coredns" {
+			t.Errorf("got deployment %q, want %q", got.Name, "coredns")
+		}
+	})
+
+	t.Run("explicit deployment ignores Service selector entirely", func(t *testing.T) {
+		// Even when the named Deployment does NOT match the Service selector,
+		// we trust the operator's explicit choice. This is the escape hatch
+		// for clusters where the Service's selector is unrelated to the
+		// Deployment's pod template labels.
+		svc := dnsService("kube-dns", ns, map[string]string{"k8s-app": "kube-dns"})
+		dep := dnsDeployment("custom-dns", ns,
+			map[string]string{"app": "custom"}, int32Ptr(1), nil)
+
+		c := newTestClient(t, svc, dep)
+		exec := &ClusterDnsFailureActionExecutor{client: c}
+
+		got, err := exec.resolveTargetDnsDeployment(context.Background(), ns, "kube-dns", "custom-dns")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Name != "custom-dns" {
+			t.Errorf("got %q, want %q", got.Name, "custom-dns")
+		}
+	})
+
+	t.Run("explicit deployment that does not exist surfaces a clear error", func(t *testing.T) {
+		c := newTestClient(t)
+		exec := &ClusterDnsFailureActionExecutor{client: c}
+
+		_, err := exec.resolveTargetDnsDeployment(context.Background(), ns, "kube-dns", "ghost")
+		if err == nil || !strings.Contains(err.Error(), "DNS deployment kube-system/ghost not found") {
+			t.Fatalf("expected not-found error for explicit deployment, got: %v", err)
+		}
+	})
+
+	t.Run("empty explicit deployment falls back to reverse-resolution", func(t *testing.T) {
+		svc := dnsService("kube-dns", ns, map[string]string{"k8s-app": "kube-dns"})
+		dep := dnsDeployment("coredns", ns,
+			map[string]string{"k8s-app": "kube-dns"}, int32Ptr(2), nil)
+
+		c := newTestClient(t, svc, dep)
+		exec := &ClusterDnsFailureActionExecutor{client: c}
+
+		got, err := exec.resolveTargetDnsDeployment(context.Background(), ns, "kube-dns", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Name != "coredns" {
+			t.Errorf("got %q, want %q", got.Name, "coredns")
+		}
+	})
+}
+
+func TestErrorsHintAtDisambiguationFlag(t *testing.T) {
+	// All reverse-resolution failure paths must point the operator at the
+	// --dns-deployment escape hatch so they are not stuck.
+	const ns = "kube-system"
+
+	cases := []struct {
+		name string
+		objs []sigsclient.Object
+	}{
+		{
+			name: "service not found",
+			objs: nil,
+		},
+		{
+			name: "service without selector",
+			objs: []sigsclient.Object{dnsService("kube-dns", ns, nil)},
+		},
+		{
+			name: "no matching deployment",
+			objs: []sigsclient.Object{dnsService("kube-dns", ns, map[string]string{"k8s-app": "kube-dns"})},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newTestClient(t, tt.objs...)
+			exec := &ClusterDnsFailureActionExecutor{client: c}
+			_, err := exec.findDnsDeployment(context.Background(), ns, "kube-dns")
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), DnsDeploymentFlag) {
+				t.Errorf("error %q should mention --%s as the escape hatch", err.Error(), DnsDeploymentFlag)
+			}
+		})
+	}
+}
+
+func TestResolveDnsFlags(t *testing.T) {
+	t.Run("explicit deployment value is trimmed and returned", func(t *testing.T) {
+		svc, ns, dep := resolveDnsFlags(&spec.ExpModel{ActionFlags: map[string]string{
+			DnsServiceFlag:          "coredns",
+			DnsServiceNamespaceFlag: "kube-system",
+			DnsDeploymentFlag:       "  my-dns  ",
+		}})
+		if svc != "coredns" || ns != "kube-system" {
+			t.Errorf("service/ns = %q/%q, want coredns/kube-system", svc, ns)
+		}
+		if dep != "my-dns" {
+			t.Errorf("deployment = %q, want %q (whitespace must be trimmed)", dep, "my-dns")
+		}
+	})
+
+	t.Run("missing explicit deployment yields empty string", func(t *testing.T) {
+		_, _, dep := resolveDnsFlags(&spec.ExpModel{ActionFlags: map[string]string{}})
+		if dep != "" {
+			t.Errorf("deployment = %q, want empty", dep)
+		}
+	})
+}
+
+func TestDnsIdentifierHelpers(t *testing.T) {
+	const ns = "kube-system"
+
+	tests := []struct {
+		name        string
+		svc         string
+		explicit    string
+		resolved    string
+		wantInitial string
+		wantFinal   string
+	}{
+		{
+			name:        "service-based identification carries svc/dep in resolved form",
+			svc:         "kube-dns",
+			explicit:    "",
+			resolved:    "coredns",
+			wantInitial: "kube-system/kube-dns",
+			wantFinal:   "kube-system/kube-dns/coredns",
+		},
+		{
+			name:        "explicit-deployment path omits the service segment",
+			svc:         "kube-dns",
+			explicit:    "node-local-dns",
+			resolved:    "node-local-dns",
+			wantInitial: "kube-system/node-local-dns",
+			wantFinal:   "kube-system/node-local-dns",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := initialDnsIdentifier(ns, tt.svc, tt.explicit); got != tt.wantInitial {
+				t.Errorf("initial identifier = %q, want %q", got, tt.wantInitial)
+			}
+			if got := resolvedDnsIdentifier(ns, tt.svc, tt.explicit, tt.resolved); got != tt.wantFinal {
+				t.Errorf("resolved identifier = %q, want %q", got, tt.wantFinal)
+			}
+		})
+	}
+}
+
+func TestInjectClusterDnsFailure(t *testing.T) {
+	const ns = "kube-system"
+	templateLabels := map[string]string{"k8s-app": "kube-dns"}
+
+	t.Run("backs up replicas, scales to zero and writes annotations", func(t *testing.T) {
+		dep := dnsDeployment("coredns", ns, templateLabels, int32Ptr(2), nil)
+		c := newTestClient(t, dep)
+		exec := &ClusterDnsFailureActionExecutor{client: c}
+
+		if err := exec.injectClusterDnsFailure(context.Background(), dep, "exp-1"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		got := &appsv1.Deployment{}
+		if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "coredns"}, got); err != nil {
+			t.Fatalf("get after inject failed: %v", err)
+		}
+		if got.Spec.Replicas == nil || *got.Spec.Replicas != 0 {
+			t.Errorf("replicas after inject = %v, want 0", got.Spec.Replicas)
+		}
+		if got.Annotations[ChaosBladeOriginalReplicasAnnotation] != "2" {
+			t.Errorf("original replicas annotation = %q, want %q",
+				got.Annotations[ChaosBladeOriginalReplicasAnnotation], "2")
+		}
+		if got.Annotations[ChaosBladeClusterDnsAnnotation] != ChaosBladeClusterDnsAction {
+			t.Errorf("dns action annotation = %q, want %q",
+				got.Annotations[ChaosBladeClusterDnsAnnotation], ChaosBladeClusterDnsAction)
+		}
+		if got.Annotations[ChaosBladeExperimentAnnotation] != "exp-1" {
+			t.Errorf("experiment annotation = %q, want %q",
+				got.Annotations[ChaosBladeExperimentAnnotation], "exp-1")
+		}
+	})
+
+	t.Run("nil replicas treated as 1", func(t *testing.T) {
+		dep := dnsDeployment("coredns", ns, templateLabels, nil, nil)
+		c := newTestClient(t, dep)
+		exec := &ClusterDnsFailureActionExecutor{client: c}
+
+		if err := exec.injectClusterDnsFailure(context.Background(), dep, "exp-1"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got := &appsv1.Deployment{}
+		_ = c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "coredns"}, got)
+		if got.Annotations[ChaosBladeOriginalReplicasAnnotation] != "1" {
+			t.Errorf("original replicas annotation = %q, want %q",
+				got.Annotations[ChaosBladeOriginalReplicasAnnotation], "1")
+		}
+	})
+
+	t.Run("idempotent: same experiment id is a no-op", func(t *testing.T) {
+		// Deployment already marked by the same experiment with replicas==0.
+		// Re-running the injection must not overwrite the backed-up replicas
+		// (which would cause the destroy flow to "restore" to 0).
+		dep := dnsDeployment("coredns", ns, templateLabels, int32Ptr(0), map[string]string{
+			ChaosBladeOriginalReplicasAnnotation: "2",
+			ChaosBladeClusterDnsAnnotation:       ChaosBladeClusterDnsAction,
+			ChaosBladeExperimentAnnotation:       "exp-1",
+		})
+		c := newTestClient(t, dep)
+		exec := &ClusterDnsFailureActionExecutor{client: c}
+
+		if err := exec.injectClusterDnsFailure(context.Background(), dep, "exp-1"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got := &appsv1.Deployment{}
+		_ = c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "coredns"}, got)
+		if got.Annotations[ChaosBladeOriginalReplicasAnnotation] != "2" {
+			t.Errorf("idempotent re-injection clobbered backup, annotation = %q",
+				got.Annotations[ChaosBladeOriginalReplicasAnnotation])
+		}
+	})
+
+	t.Run("conflict: another experiment owns the deployment", func(t *testing.T) {
+		dep := dnsDeployment("coredns", ns, templateLabels, int32Ptr(0), map[string]string{
+			ChaosBladeOriginalReplicasAnnotation: "2",
+			ChaosBladeClusterDnsAnnotation:       ChaosBladeClusterDnsAction,
+			ChaosBladeExperimentAnnotation:       "exp-other",
+		})
+		c := newTestClient(t, dep)
+		exec := &ClusterDnsFailureActionExecutor{client: c}
+
+		err := exec.injectClusterDnsFailure(context.Background(), dep, "exp-1")
+		if err == nil {
+			t.Fatalf("expected conflict error, got nil")
+		}
+		if !strings.Contains(err.Error(), "already modified by another chaosblade experiment") {
+			t.Errorf("unexpected error message: %v", err)
+		}
+
+		// Backup must remain untouched so the original owner can still restore.
+		got := &appsv1.Deployment{}
+		_ = c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "coredns"}, got)
+		if got.Annotations[ChaosBladeOriginalReplicasAnnotation] != "2" {
+			t.Errorf("conflict path mutated backup annotation: %q",
+				got.Annotations[ChaosBladeOriginalReplicasAnnotation])
+		}
+		if got.Annotations[ChaosBladeExperimentAnnotation] != "exp-other" {
+			t.Errorf("conflict path mutated experiment owner: %q",
+				got.Annotations[ChaosBladeExperimentAnnotation])
+		}
+	})
+}
+
+func TestRestoreClusterDnsDeployment(t *testing.T) {
+	const ns = "kube-system"
+	templateLabels := map[string]string{"k8s-app": "kube-dns"}
+
+	t.Run("restores replicas and clears annotations", func(t *testing.T) {
+		dep := dnsDeployment("coredns", ns, templateLabels, int32Ptr(0), map[string]string{
+			ChaosBladeOriginalReplicasAnnotation: "2",
+			ChaosBladeClusterDnsAnnotation:       ChaosBladeClusterDnsAction,
+			ChaosBladeExperimentAnnotation:       "exp-1",
+			"other-annotation":                   "keep-me",
+		})
+		c := newTestClient(t, dep)
+		exec := &ClusterDnsFailureActionExecutor{client: c}
+
+		if err := exec.restoreClusterDnsDeployment(context.Background(), dep, "exp-1"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		got := &appsv1.Deployment{}
+		if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "coredns"}, got); err != nil {
+			t.Fatalf("get after restore failed: %v", err)
+		}
+		if got.Spec.Replicas == nil || *got.Spec.Replicas != 2 {
+			t.Errorf("replicas after restore = %v, want 2", got.Spec.Replicas)
+		}
+		if _, exists := got.Annotations[ChaosBladeOriginalReplicasAnnotation]; exists {
+			t.Errorf("original replicas annotation should be cleared")
+		}
+		if _, exists := got.Annotations[ChaosBladeClusterDnsAnnotation]; exists {
+			t.Errorf("dns action annotation should be cleared")
+		}
+		if _, exists := got.Annotations[ChaosBladeExperimentAnnotation]; exists {
+			t.Errorf("experiment annotation should be cleared")
+		}
+		if got.Annotations["other-annotation"] != "keep-me" {
+			t.Errorf("unrelated annotation must be preserved")
+		}
+	})
+
+	t.Run("deployment without annotations is a safe no-op", func(t *testing.T) {
+		dep := dnsDeployment("coredns", ns, templateLabels, int32Ptr(3), nil)
+		c := newTestClient(t, dep)
+		exec := &ClusterDnsFailureActionExecutor{client: c}
+
+		if err := exec.restoreClusterDnsDeployment(context.Background(), dep, "exp-1"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got := &appsv1.Deployment{}
+		_ = c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "coredns"}, got)
+		if got.Spec.Replicas == nil || *got.Spec.Replicas != 3 {
+			t.Errorf("replicas changed unexpectedly: %v", got.Spec.Replicas)
+		}
+	})
+
+	t.Run("foreign experiment id is a safe no-op", func(t *testing.T) {
+		// Critical safety property: a destroy from a different experiment must
+		// not restore (and thereby leak) somebody else's backup, nor change
+		// the current replica count.
+		dep := dnsDeployment("coredns", ns, templateLabels, int32Ptr(0), map[string]string{
+			ChaosBladeOriginalReplicasAnnotation: "2",
+			ChaosBladeClusterDnsAnnotation:       ChaosBladeClusterDnsAction,
+			ChaosBladeExperimentAnnotation:       "exp-other",
+		})
+		c := newTestClient(t, dep)
+		exec := &ClusterDnsFailureActionExecutor{client: c}
+
+		if err := exec.restoreClusterDnsDeployment(context.Background(), dep, "exp-1"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got := &appsv1.Deployment{}
+		_ = c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "coredns"}, got)
+		if got.Spec.Replicas == nil || *got.Spec.Replicas != 0 {
+			t.Errorf("foreign-id restore mutated replicas: %v", got.Spec.Replicas)
+		}
+		if got.Annotations[ChaosBladeExperimentAnnotation] != "exp-other" {
+			t.Errorf("foreign-id restore cleared other owner's annotation")
+		}
+	})
+
+	t.Run("malformed backup annotation surfaces decode error", func(t *testing.T) {
+		dep := dnsDeployment("coredns", ns, templateLabels, int32Ptr(0), map[string]string{
+			ChaosBladeOriginalReplicasAnnotation: "not-a-number",
+			ChaosBladeClusterDnsAnnotation:       ChaosBladeClusterDnsAction,
+			ChaosBladeExperimentAnnotation:       "exp-1",
+		})
+		c := newTestClient(t, dep)
+		exec := &ClusterDnsFailureActionExecutor{client: c}
+
+		err := exec.restoreClusterDnsDeployment(context.Background(), dep, "exp-1")
+		if err == nil {
+			t.Fatalf("expected decode error, got nil")
+		}
+		if !strings.Contains(err.Error(), "decode original replicas") {
+			t.Errorf("unexpected error message: %v", err)
+		}
+
+		// The deployment must remain untouched so a human (or a follow-up
+		// destroy with a corrected annotation) can recover it.
+		got := &appsv1.Deployment{}
+		_ = c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "coredns"}, got)
+		if got.Spec.Replicas == nil || *got.Spec.Replicas != 0 {
+			t.Errorf("error path mutated replicas: %v", got.Spec.Replicas)
+		}
+	})
+}
+
+// TestExec_CreateThenDestroy_RoundTrip is the end-to-end safety net the code
+// review asked for: it stitches the real Exec entry point against a fake
+// client and verifies that destroying the experiment scales the DNS workload
+// back to its original replica count.
+func TestExec_CreateThenDestroy_RoundTrip(t *testing.T) {
+	const ns = "kube-system"
+	selector := map[string]string{"k8s-app": "kube-dns"}
+
+	svc := dnsService("kube-dns", ns, selector)
+	dep := dnsDeployment("coredns", ns, selector, int32Ptr(2), nil)
+
+	c := newTestClient(t, svc, dep)
+	executor := &ClusterDnsFailureActionExecutor{client: c}
+
+	expModel := &spec.ExpModel{
+		ActionFlags: map[string]string{
+			DnsServiceFlag:          "kube-dns",
+			DnsServiceNamespaceFlag: ns,
+		},
+	}
+
+	createCtx := model.SetExperimentIdToContext(context.Background(), "exp-roundtrip")
+	createResp := executor.Exec("uid-1", createCtx, expModel)
+	if createResp == nil {
+		t.Fatal("create response is nil")
+	}
+	if status, ok := createResp.Result.(v1alpha1.ExperimentStatus); ok && !status.Success {
+		t.Fatalf("create failed: %s", status.Error)
+	}
+
+	// Mid-experiment state: replicas==0 and annotations populated.
+	mid := &appsv1.Deployment{}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "coredns"}, mid); err != nil {
+		t.Fatalf("get mid-state failed: %v", err)
+	}
+	if mid.Spec.Replicas == nil || *mid.Spec.Replicas != 0 {
+		t.Fatalf("mid-state replicas = %v, want 0", mid.Spec.Replicas)
+	}
+	if mid.Annotations[ChaosBladeExperimentAnnotation] != "exp-roundtrip" {
+		t.Fatalf("mid-state experiment annotation = %q, want %q",
+			mid.Annotations[ChaosBladeExperimentAnnotation], "exp-roundtrip")
+	}
+
+	// Destroy phase.
+	destroyCtx := spec.SetDestroyFlag(createCtx, "uid-1")
+	destroyResp := executor.Exec("uid-1", destroyCtx, expModel)
+	if destroyResp == nil {
+		t.Fatal("destroy response is nil")
+	}
+
+	// Post-destroy state: replicas restored, annotations cleared.
+	post := &appsv1.Deployment{}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "coredns"}, post); err != nil {
+		t.Fatalf("get post-destroy state failed: %v", err)
+	}
+	if post.Spec.Replicas == nil || *post.Spec.Replicas != 2 {
+		t.Errorf("post-destroy replicas = %v, want 2 — DNS workload would be left scaled to %v",
+			post.Spec.Replicas, post.Spec.Replicas)
+	}
+	for _, key := range []string{
+		ChaosBladeOriginalReplicasAnnotation,
+		ChaosBladeClusterDnsAnnotation,
+		ChaosBladeExperimentAnnotation,
+	} {
+		if _, exists := post.Annotations[key]; exists {
+			t.Errorf("annotation %q should have been cleared after destroy", key)
+		}
+	}
+}
+
+// TestExec_ExplicitDeployment_RoundTrip covers the disambiguation path: two
+// Deployments share the kube-dns Service selector, so the reverse-resolution
+// would refuse to choose. The operator escapes via --dns-deployment, and the
+// action must still inject and restore the explicitly named workload while
+// leaving the other one completely untouched.
+func TestExec_ExplicitDeployment_RoundTrip(t *testing.T) {
+	const ns = "kube-system"
+	selector := map[string]string{"k8s-app": "kube-dns"}
+
+	svc := dnsService("kube-dns", ns, selector)
+	coredns := dnsDeployment("coredns", ns, selector, int32Ptr(2), nil)
+	nodeLocal := dnsDeployment("node-local-dns", ns, selector, int32Ptr(3), nil)
+
+	c := newTestClient(t, svc, coredns, nodeLocal)
+	executor := &ClusterDnsFailureActionExecutor{client: c}
+
+	expModel := &spec.ExpModel{
+		ActionFlags: map[string]string{
+			DnsServiceFlag:          "kube-dns",
+			DnsServiceNamespaceFlag: ns,
+			DnsDeploymentFlag:       "coredns",
+		},
+	}
+
+	createCtx := model.SetExperimentIdToContext(context.Background(), "exp-explicit")
+	if createResp := executor.Exec("uid-1", createCtx, expModel); createResp == nil {
+		t.Fatal("create response is nil")
+	}
+
+	mid := &appsv1.Deployment{}
+	_ = c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "coredns"}, mid)
+	if mid.Spec.Replicas == nil || *mid.Spec.Replicas != 0 {
+		t.Errorf("explicit-target replicas after inject = %v, want 0", mid.Spec.Replicas)
+	}
+	if mid.Annotations[ChaosBladeExperimentAnnotation] != "exp-explicit" {
+		t.Errorf("explicit-target experiment annotation = %q, want exp-explicit",
+			mid.Annotations[ChaosBladeExperimentAnnotation])
+	}
+
+	// The non-targeted workload must be completely untouched — this is the
+	// whole point of the disambiguation fix.
+	bystander := &appsv1.Deployment{}
+	_ = c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "node-local-dns"}, bystander)
+	if bystander.Spec.Replicas == nil || *bystander.Spec.Replicas != 3 {
+		t.Errorf("bystander replicas mutated to %v — disambiguation failed", bystander.Spec.Replicas)
+	}
+	if _, exists := bystander.Annotations[ChaosBladeExperimentAnnotation]; exists {
+		t.Error("bystander annotation set — disambiguation failed")
+	}
+
+	// Destroy phase: must also operate on the explicit target only.
+	destroyCtx := spec.SetDestroyFlag(createCtx, "uid-1")
+	if destroyResp := executor.Exec("uid-1", destroyCtx, expModel); destroyResp == nil {
+		t.Fatal("destroy response is nil")
+	}
+
+	post := &appsv1.Deployment{}
+	_ = c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "coredns"}, post)
+	if post.Spec.Replicas == nil || *post.Spec.Replicas != 2 {
+		t.Errorf("post-destroy replicas = %v, want 2", post.Spec.Replicas)
+	}
+
+	bystanderAfter := &appsv1.Deployment{}
+	_ = c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "node-local-dns"}, bystanderAfter)
+	if bystanderAfter.Spec.Replicas == nil || *bystanderAfter.Spec.Replicas != 3 {
+		t.Errorf("bystander replicas mutated during destroy: %v", bystanderAfter.Spec.Replicas)
+	}
+}
+
+// TestExec_AmbiguousSelector_FailsLoudly verifies the create path surfaces a
+// resource-level failure (rather than silently picking one) when multiple
+// Deployments match the DNS Service selector and no --dns-deployment is set.
+func TestExec_AmbiguousSelector_FailsLoudly(t *testing.T) {
+	const ns = "kube-system"
+	selector := map[string]string{"k8s-app": "kube-dns"}
+
+	svc := dnsService("kube-dns", ns, selector)
+	coredns := dnsDeployment("coredns", ns, selector, int32Ptr(2), nil)
+	nodeLocal := dnsDeployment("node-local-dns", ns, selector, int32Ptr(3), nil)
+
+	c := newTestClient(t, svc, coredns, nodeLocal)
+	executor := &ClusterDnsFailureActionExecutor{client: c}
+
+	expModel := &spec.ExpModel{
+		ActionFlags: map[string]string{
+			DnsServiceFlag:          "kube-dns",
+			DnsServiceNamespaceFlag: ns,
+			// Intentionally no DnsDeploymentFlag.
+		},
+	}
+
+	ctx := model.SetExperimentIdToContext(context.Background(), "exp-ambiguous")
+	resp := executor.Exec("uid-1", ctx, expModel)
+	if resp == nil {
+		t.Fatal("response is nil")
+	}
+
+	// Neither Deployment should have been scaled — the ambiguity must be
+	// surfaced before any mutation. This is the regression the reviewer's
+	// concern would have allowed.
+	for _, name := range []string{"coredns", "node-local-dns"} {
+		got := &appsv1.Deployment{}
+		_ = c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: name}, got)
+		if got.Spec.Replicas == nil {
+			t.Errorf("%s replicas became nil", name)
+			continue
+		}
+		// coredns started at 2, node-local-dns at 3 — both must be unchanged.
+		want := int32(2)
+		if name == "node-local-dns" {
+			want = 3
+		}
+		if *got.Spec.Replicas != want {
+			t.Errorf("%s replicas = %d, want %d (ambiguous-selector path must not mutate)",
+				name, *got.Spec.Replicas, want)
+		}
+		if _, exists := got.Annotations[ChaosBladeExperimentAnnotation]; exists {
+			t.Errorf("%s was annotated by ambiguous-selector path", name)
+		}
+	}
+}

--- a/exec/controller.go
+++ b/exec/controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/chaosblade-io/chaosblade-operator/channel"
+	"github.com/chaosblade-io/chaosblade-operator/exec/cluster"
 	"github.com/chaosblade-io/chaosblade-operator/exec/container"
 	"github.com/chaosblade-io/chaosblade-operator/exec/model"
 	"github.com/chaosblade-io/chaosblade-operator/exec/node"
@@ -53,6 +54,7 @@ func NewDispatcherExecutor(client *channel.Client) *ResourceDispatchedController
 			pod.NewExpController(client),
 			container.NewExpController(client),
 			service.NewExpController(client),
+			cluster.NewExpController(client),
 		)
 	})
 	return executor

--- a/exec/pod/dnsfailureexp.go
+++ b/exec/pod/dnsfailureexp.go
@@ -1,0 +1,620 @@
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pod
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
+	"github.com/sirupsen/logrus"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	sigsclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/chaosblade-io/chaosblade-operator/channel"
+	"github.com/chaosblade-io/chaosblade-operator/exec/model"
+	"github.com/chaosblade-io/chaosblade-operator/pkg/apis/chaosblade/v1alpha1"
+)
+
+const (
+	// DnsFailureNameserverFlag is the optional flag specifying the nameserver IP
+	// to be validated against the pod's DNS configuration. When provided, the
+	// action requires the pod's resolved nameservers to contain this IP before
+	// proceeding with the injection.
+	DnsFailureNameserverFlag = "nameserver"
+
+	// ChaosBladePodDnsFailureAction is the marker annotation value for the pod
+	// DNS failure action.
+	ChaosBladePodDnsFailureAction = "dnsfailure"
+	// ChaosBladePodDnsFailureAnnotation marks workloads modified by the pod DNS
+	// failure action.
+	ChaosBladePodDnsFailureAnnotation = "chaosblade.io/pod-dnsfailure"
+	// ChaosBladeOriginalDnsPolicyAnnotation stores the workload's original
+	// PodSpec.DNSPolicy as a JSON string.
+	ChaosBladeOriginalDnsPolicyAnnotation = "chaosblade.io/original-dnspolicy"
+	// ChaosBladeOriginalDnsConfigAnnotation stores the workload's original
+	// PodSpec.DNSConfig as a JSON string. An empty string means the original
+	// DNSConfig was nil (i.e. the pod inherited from DNSPolicy).
+	ChaosBladeOriginalDnsConfigAnnotation = "chaosblade.io/original-dnsconfig"
+
+	// UnreachableDnsNameserver is the placeholder nameserver injected to the
+	// workload's PodSpec to make all DNS queries originating from the pod fail.
+	// 127.0.0.255 is in the loopback /8 and is guaranteed not to listen on UDP/53.
+	UnreachableDnsNameserver = "127.0.0.255"
+)
+
+// supportedWorkloadKinds is the set of workload kinds that this action can
+// inject into. Pods owned by workloads outside this set (e.g. naked pods, Jobs)
+// are not supported because their PodSpec is not modifiable in a way that
+// survives recreation.
+var supportedWorkloadKinds = map[string]struct{}{
+	"Deployment":  {},
+	"DaemonSet":   {},
+	"StatefulSet": {},
+}
+
+type PodDnsFailureActionSpec struct {
+	spec.BaseExpActionCommandSpec
+	client *channel.Client
+}
+
+func NewPodDnsFailureActionSpec(client *channel.Client) spec.ExpActionCommandSpec {
+	return &PodDnsFailureActionSpec{
+		BaseExpActionCommandSpec: spec.BaseExpActionCommandSpec{
+			ActionMatchers: []spec.ExpFlagSpec{},
+			ActionFlags: []spec.ExpFlagSpec{
+				&spec.ExpFlag{
+					Name:     DnsFailureNameserverFlag,
+					Desc:     "Nameserver IP to be validated against the pod's DNS configuration. When set, the pod must reference this nameserver, otherwise the injection fails. Optional",
+					Required: false,
+				},
+			},
+			ActionExecutor: &PodDnsFailureActionExecutor{client: client},
+			ActionExample: `# Make all DNS queries from a pod fail by injecting an unreachable nameserver to its workload
+blade create k8s pod-pod dnsfailure --names nginx-app-xxx --namespace default --kubeconfig ~/.kube/config
+
+# Same as above but require that the pod is currently configured to use 10.96.0.10 as a nameserver
+blade create k8s pod-pod dnsfailure --names nginx-app-xxx --namespace default --nameserver 10.96.0.10 --kubeconfig ~/.kube/config
+
+# Inject DNS failure for pods selected by labels
+blade create k8s pod-pod dnsfailure --labels app=nginx --namespace default --kubeconfig ~/.kube/config
+`,
+			ActionCategories: []string{model.CategorySystemContainer},
+		},
+		client: client,
+	}
+}
+
+func (*PodDnsFailureActionSpec) Name() string {
+	return "dnsfailure"
+}
+
+func (*PodDnsFailureActionSpec) Aliases() []string {
+	return []string{}
+}
+
+func (*PodDnsFailureActionSpec) ShortDesc() string {
+	return "Make pod DNS resolution completely unavailable by injecting an unreachable nameserver"
+}
+
+func (*PodDnsFailureActionSpec) LongDesc() string {
+	return "Resolve the target pod's DNS configuration (DNSPolicy + DNSConfig and the runtime resolv.conf), " +
+		"then inject a complete DNS unavailability fault by overriding the owning workload's PodSpec to use " +
+		"an unreachable nameserver. The original DNSPolicy/DNSConfig is backed up to workload annotations and " +
+		"restored when the experiment is destroyed. The pod is deleted after injection so the controller " +
+		"recreates it with the faulty DNS configuration."
+}
+
+type PodDnsFailureActionExecutor struct {
+	client *channel.Client
+}
+
+func (*PodDnsFailureActionExecutor) Name() string {
+	return "dnsfailure"
+}
+
+func (*PodDnsFailureActionExecutor) SetChannel(channel spec.Channel) {}
+
+func (d *PodDnsFailureActionExecutor) Exec(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	if _, ok := spec.IsDestroy(ctx); ok {
+		return d.destroy(uid, ctx, expModel)
+	}
+	return d.create(uid, ctx, expModel)
+}
+
+func (d *PodDnsFailureActionExecutor) create(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	experimentId := model.GetExperimentIdFromContext(ctx)
+	logrusField := logrus.WithField("experiment", experimentId)
+
+	containerObjectMetaList, err := model.GetContainerObjectMetaListFromContext(ctx)
+	if err != nil {
+		util.Errorf(uid, util.GetRunFuncName(), err.Error())
+		return spec.ResponseFailWithResult(spec.ContainerInContextNotFound,
+			v1alpha1.CreateFailExperimentStatus(spec.ContainerInContextNotFound.Msg, []v1alpha1.ResourceStatus{}))
+	}
+
+	requiredNameserver := strings.TrimSpace(expModel.ActionFlags[DnsFailureNameserverFlag])
+
+	// Track workloads already injected during this experiment to avoid double
+	// processing when multiple matched pods belong to the same workload.
+	processedWorkloads := make(map[string]bool)
+	statuses := make([]v1alpha1.ResourceStatus, 0)
+	success := false
+
+	for _, meta := range containerObjectMetaList {
+		status := v1alpha1.ResourceStatus{
+			Kind:       v1alpha1.PodKind,
+			Identifier: meta.GetIdentifier(),
+		}
+
+		pod := &v1.Pod{}
+		if err := d.client.Get(ctx, types.NamespacedName{Name: meta.PodName, Namespace: meta.Namespace}, pod); err != nil {
+			logrusField.Warningf("get pod %s/%s failed: %v", meta.Namespace, meta.PodName, err)
+			status = status.CreateFailResourceStatus(fmt.Sprintf("get pod failed: %v", err), spec.K8sExecFailed.Code)
+			statuses = append(statuses, status)
+			continue
+		}
+
+		if requiredNameserver != "" {
+			if !podUsesNameserver(pod, requiredNameserver) {
+				errMsg := fmt.Sprintf("pod %s/%s does not reference nameserver %s in its DNS config",
+					meta.Namespace, meta.PodName, requiredNameserver)
+				logrusField.Warning(errMsg)
+				status = status.CreateFailResourceStatus(errMsg, spec.K8sExecFailed.Code)
+				statuses = append(statuses, status)
+				continue
+			}
+		}
+
+		ownerKind, ownerName, err := resolveTopLevelWorkload(ctx, d.client, pod)
+		if err != nil {
+			logrusField.Warningf("resolve workload for pod %s/%s failed: %v", meta.Namespace, meta.PodName, err)
+			status = status.CreateFailResourceStatus(err.Error(), spec.K8sExecFailed.Code)
+			statuses = append(statuses, status)
+			continue
+		}
+
+		workloadKey := fmt.Sprintf("%s/%s/%s", pod.Namespace, ownerKind, ownerName)
+		if !processedWorkloads[workloadKey] {
+			if err := d.injectWorkloadDnsFailure(ctx, pod.Namespace, ownerKind, ownerName, experimentId); err != nil {
+				logrusField.Warningf("inject DNS failure to %s %s/%s failed: %v", ownerKind, pod.Namespace, ownerName, err)
+				status = status.CreateFailResourceStatus(
+					fmt.Sprintf("inject DNS failure to %s %s/%s failed: %v", ownerKind, pod.Namespace, ownerName, err),
+					spec.K8sExecFailed.Code,
+				)
+				statuses = append(statuses, status)
+				continue
+			}
+			processedWorkloads[workloadKey] = true
+			logrusField.Infof("injected DNS failure to %s %s/%s for pod %s",
+				ownerKind, pod.Namespace, ownerName, meta.PodName)
+		}
+
+		// Delete the pod so the controller recreates it with the faulty DNS config.
+		if err := d.client.Delete(ctx, pod); err != nil && !apierrors.IsNotFound(err) {
+			logrusField.Warningf("delete pod %s/%s failed: %v", meta.Namespace, meta.PodName, err)
+			status = status.CreateFailResourceStatus(fmt.Sprintf("delete pod failed: %v", err), spec.K8sExecFailed.Code)
+			statuses = append(statuses, status)
+			continue
+		}
+
+		status = status.CreateSuccessResourceStatus()
+		statuses = append(statuses, status)
+		success = true
+	}
+
+	if success {
+		return spec.ReturnResultIgnoreCode(v1alpha1.CreateSuccessExperimentStatus(statuses))
+	}
+	return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus("see resStatuses for details", statuses))
+}
+
+func (d *PodDnsFailureActionExecutor) destroy(uid string, ctx context.Context, expModel *spec.ExpModel) *spec.Response {
+	experimentId := model.GetExperimentIdFromContext(ctx)
+	logrusField := logrus.WithField("experiment", experimentId)
+
+	containerObjectMetaList, err := model.GetContainerObjectMetaListFromContext(ctx)
+	if err != nil {
+		util.Errorf(uid, util.GetRunFuncName(), err.Error())
+		return spec.ResponseFailWithResult(spec.ContainerInContextNotFound,
+			v1alpha1.CreateFailExperimentStatus(spec.ContainerInContextNotFound.Msg, []v1alpha1.ResourceStatus{}))
+	}
+
+	processedWorkloads := make(map[string]bool)
+	statuses := make([]v1alpha1.ResourceStatus, 0)
+	allSuccess := true
+
+	for _, meta := range containerObjectMetaList {
+		status := v1alpha1.ResourceStatus{
+			Id:         meta.Id,
+			Kind:       v1alpha1.PodKind,
+			Identifier: meta.GetIdentifier(),
+		}
+
+		// During destroy, the pod referenced by the original injection is likely
+		// already replaced. Still attempt to look up an owner via any pod that
+		// currently has this name in the namespace; if the lookup fails we fall
+		// back to using the original ResourceStatus identifier.
+		pod := &v1.Pod{}
+		if err := d.client.Get(ctx, types.NamespacedName{Name: meta.PodName, Namespace: meta.Namespace}, pod); err != nil {
+			if !apierrors.IsNotFound(err) {
+				logrusField.Warningf("get pod %s/%s for restore failed: %v", meta.Namespace, meta.PodName, err)
+			}
+			// If we cannot resolve the owner from the pod, the workload likely
+			// still needs to be restored. We try to restore by enumerating
+			// supported workloads in the namespace that carry our experiment
+			// annotation.
+			if err := d.restoreNamespaceWorkloads(ctx, meta.Namespace, experimentId, processedWorkloads); err != nil {
+				logrusField.Warningf("restore namespace %s workloads failed: %v", meta.Namespace, err)
+				status = status.CreateFailResourceStatus(err.Error(), spec.K8sExecFailed.Code)
+				statuses = append(statuses, status)
+				allSuccess = false
+				continue
+			}
+			status = status.CreateSuccessResourceStatus()
+			status.State = v1alpha1.DestroyedState
+			statuses = append(statuses, status)
+			continue
+		}
+
+		ownerKind, ownerName, err := resolveTopLevelWorkload(ctx, d.client, pod)
+		if err != nil {
+			logrusField.Warningf("resolve workload for pod %s/%s during restore failed: %v",
+				meta.Namespace, meta.PodName, err)
+			if err := d.restoreNamespaceWorkloads(ctx, meta.Namespace, experimentId, processedWorkloads); err != nil {
+				logrusField.Warningf("restore namespace %s workloads failed: %v", meta.Namespace, err)
+				status = status.CreateFailResourceStatus(err.Error(), spec.K8sExecFailed.Code)
+				statuses = append(statuses, status)
+				allSuccess = false
+				continue
+			}
+			status = status.CreateSuccessResourceStatus()
+			status.State = v1alpha1.DestroyedState
+			statuses = append(statuses, status)
+			continue
+		}
+
+		workloadKey := fmt.Sprintf("%s/%s/%s", pod.Namespace, ownerKind, ownerName)
+		if !processedWorkloads[workloadKey] {
+			if err := d.restoreWorkloadDnsFailure(ctx, pod.Namespace, ownerKind, ownerName, experimentId); err != nil {
+				logrusField.Warningf("restore DNS failure on %s %s/%s failed: %v",
+					ownerKind, pod.Namespace, ownerName, err)
+				status = status.CreateFailResourceStatus(err.Error(), spec.K8sExecFailed.Code)
+				statuses = append(statuses, status)
+				allSuccess = false
+				continue
+			}
+			processedWorkloads[workloadKey] = true
+			logrusField.Infof("restored DNS configuration on %s %s/%s", ownerKind, pod.Namespace, ownerName)
+		}
+
+		status = status.CreateSuccessResourceStatus()
+		status.State = v1alpha1.DestroyedState
+		statuses = append(statuses, status)
+	}
+
+	if allSuccess {
+		return spec.ReturnResultIgnoreCode(v1alpha1.CreateDestroyedExperimentStatus(statuses))
+	}
+	return spec.ReturnResultIgnoreCode(v1alpha1.CreateFailExperimentStatus("see resStatuses for details", statuses))
+}
+
+// injectWorkloadDnsFailure overrides the workload's PodTemplate DNSPolicy/DNSConfig
+// with an unreachable nameserver after backing up the original values.
+func (d *PodDnsFailureActionExecutor) injectWorkloadDnsFailure(ctx context.Context, namespace, kind, name, experimentId string) error {
+	if _, ok := supportedWorkloadKinds[kind]; !ok {
+		return fmt.Errorf("unsupported owner kind %s for pod DNS failure (must be Deployment/DaemonSet/StatefulSet)", kind)
+	}
+
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		switch kind {
+		case "Deployment":
+			latest := &appsv1.Deployment{}
+			if err := d.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, latest); err != nil {
+				return err
+			}
+			if latest.Annotations == nil {
+				latest.Annotations = make(map[string]string)
+			}
+			if err := beginPodDnsFailure(latest.Annotations, &latest.Spec.Template.Spec, experimentId); err != nil {
+				return err
+			}
+			return d.client.Update(ctx, latest)
+		case "DaemonSet":
+			latest := &appsv1.DaemonSet{}
+			if err := d.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, latest); err != nil {
+				return err
+			}
+			if latest.Annotations == nil {
+				latest.Annotations = make(map[string]string)
+			}
+			if err := beginPodDnsFailure(latest.Annotations, &latest.Spec.Template.Spec, experimentId); err != nil {
+				return err
+			}
+			return d.client.Update(ctx, latest)
+		case "StatefulSet":
+			latest := &appsv1.StatefulSet{}
+			if err := d.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, latest); err != nil {
+				return err
+			}
+			if latest.Annotations == nil {
+				latest.Annotations = make(map[string]string)
+			}
+			if err := beginPodDnsFailure(latest.Annotations, &latest.Spec.Template.Spec, experimentId); err != nil {
+				return err
+			}
+			return d.client.Update(ctx, latest)
+		}
+		return fmt.Errorf("unhandled workload kind %s", kind)
+	})
+}
+
+func (d *PodDnsFailureActionExecutor) restoreWorkloadDnsFailure(ctx context.Context, namespace, kind, name, experimentId string) error {
+	if _, ok := supportedWorkloadKinds[kind]; !ok {
+		return nil
+	}
+
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		switch kind {
+		case "Deployment":
+			latest := &appsv1.Deployment{}
+			if err := d.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, latest); err != nil {
+				if apierrors.IsNotFound(err) {
+					return nil
+				}
+				return err
+			}
+			if !endPodDnsFailure(latest.Annotations, &latest.Spec.Template.Spec, experimentId) {
+				return nil
+			}
+			return d.client.Update(ctx, latest)
+		case "DaemonSet":
+			latest := &appsv1.DaemonSet{}
+			if err := d.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, latest); err != nil {
+				if apierrors.IsNotFound(err) {
+					return nil
+				}
+				return err
+			}
+			if !endPodDnsFailure(latest.Annotations, &latest.Spec.Template.Spec, experimentId) {
+				return nil
+			}
+			return d.client.Update(ctx, latest)
+		case "StatefulSet":
+			latest := &appsv1.StatefulSet{}
+			if err := d.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, latest); err != nil {
+				if apierrors.IsNotFound(err) {
+					return nil
+				}
+				return err
+			}
+			if !endPodDnsFailure(latest.Annotations, &latest.Spec.Template.Spec, experimentId) {
+				return nil
+			}
+			return d.client.Update(ctx, latest)
+		}
+		return fmt.Errorf("unhandled workload kind %s", kind)
+	})
+}
+
+// restoreNamespaceWorkloads enumerates supported workloads in the given namespace
+// and restores any that carry this experiment's annotation. Used as a fallback
+// when the originally injected pod cannot be re-located on destroy.
+func (d *PodDnsFailureActionExecutor) restoreNamespaceWorkloads(ctx context.Context, namespace, experimentId string, processed map[string]bool) error {
+	listOpts := &sigsclient.ListOptions{Namespace: namespace}
+	deployList := &appsv1.DeploymentList{}
+	if err := d.client.List(ctx, deployList, listOpts); err != nil {
+		return err
+	}
+	for i := range deployList.Items {
+		dep := &deployList.Items[i]
+		if dep.Annotations[ChaosBladeExperimentAnnotation] != experimentId {
+			continue
+		}
+		if dep.Annotations[ChaosBladePodDnsFailureAnnotation] != ChaosBladePodDnsFailureAction {
+			continue
+		}
+		key := fmt.Sprintf("%s/Deployment/%s", namespace, dep.Name)
+		if processed[key] {
+			continue
+		}
+		if err := d.restoreWorkloadDnsFailure(ctx, namespace, "Deployment", dep.Name, experimentId); err != nil {
+			return err
+		}
+		processed[key] = true
+	}
+
+	dsList := &appsv1.DaemonSetList{}
+	if err := d.client.List(ctx, dsList, listOpts); err != nil {
+		return err
+	}
+	for i := range dsList.Items {
+		ds := &dsList.Items[i]
+		if ds.Annotations[ChaosBladeExperimentAnnotation] != experimentId {
+			continue
+		}
+		if ds.Annotations[ChaosBladePodDnsFailureAnnotation] != ChaosBladePodDnsFailureAction {
+			continue
+		}
+		key := fmt.Sprintf("%s/DaemonSet/%s", namespace, ds.Name)
+		if processed[key] {
+			continue
+		}
+		if err := d.restoreWorkloadDnsFailure(ctx, namespace, "DaemonSet", ds.Name, experimentId); err != nil {
+			return err
+		}
+		processed[key] = true
+	}
+
+	stsList := &appsv1.StatefulSetList{}
+	if err := d.client.List(ctx, stsList, listOpts); err != nil {
+		return err
+	}
+	for i := range stsList.Items {
+		sts := &stsList.Items[i]
+		if sts.Annotations[ChaosBladeExperimentAnnotation] != experimentId {
+			continue
+		}
+		if sts.Annotations[ChaosBladePodDnsFailureAnnotation] != ChaosBladePodDnsFailureAction {
+			continue
+		}
+		key := fmt.Sprintf("%s/StatefulSet/%s", namespace, sts.Name)
+		if processed[key] {
+			continue
+		}
+		if err := d.restoreWorkloadDnsFailure(ctx, namespace, "StatefulSet", sts.Name, experimentId); err != nil {
+			return err
+		}
+		processed[key] = true
+	}
+	return nil
+}
+
+// beginPodDnsFailure is shared logic for all workload kinds: it checks for
+// annotation conflicts, backs up the existing DNSPolicy/DNSConfig, then
+// overrides the pod template DNS settings with an unreachable nameserver.
+// Returns nil on success or when the annotations indicate the workload is
+// already injected by the same experiment (idempotent).
+func beginPodDnsFailure(annotations map[string]string, podSpec *v1.PodSpec, experimentId string) error {
+	if existingId, ok := annotations[ChaosBladeExperimentAnnotation]; ok && existingId != "" && existingId != experimentId {
+		return fmt.Errorf("workload is already modified by another chaosblade experiment: %s", existingId)
+	}
+	if annotations[ChaosBladeExperimentAnnotation] == experimentId {
+		return nil
+	}
+
+	originalPolicyBytes, err := json.Marshal(podSpec.DNSPolicy)
+	if err != nil {
+		return fmt.Errorf("marshal original DNSPolicy failed: %v", err)
+	}
+	annotations[ChaosBladeOriginalDnsPolicyAnnotation] = string(originalPolicyBytes)
+
+	if podSpec.DNSConfig != nil {
+		originalCfgBytes, err := json.Marshal(podSpec.DNSConfig)
+		if err != nil {
+			return fmt.Errorf("marshal original DNSConfig failed: %v", err)
+		}
+		annotations[ChaosBladeOriginalDnsConfigAnnotation] = string(originalCfgBytes)
+	} else {
+		annotations[ChaosBladeOriginalDnsConfigAnnotation] = ""
+	}
+
+	annotations[ChaosBladePodDnsFailureAnnotation] = ChaosBladePodDnsFailureAction
+	annotations[ChaosBladeExperimentAnnotation] = experimentId
+
+	podSpec.DNSPolicy = v1.DNSNone
+	podSpec.DNSConfig = &v1.PodDNSConfig{
+		Nameservers: []string{UnreachableDnsNameserver},
+	}
+	return nil
+}
+
+// endPodDnsFailure restores the workload's DNS configuration. It returns true
+// when an actual mutation was performed (so the caller should issue an Update).
+func endPodDnsFailure(annotations map[string]string, podSpec *v1.PodSpec, experimentId string) bool {
+	if annotations == nil {
+		return false
+	}
+	if annotations[ChaosBladeExperimentAnnotation] != experimentId {
+		return false
+	}
+
+	if raw, ok := annotations[ChaosBladeOriginalDnsPolicyAnnotation]; ok {
+		var original v1.DNSPolicy
+		if err := json.Unmarshal([]byte(raw), &original); err == nil {
+			podSpec.DNSPolicy = original
+		}
+	}
+
+	if raw, ok := annotations[ChaosBladeOriginalDnsConfigAnnotation]; ok {
+		if raw == "" {
+			podSpec.DNSConfig = nil
+		} else {
+			var original v1.PodDNSConfig
+			if err := json.Unmarshal([]byte(raw), &original); err == nil {
+				podSpec.DNSConfig = &original
+			}
+		}
+	}
+
+	delete(annotations, ChaosBladeOriginalDnsPolicyAnnotation)
+	delete(annotations, ChaosBladeOriginalDnsConfigAnnotation)
+	delete(annotations, ChaosBladePodDnsFailureAnnotation)
+	delete(annotations, ChaosBladeExperimentAnnotation)
+	return true
+}
+
+// resolveTopLevelWorkload walks owner references upwards starting from a Pod
+// and returns the kind/name of the top-level workload (Deployment / DaemonSet
+// / StatefulSet). Returns an error if the pod has no supported owner.
+func resolveTopLevelWorkload(ctx context.Context, client *channel.Client, pod *v1.Pod) (string, string, error) {
+	owner := metav1.GetControllerOf(&pod.ObjectMeta)
+	if owner == nil {
+		return "", "", fmt.Errorf("pod %s/%s has no controller owner", pod.Namespace, pod.Name)
+	}
+
+	switch owner.Kind {
+	case "ReplicaSet":
+		rs := &appsv1.ReplicaSet{}
+		if err := client.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: owner.Name}, rs); err != nil {
+			return "", "", fmt.Errorf("get replicaset %s/%s failed: %v", pod.Namespace, owner.Name, err)
+		}
+		rsOwner := metav1.GetControllerOf(&rs.ObjectMeta)
+		if rsOwner == nil || rsOwner.Kind != "Deployment" {
+			return "", "", fmt.Errorf("replicaset %s/%s is not owned by a Deployment", pod.Namespace, owner.Name)
+		}
+		return "Deployment", rsOwner.Name, nil
+	case "DaemonSet":
+		return "DaemonSet", owner.Name, nil
+	case "StatefulSet":
+		return "StatefulSet", owner.Name, nil
+	default:
+		return "", "", fmt.Errorf("unsupported pod owner kind %s for pod %s/%s",
+			owner.Kind, pod.Namespace, pod.Name)
+	}
+}
+
+// podUsesNameserver returns true when the pod's effective DNS configuration
+// contains the given nameserver IP. The check is best-effort: if DNSConfig is
+// not explicitly set, the pod inherits cluster DNS at runtime, so we cannot
+// validate from the spec alone and we treat the precondition as satisfied.
+func podUsesNameserver(pod *v1.Pod, nameserver string) bool {
+	if pod.Spec.DNSConfig != nil {
+		for _, ns := range pod.Spec.DNSConfig.Nameservers {
+			if ns == nameserver {
+				return true
+			}
+		}
+		// HostNetwork pods with explicit DNSConfig require the nameserver to be listed.
+		if pod.Spec.DNSPolicy == v1.DNSNone {
+			return false
+		}
+	}
+	// When DNSConfig is empty the pod uses ClusterFirst / ClusterFirstWithHostNet
+	// or Default, which means the cluster DNS service is in use. Without runtime
+	// access to /etc/resolv.conf we accept the nameserver flag as a hint.
+	return true
+}

--- a/exec/pod/dnsfailureexp.go
+++ b/exec/pod/dnsfailureexp.go
@@ -40,10 +40,20 @@ import (
 )
 
 const (
-	// DnsFailureNameserverFlag is the optional flag specifying the nameserver IP
-	// to be validated against the pod's DNS configuration. When provided, the
-	// action requires the pod's resolved nameservers to contain this IP before
-	// proceeding with the injection.
+	// DnsFailureNameserverFlag is the optional flag that toggles a best-effort
+	// precondition check against the pod's PodSpec.DNSConfig.
+	//
+	// The check is strict only when the pod has DNSPolicy=None with an
+	// explicit DNSConfig.Nameservers list — that is the only configuration
+	// where the PodSpec fully determines the pod's effective resolvers. In
+	// every other configuration (DNSConfig is nil, or DNSPolicy is one of
+	// ClusterFirst/ClusterFirstWithHostNet/Default) the pod inherits cluster
+	// or kubelet DNS at runtime, which is not visible from the PodSpec, so the
+	// flag is accepted as a hint and the experiment proceeds.
+	//
+	// The action intentionally does NOT exec into the pod to read
+	// /etc/resolv.conf. For runtime-precise validation, inspect resolv.conf
+	// inside the target pod manually before running the experiment.
 	DnsFailureNameserverFlag = "nameserver"
 
 	// ChaosBladePodDnsFailureAction is the marker annotation value for the pod
@@ -88,8 +98,11 @@ func NewPodDnsFailureActionSpec(client *channel.Client) spec.ExpActionCommandSpe
 			ActionMatchers: []spec.ExpFlagSpec{},
 			ActionFlags: []spec.ExpFlagSpec{
 				&spec.ExpFlag{
-					Name:     DnsFailureNameserverFlag,
-					Desc:     "Nameserver IP to be validated against the pod's DNS configuration. When set, the pod must reference this nameserver, otherwise the injection fails. Optional",
+					Name: DnsFailureNameserverFlag,
+					Desc: "Best-effort precondition: nameserver IP to check against the pod's PodSpec.DNSConfig. " +
+						"Strict only when the pod has DNSPolicy=None with explicit DNSConfig.Nameservers (then the " +
+						"list MUST contain this IP); otherwise accepted as a hint because the pod's runtime " +
+						"/etc/resolv.conf cannot be read from the spec. Optional",
 					Required: false,
 				},
 			},
@@ -97,7 +110,10 @@ func NewPodDnsFailureActionSpec(client *channel.Client) spec.ExpActionCommandSpe
 			ActionExample: `# Make all DNS queries from a pod fail by injecting an unreachable nameserver to its workload
 blade create k8s pod-pod dnsfailure --names nginx-app-xxx --namespace default --kubeconfig ~/.kube/config
 
-# Same as above but require that the pod is currently configured to use 10.96.0.10 as a nameserver
+# Best-effort precondition: the action will refuse to inject when the pod has DNSPolicy=None and the
+# given IP is not listed in DNSConfig.Nameservers. For pods using ClusterFirst (the common case) the
+# flag is accepted as a hint because the cluster DNS IP is not visible from the PodSpec — verify by
+# running 'kubectl exec <pod> -- cat /etc/resolv.conf' if runtime accuracy is required.
 blade create k8s pod-pod dnsfailure --names nginx-app-xxx --namespace default --nameserver 10.96.0.10 --kubeconfig ~/.kube/config
 
 # Inject DNS failure for pods selected by labels
@@ -122,11 +138,16 @@ func (*PodDnsFailureActionSpec) ShortDesc() string {
 }
 
 func (*PodDnsFailureActionSpec) LongDesc() string {
-	return "Resolve the target pod's DNS configuration (DNSPolicy + DNSConfig and the runtime resolv.conf), " +
-		"then inject a complete DNS unavailability fault by overriding the owning workload's PodSpec to use " +
-		"an unreachable nameserver. The original DNSPolicy/DNSConfig is backed up to workload annotations and " +
-		"restored when the experiment is destroyed. The pod is deleted after injection so the controller " +
-		"recreates it with the faulty DNS configuration."
+	return "Inject a complete DNS unavailability fault to a pod by overriding the owning workload's " +
+		"PodSpec.DNSPolicy/DNSConfig to use an unreachable nameserver (" + UnreachableDnsNameserver + "). " +
+		"The original DNSPolicy/DNSConfig is backed up to workload annotations and restored when the " +
+		"experiment is destroyed. The pod is deleted after injection so the controller recreates it with " +
+		"the faulty DNS configuration. " +
+		"The optional --" + DnsFailureNameserverFlag + " flag performs a best-effort precondition check " +
+		"against PodSpec.DNSConfig only; it does not exec into the pod to read /etc/resolv.conf and " +
+		"therefore only rejects pods whose spec is authoritative (DNSPolicy=None with explicit " +
+		"DNSConfig.Nameservers). For ClusterFirst / ClusterFirstWithHostNet / Default pods the flag is " +
+		"accepted as a hint."
 }
 
 type PodDnsFailureActionExecutor struct {
@@ -181,7 +202,14 @@ func (d *PodDnsFailureActionExecutor) create(uid string, ctx context.Context, ex
 
 		if requiredNameserver != "" {
 			if !podUsesNameserver(pod, requiredNameserver) {
-				errMsg := fmt.Sprintf("pod %s/%s does not reference nameserver %s in its DNS config",
+				// The only path that returns false is "DNSPolicy=None with an
+				// explicit DNSConfig.Nameservers list that does not include
+				// the requested IP" — spell that out so operators understand
+				// the precondition is strict by design here, not just a
+				// general nameserver mismatch.
+				errMsg := fmt.Sprintf(
+					"pod %s/%s has DNSPolicy=None and DNSConfig.Nameservers does not contain %s; "+
+						"refusing to inject because the PodSpec is authoritative in this configuration",
 					meta.Namespace, meta.PodName, requiredNameserver)
 				logrusField.Warning(errMsg)
 				status = status.CreateFailResourceStatus(errMsg, spec.K8sExecFailed.Code)
@@ -388,7 +416,11 @@ func (d *PodDnsFailureActionExecutor) restoreWorkloadDnsFailure(ctx context.Cont
 				}
 				return err
 			}
-			if !endPodDnsFailure(latest.Annotations, &latest.Spec.Template.Spec, experimentId) {
+			mutated, err := endPodDnsFailure(latest.Annotations, &latest.Spec.Template.Spec, experimentId)
+			if err != nil {
+				return err
+			}
+			if !mutated {
 				return nil
 			}
 			return d.client.Update(ctx, latest)
@@ -400,7 +432,11 @@ func (d *PodDnsFailureActionExecutor) restoreWorkloadDnsFailure(ctx context.Cont
 				}
 				return err
 			}
-			if !endPodDnsFailure(latest.Annotations, &latest.Spec.Template.Spec, experimentId) {
+			mutated, err := endPodDnsFailure(latest.Annotations, &latest.Spec.Template.Spec, experimentId)
+			if err != nil {
+				return err
+			}
+			if !mutated {
 				return nil
 			}
 			return d.client.Update(ctx, latest)
@@ -412,7 +448,11 @@ func (d *PodDnsFailureActionExecutor) restoreWorkloadDnsFailure(ctx context.Cont
 				}
 				return err
 			}
-			if !endPodDnsFailure(latest.Annotations, &latest.Spec.Template.Spec, experimentId) {
+			mutated, err := endPodDnsFailure(latest.Annotations, &latest.Spec.Template.Spec, experimentId)
+			if err != nil {
+				return err
+			}
+			if !mutated {
 				return nil
 			}
 			return d.client.Update(ctx, latest)
@@ -533,39 +573,90 @@ func beginPodDnsFailure(annotations map[string]string, podSpec *v1.PodSpec, expe
 	return nil
 }
 
-// endPodDnsFailure restores the workload's DNS configuration. It returns true
-// when an actual mutation was performed (so the caller should issue an Update).
-func endPodDnsFailure(annotations map[string]string, podSpec *v1.PodSpec, experimentId string) bool {
+// endPodDnsFailure restores the workload's DNS configuration from the values
+// previously stored in annotations.
+//
+// Return values:
+//
+//   - (true,  nil): the podSpec was restored and the chaosblade annotations
+//     were cleared. The caller MUST issue an Update.
+//
+//   - (false, nil): this restore is a deliberate no-op — either annotations
+//     are nil, or the workload is owned by a different experiment, or it
+//     does not carry the pod-DNS-failure action marker. The caller MUST NOT
+//     issue an Update.
+//
+//   - (false, err): the backed-up DNSPolicy/DNSConfig is missing or could
+//     not be decoded. NEITHER the podSpec NOR the annotations are mutated,
+//     so the operator can either retry the destroy after repairing the
+//     annotation value or manually finish the cleanup. The previous
+//     behaviour of swallowing decode errors and still deleting the
+//     chaosblade annotations would leave the workload permanently stranded
+//     with the injected unreachable nameserver and no metadata to identify
+//     it for later restore — that mode is explicitly removed.
+//
+// To keep partial failure from stranding the workload, the function decodes
+// EVERY backup before mutating anything. If any decode fails the workload is
+// left exactly as it was found.
+func endPodDnsFailure(annotations map[string]string, podSpec *v1.PodSpec, experimentId string) (bool, error) {
 	if annotations == nil {
-		return false
+		return false, nil
 	}
 	if annotations[ChaosBladeExperimentAnnotation] != experimentId {
-		return false
+		return false, nil
+	}
+	if annotations[ChaosBladePodDnsFailureAnnotation] != ChaosBladePodDnsFailureAction {
+		// Same experiment id, but the action marker is missing — either we
+		// did not inject this workload or another phase already removed the
+		// marker. Skip rather than risk mutating an unrelated workload.
+		return false, nil
 	}
 
-	if raw, ok := annotations[ChaosBladeOriginalDnsPolicyAnnotation]; ok {
-		var original v1.DNSPolicy
-		if err := json.Unmarshal([]byte(raw), &original); err == nil {
-			podSpec.DNSPolicy = original
-		}
+	// Phase 1 — validate ALL backups WITHOUT touching anything.
+	rawPolicy, hasPolicy := annotations[ChaosBladeOriginalDnsPolicyAnnotation]
+	if !hasPolicy {
+		return false, fmt.Errorf("backed-up %s annotation is missing; refusing to restore "+
+			"because clearing the ownership annotations would strand the workload — "+
+			"repair the annotation and retry the destroy",
+			ChaosBladeOriginalDnsPolicyAnnotation)
+	}
+	var restorePolicy v1.DNSPolicy
+	if err := json.Unmarshal([]byte(rawPolicy), &restorePolicy); err != nil {
+		return false, fmt.Errorf("decode backed-up %s annotation %q failed: %v; "+
+			"annotations are left in place so the restore can be retried after the value is repaired",
+			ChaosBladeOriginalDnsPolicyAnnotation, rawPolicy, err)
 	}
 
-	if raw, ok := annotations[ChaosBladeOriginalDnsConfigAnnotation]; ok {
-		if raw == "" {
-			podSpec.DNSConfig = nil
-		} else {
-			var original v1.PodDNSConfig
-			if err := json.Unmarshal([]byte(raw), &original); err == nil {
-				podSpec.DNSConfig = &original
-			}
-		}
+	rawConfig, hasConfig := annotations[ChaosBladeOriginalDnsConfigAnnotation]
+	if !hasConfig {
+		return false, fmt.Errorf("backed-up %s annotation is missing; refusing to restore "+
+			"because clearing the ownership annotations would strand the workload — "+
+			"repair the annotation and retry the destroy",
+			ChaosBladeOriginalDnsConfigAnnotation)
 	}
+	var restoreConfig *v1.PodDNSConfig
+	if rawConfig != "" {
+		var cfg v1.PodDNSConfig
+		if err := json.Unmarshal([]byte(rawConfig), &cfg); err != nil {
+			return false, fmt.Errorf("decode backed-up %s annotation %q failed: %v; "+
+				"annotations are left in place so the restore can be retried after the value is repaired",
+				ChaosBladeOriginalDnsConfigAnnotation, rawConfig, err)
+		}
+		restoreConfig = &cfg
+	}
+	// restoreConfig stays nil when rawConfig == "" (sentinel meaning the
+	// original DNSConfig was nil — i.e. the pod inherited cluster DNS).
+
+	// Phase 2 — all backups decoded successfully. Restore podSpec and clear
+	// annotations atomically.
+	podSpec.DNSPolicy = restorePolicy
+	podSpec.DNSConfig = restoreConfig
 
 	delete(annotations, ChaosBladeOriginalDnsPolicyAnnotation)
 	delete(annotations, ChaosBladeOriginalDnsConfigAnnotation)
 	delete(annotations, ChaosBladePodDnsFailureAnnotation)
 	delete(annotations, ChaosBladeExperimentAnnotation)
-	return true
+	return true, nil
 }
 
 // resolveTopLevelWorkload walks owner references upwards starting from a Pod
@@ -598,10 +689,22 @@ func resolveTopLevelWorkload(ctx context.Context, client *channel.Client, pod *v
 	}
 }
 
-// podUsesNameserver returns true when the pod's effective DNS configuration
-// contains the given nameserver IP. The check is best-effort: if DNSConfig is
-// not explicitly set, the pod inherits cluster DNS at runtime, so we cannot
-// validate from the spec alone and we treat the precondition as satisfied.
+// podUsesNameserver implements the best-effort precondition behind the
+// --nameserver flag. It returns true when the pod's PodSpec is consistent with
+// the given nameserver IP, and false only when the spec explicitly contradicts
+// it.
+//
+// The check is strict in exactly one configuration: DNSPolicy=None combined
+// with a DNSConfig.Nameservers list that does not contain the requested IP.
+// That is the only configuration in which the PodSpec fully determines the
+// pod's effective resolvers, so a mismatch can be detected from the spec
+// alone. In every other configuration (DNSConfig is nil, or DNSPolicy is
+// ClusterFirst/ClusterFirstWithHostNet/Default) the pod inherits cluster or
+// kubelet DNS at runtime, which is not visible from the PodSpec; the flag is
+// then accepted as a hint and the experiment proceeds.
+//
+// Callers that need runtime-precise validation should inspect
+// /etc/resolv.conf inside the target pod before invoking the action.
 func podUsesNameserver(pod *v1.Pod, nameserver string) bool {
 	if pod.Spec.DNSConfig != nil {
 		for _, ns := range pod.Spec.DNSConfig.Nameservers {
@@ -609,13 +712,16 @@ func podUsesNameserver(pod *v1.Pod, nameserver string) bool {
 				return true
 			}
 		}
-		// HostNetwork pods with explicit DNSConfig require the nameserver to be listed.
+		// DNSPolicy=None means PodSpec.DNSConfig.Nameservers IS the complete
+		// resolver list at runtime. If the requested IP is not in it, the
+		// precondition truly cannot be satisfied — reject strictly.
 		if pod.Spec.DNSPolicy == v1.DNSNone {
 			return false
 		}
 	}
-	// When DNSConfig is empty the pod uses ClusterFirst / ClusterFirstWithHostNet
-	// or Default, which means the cluster DNS service is in use. Without runtime
-	// access to /etc/resolv.conf we accept the nameserver flag as a hint.
+	// Either DNSConfig is unset, or DNSConfig is set with extra nameservers
+	// alongside the cluster-inherited ones (DNSPolicy=ClusterFirst*). The
+	// cluster DNS IP is not encoded in the PodSpec, so we cannot prove or
+	// disprove the precondition; accept as a hint.
 	return true
 }

--- a/exec/pod/dnsfailureexp.go
+++ b/exec/pod/dnsfailureexp.go
@@ -210,7 +210,8 @@ func (d *PodDnsFailureActionExecutor) create(uid string, ctx context.Context, ex
 				errMsg := fmt.Sprintf(
 					"pod %s/%s has DNSPolicy=None and DNSConfig.Nameservers does not contain %s; "+
 						"refusing to inject because the PodSpec is authoritative in this configuration",
-					meta.Namespace, meta.PodName, requiredNameserver)
+					meta.Namespace, meta.PodName, requiredNameserver,
+				)
 				logrusField.Warning(errMsg)
 				status = status.CreateFailResourceStatus(errMsg, spec.K8sExecFailed.Code)
 				statuses = append(statuses, status)

--- a/exec/pod/dnsfailureexp.go
+++ b/exec/pod/dnsfailureexp.go
@@ -62,7 +62,8 @@ const (
 
 	// UnreachableDnsNameserver is the placeholder nameserver injected to the
 	// workload's PodSpec to make all DNS queries originating from the pod fail.
-	// 127.0.0.255 is in the loopback /8 and is guaranteed not to listen on UDP/53.
+	// 127.0.0.255 is in the loopback /8 and is very unlikely to have a DNS
+	// server listening on UDP/53.
 	UnreachableDnsNameserver = "127.0.0.255"
 )
 

--- a/exec/pod/dnsfailureexp_test.go
+++ b/exec/pod/dnsfailureexp_test.go
@@ -863,14 +863,16 @@ func TestRestoreWorkloadDnsFailure_MissingWorkloadIsNoOp(t *testing.T) {
 	executor := &PodDnsFailureActionExecutor{client: c}
 
 	if err := executor.restoreWorkloadDnsFailure(
-		context.Background(), "default", "Deployment", "ghost", "exp-1"); err != nil {
+		context.Background(), "default", "Deployment", "ghost", "exp-1",
+	); err != nil {
 		t.Errorf("restore of missing workload should be a no-op, got: %v", err)
 	}
 }
 
 func TestRestoreWorkloadDnsFailure_ForeignExperimentIsNoOp(t *testing.T) {
 	const ns = "default"
-	dep := newDeployment("nginx", ns,
+	dep := newDeployment(
+		"nginx", ns,
 		v1.PodSpec{
 			DNSPolicy: v1.DNSNone,
 			DNSConfig: &v1.PodDNSConfig{Nameservers: []string{UnreachableDnsNameserver}},
@@ -933,7 +935,8 @@ func TestRestoreNamespaceWorkloads(t *testing.T) {
 	// Carries our experiment annotation but is owned by another chaosblade
 	// *action* (e.g. taint, badresource). The DNS failure restore must not
 	// touch workloads it did not inject.
-	depWrongAction := newDeployment("nginx-wrong-action", ns, v1.PodSpec{DNSPolicy: v1.DNSClusterFirst},
+	depWrongAction := newDeployment(
+		"nginx-wrong-action", ns, v1.PodSpec{DNSPolicy: v1.DNSClusterFirst},
 		map[string]string{
 			ChaosBladeExperimentAnnotation: expId,
 			// Note: no ChaosBladePodDnsFailureAnnotation marker.
@@ -996,7 +999,8 @@ func TestRestoreNamespaceWorkloads_RespectsAlreadyProcessed(t *testing.T) {
 	const ns = "default"
 	const expId = "exp-1"
 
-	dep := newDeployment("nginx", ns,
+	dep := newDeployment(
+		"nginx", ns,
 		v1.PodSpec{
 			DNSPolicy: v1.DNSNone,
 			DNSConfig: &v1.PodDNSConfig{Nameservers: []string{UnreachableDnsNameserver}},

--- a/exec/pod/dnsfailureexp_test.go
+++ b/exec/pod/dnsfailureexp_test.go
@@ -1,0 +1,1442 @@
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pod
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	sigsclient "sigs.k8s.io/controller-runtime/pkg/client"
+	sigsfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/chaosblade-io/chaosblade-operator/channel"
+	"github.com/chaosblade-io/chaosblade-operator/exec/model"
+	"github.com/chaosblade-io/chaosblade-operator/pkg/apis/chaosblade/v1alpha1"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+func newDnsTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := v1.AddToScheme(scheme); err != nil {
+		t.Fatalf("register corev1 scheme: %v", err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("register appsv1 scheme: %v", err)
+	}
+	return scheme
+}
+
+func newDnsTestClient(t *testing.T, objs ...sigsclient.Object) *channel.Client {
+	t.Helper()
+	fake := sigsfake.NewClientBuilder().
+		WithScheme(newDnsTestScheme(t)).
+		WithObjects(objs...).
+		Build()
+	return &channel.Client{Client: fake}
+}
+
+// controllerRef returns an OwnerReference with controller=true for use in
+// pod / replicaset metadata.
+func controllerRef(kind, name string) metav1.OwnerReference {
+	ctrl := true
+	return metav1.OwnerReference{
+		APIVersion: "apps/v1",
+		Kind:       kind,
+		Name:       name,
+		Controller: &ctrl,
+		UID:        types.UID(kind + "-" + name + "-uid"),
+	}
+}
+
+func newPod(name, namespace string, owners ...metav1.OwnerReference) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       namespace,
+			OwnerReferences: owners,
+		},
+	}
+}
+
+func newReplicaSet(name, namespace string, owners ...metav1.OwnerReference) *appsv1.ReplicaSet {
+	return &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       namespace,
+			OwnerReferences: owners,
+		},
+	}
+}
+
+func newDeployment(name, namespace string, podSpec v1.PodSpec, annotations map[string]string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: v1.PodTemplateSpec{Spec: podSpec},
+		},
+	}
+}
+
+func newDaemonSet(name, namespace string, podSpec v1.PodSpec, annotations map[string]string) *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Template: v1.PodTemplateSpec{Spec: podSpec},
+		},
+	}
+}
+
+func newStatefulSet(name, namespace string, podSpec v1.PodSpec, annotations map[string]string) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Template: v1.PodTemplateSpec{Spec: podSpec},
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pure logic: podUsesNameserver
+// ---------------------------------------------------------------------------
+
+// TestPodUsesNameserver locks in the documented "best-effort precondition"
+// contract: strict only when DNSPolicy=None with explicit DNSConfig.Nameservers,
+// hint-accepted in every other configuration. If a future change tightens any
+// of the hint-mode cases without also updating the LongDesc / flag Desc, this
+// table will catch the drift.
+func TestPodUsesNameserver(t *testing.T) {
+	tests := []struct {
+		name       string
+		pod        *v1.Pod
+		nameserver string
+		want       bool
+	}{
+		{
+			name: "DNSConfig nil with ClusterFirst — accepted as hint",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				DNSPolicy: v1.DNSClusterFirst,
+			}},
+			nameserver: "10.96.0.10",
+			want:       true,
+		},
+		{
+			name: "DNSConfig nil with Default policy — accepted as hint",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				DNSPolicy: v1.DNSDefault,
+			}},
+			nameserver: "10.96.0.10",
+			want:       true,
+		},
+		{
+			name: "DNSConfig nil with ClusterFirstWithHostNet — accepted as hint",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				DNSPolicy: v1.DNSClusterFirstWithHostNet,
+			}},
+			nameserver: "10.96.0.10",
+			want:       true,
+		},
+		{
+			name: "DNSConfig set with matching nameserver",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				DNSPolicy: v1.DNSClusterFirst,
+				DNSConfig: &v1.PodDNSConfig{
+					Nameservers: []string{"10.96.0.10", "8.8.8.8"},
+				},
+			}},
+			nameserver: "10.96.0.10",
+			want:       true,
+		},
+		{
+			name: "DNSConfig set, nameserver not listed, policy ClusterFirst — still accepted (hint mode)",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				DNSPolicy: v1.DNSClusterFirst,
+				DNSConfig: &v1.PodDNSConfig{
+					Nameservers: []string{"8.8.8.8"},
+				},
+			}},
+			nameserver: "10.96.0.10",
+			want:       true,
+		},
+		{
+			name: "DNSConfig set, nameserver not listed, policy None — strict mode rejects",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				DNSPolicy: v1.DNSNone,
+				DNSConfig: &v1.PodDNSConfig{
+					Nameservers: []string{"8.8.8.8"},
+				},
+			}},
+			nameserver: "10.96.0.10",
+			want:       false,
+		},
+		{
+			name: "DNSConfig set, nameserver matches, policy None — accepted",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				DNSPolicy: v1.DNSNone,
+				DNSConfig: &v1.PodDNSConfig{
+					Nameservers: []string{"10.96.0.10"},
+				},
+			}},
+			nameserver: "10.96.0.10",
+			want:       true,
+		},
+		{
+			name: "empty Nameservers list, policy None — strict mode rejects",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				DNSPolicy: v1.DNSNone,
+				DNSConfig: &v1.PodDNSConfig{},
+			}},
+			nameserver: "10.96.0.10",
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := podUsesNameserver(tt.pod, tt.nameserver)
+			if got != tt.want {
+				t.Errorf("podUsesNameserver() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pure logic: beginPodDnsFailure
+// ---------------------------------------------------------------------------
+
+func TestBeginPodDnsFailure_BackupAndInject_WithExistingDnsConfig(t *testing.T) {
+	annotations := map[string]string{}
+	originalCfg := &v1.PodDNSConfig{
+		Nameservers: []string{"10.96.0.10"},
+		Searches:    []string{"svc.cluster.local"},
+	}
+	podSpec := &v1.PodSpec{
+		DNSPolicy: v1.DNSClusterFirst,
+		DNSConfig: originalCfg,
+	}
+
+	if err := beginPodDnsFailure(annotations, podSpec, "exp-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if annotations[ChaosBladeOriginalDnsPolicyAnnotation] != `"ClusterFirst"` {
+		t.Errorf("original policy annotation = %q, want %q",
+			annotations[ChaosBladeOriginalDnsPolicyAnnotation], `"ClusterFirst"`)
+	}
+	rawCfg := annotations[ChaosBladeOriginalDnsConfigAnnotation]
+	if rawCfg == "" {
+		t.Fatal("original DNSConfig annotation should be non-empty when DNSConfig was set")
+	}
+	var restoredCfg v1.PodDNSConfig
+	if err := json.Unmarshal([]byte(rawCfg), &restoredCfg); err != nil {
+		t.Fatalf("backed-up DNSConfig is not valid JSON: %v", err)
+	}
+	if len(restoredCfg.Nameservers) != 1 || restoredCfg.Nameservers[0] != "10.96.0.10" {
+		t.Errorf("backed-up nameservers = %v, want [10.96.0.10]", restoredCfg.Nameservers)
+	}
+
+	if annotations[ChaosBladePodDnsFailureAnnotation] != ChaosBladePodDnsFailureAction {
+		t.Errorf("dns-failure marker annotation = %q, want %q",
+			annotations[ChaosBladePodDnsFailureAnnotation], ChaosBladePodDnsFailureAction)
+	}
+	if annotations[ChaosBladeExperimentAnnotation] != "exp-1" {
+		t.Errorf("experiment annotation = %q, want %q",
+			annotations[ChaosBladeExperimentAnnotation], "exp-1")
+	}
+
+	if podSpec.DNSPolicy != v1.DNSNone {
+		t.Errorf("injected DNSPolicy = %v, want DNSNone", podSpec.DNSPolicy)
+	}
+	if podSpec.DNSConfig == nil || len(podSpec.DNSConfig.Nameservers) != 1 ||
+		podSpec.DNSConfig.Nameservers[0] != UnreachableDnsNameserver {
+		t.Errorf("injected DNSConfig.Nameservers = %v, want [%s]",
+			podSpec.DNSConfig, UnreachableDnsNameserver)
+	}
+}
+
+func TestBeginPodDnsFailure_NilDnsConfigYieldsEmptyAnnotation(t *testing.T) {
+	annotations := map[string]string{}
+	podSpec := &v1.PodSpec{DNSPolicy: v1.DNSClusterFirst, DNSConfig: nil}
+
+	if err := beginPodDnsFailure(annotations, podSpec, "exp-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The empty string is the explicit marker for "was nil"; without this
+	// signal, endPodDnsFailure would leave the injected DNSConfig in place.
+	if v, ok := annotations[ChaosBladeOriginalDnsConfigAnnotation]; !ok {
+		t.Error("original DNSConfig annotation must be present even when value was nil")
+	} else if v != "" {
+		t.Errorf("original DNSConfig annotation = %q, want empty string sentinel", v)
+	}
+}
+
+func TestBeginPodDnsFailure_ConflictWithOtherExperiment(t *testing.T) {
+	annotations := map[string]string{
+		ChaosBladeExperimentAnnotation:        "exp-other",
+		ChaosBladeOriginalDnsPolicyAnnotation: `"ClusterFirst"`,
+	}
+	podSpec := &v1.PodSpec{
+		DNSPolicy: v1.DNSNone,
+		DNSConfig: &v1.PodDNSConfig{Nameservers: []string{UnreachableDnsNameserver}},
+	}
+
+	err := beginPodDnsFailure(annotations, podSpec, "exp-1")
+	if err == nil {
+		t.Fatal("expected conflict error, got nil")
+	}
+	if !strings.Contains(err.Error(), "already modified by another chaosblade experiment") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	// The other experiment's backup must remain intact.
+	if annotations[ChaosBladeOriginalDnsPolicyAnnotation] != `"ClusterFirst"` {
+		t.Errorf("conflict path mutated other experiment's backup: %q",
+			annotations[ChaosBladeOriginalDnsPolicyAnnotation])
+	}
+	if annotations[ChaosBladeExperimentAnnotation] != "exp-other" {
+		t.Errorf("conflict path mutated experiment owner annotation: %q",
+			annotations[ChaosBladeExperimentAnnotation])
+	}
+}
+
+func TestBeginPodDnsFailure_IdempotentSameExperimentIsNoOp(t *testing.T) {
+	// Workload already injected (DNSPolicy=None, fake nameserver) with the same
+	// experiment id. Re-running must not re-marshal the *injected* spec back
+	// into the backup annotation — otherwise the backup would record "None"
+	// and the restore would never reach the original ClusterFirst.
+	annotations := map[string]string{
+		ChaosBladeExperimentAnnotation:        "exp-1",
+		ChaosBladePodDnsFailureAnnotation:     ChaosBladePodDnsFailureAction,
+		ChaosBladeOriginalDnsPolicyAnnotation: `"ClusterFirst"`,
+		ChaosBladeOriginalDnsConfigAnnotation: "",
+	}
+	podSpec := &v1.PodSpec{
+		DNSPolicy: v1.DNSNone,
+		DNSConfig: &v1.PodDNSConfig{Nameservers: []string{UnreachableDnsNameserver}},
+	}
+
+	if err := beginPodDnsFailure(annotations, podSpec, "exp-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if annotations[ChaosBladeOriginalDnsPolicyAnnotation] != `"ClusterFirst"` {
+		t.Errorf("idempotent re-injection clobbered policy backup: %q",
+			annotations[ChaosBladeOriginalDnsPolicyAnnotation])
+	}
+	if annotations[ChaosBladeOriginalDnsConfigAnnotation] != "" {
+		t.Errorf("idempotent re-injection clobbered DNSConfig backup: %q",
+			annotations[ChaosBladeOriginalDnsConfigAnnotation])
+	}
+}
+
+func TestBeginPodDnsFailure_EmptyExperimentAnnotationIsNotConflict(t *testing.T) {
+	// An empty string for the experiment annotation is treated as "no owner";
+	// proceeding to inject under the current experiment is allowed.
+	annotations := map[string]string{
+		ChaosBladeExperimentAnnotation: "",
+	}
+	podSpec := &v1.PodSpec{DNSPolicy: v1.DNSClusterFirst}
+
+	if err := beginPodDnsFailure(annotations, podSpec, "exp-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if annotations[ChaosBladeExperimentAnnotation] != "exp-1" {
+		t.Errorf("expected experiment annotation set to exp-1, got %q",
+			annotations[ChaosBladeExperimentAnnotation])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pure logic: endPodDnsFailure
+// ---------------------------------------------------------------------------
+
+func TestEndPodDnsFailure_RestoresPolicyAndConfig(t *testing.T) {
+	originalCfg := &v1.PodDNSConfig{Nameservers: []string{"10.96.0.10"}}
+	originalCfgBytes, _ := json.Marshal(originalCfg)
+
+	annotations := map[string]string{
+		ChaosBladeExperimentAnnotation:        "exp-1",
+		ChaosBladePodDnsFailureAnnotation:     ChaosBladePodDnsFailureAction,
+		ChaosBladeOriginalDnsPolicyAnnotation: `"ClusterFirst"`,
+		ChaosBladeOriginalDnsConfigAnnotation: string(originalCfgBytes),
+		"unrelated":                           "keep-me",
+	}
+	podSpec := &v1.PodSpec{
+		DNSPolicy: v1.DNSNone,
+		DNSConfig: &v1.PodDNSConfig{Nameservers: []string{UnreachableDnsNameserver}},
+	}
+
+	mutated, err := endPodDnsFailure(annotations, podSpec, "exp-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !mutated {
+		t.Fatal("endPodDnsFailure should report a mutation when experiment id matches")
+	}
+	if podSpec.DNSPolicy != v1.DNSClusterFirst {
+		t.Errorf("DNSPolicy after restore = %v, want ClusterFirst", podSpec.DNSPolicy)
+	}
+	if podSpec.DNSConfig == nil || len(podSpec.DNSConfig.Nameservers) != 1 ||
+		podSpec.DNSConfig.Nameservers[0] != "10.96.0.10" {
+		t.Errorf("DNSConfig after restore = %+v, want nameserver 10.96.0.10", podSpec.DNSConfig)
+	}
+	for _, k := range []string{
+		ChaosBladeExperimentAnnotation,
+		ChaosBladePodDnsFailureAnnotation,
+		ChaosBladeOriginalDnsPolicyAnnotation,
+		ChaosBladeOriginalDnsConfigAnnotation,
+	} {
+		if _, exists := annotations[k]; exists {
+			t.Errorf("annotation %q must be cleared after restore", k)
+		}
+	}
+	if annotations["unrelated"] != "keep-me" {
+		t.Error("unrelated annotation must be preserved")
+	}
+}
+
+func TestEndPodDnsFailure_RestoresNilDnsConfigViaEmptySentinel(t *testing.T) {
+	annotations := map[string]string{
+		ChaosBladeExperimentAnnotation:        "exp-1",
+		ChaosBladePodDnsFailureAnnotation:     ChaosBladePodDnsFailureAction,
+		ChaosBladeOriginalDnsPolicyAnnotation: `"ClusterFirst"`,
+		ChaosBladeOriginalDnsConfigAnnotation: "",
+	}
+	podSpec := &v1.PodSpec{
+		DNSPolicy: v1.DNSNone,
+		DNSConfig: &v1.PodDNSConfig{Nameservers: []string{UnreachableDnsNameserver}},
+	}
+
+	mutated, err := endPodDnsFailure(annotations, podSpec, "exp-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !mutated {
+		t.Fatal("endPodDnsFailure should return true on matching experiment id")
+	}
+	if podSpec.DNSConfig != nil {
+		t.Errorf("DNSConfig after restore = %+v, want nil (original was nil)", podSpec.DNSConfig)
+	}
+}
+
+func TestEndPodDnsFailure_NoMutationWhenExperimentMismatches(t *testing.T) {
+	annotations := map[string]string{
+		ChaosBladeExperimentAnnotation:        "exp-other",
+		ChaosBladeOriginalDnsPolicyAnnotation: `"ClusterFirst"`,
+	}
+	podSpec := &v1.PodSpec{
+		DNSPolicy: v1.DNSNone,
+		DNSConfig: &v1.PodDNSConfig{Nameservers: []string{UnreachableDnsNameserver}},
+	}
+
+	mutated, err := endPodDnsFailure(annotations, podSpec, "exp-1")
+	if err != nil {
+		t.Errorf("foreign experiment id must not surface as an error, got: %v", err)
+	}
+	if mutated {
+		t.Error("endPodDnsFailure must not report a mutation for a foreign experiment id")
+	}
+	if podSpec.DNSPolicy != v1.DNSNone {
+		t.Errorf("podSpec must remain untouched, got DNSPolicy=%v", podSpec.DNSPolicy)
+	}
+	if annotations[ChaosBladeExperimentAnnotation] != "exp-other" {
+		t.Errorf("foreign annotation must not be cleared, got %q",
+			annotations[ChaosBladeExperimentAnnotation])
+	}
+}
+
+func TestEndPodDnsFailure_NilAnnotationsIsNoOp(t *testing.T) {
+	podSpec := &v1.PodSpec{DNSPolicy: v1.DNSNone}
+	mutated, err := endPodDnsFailure(nil, podSpec, "exp-1")
+	if err != nil {
+		t.Errorf("nil annotations must not surface as an error, got: %v", err)
+	}
+	if mutated {
+		t.Error("endPodDnsFailure on nil annotations must return false")
+	}
+	if podSpec.DNSPolicy != v1.DNSNone {
+		t.Errorf("podSpec must remain untouched, got DNSPolicy=%v", podSpec.DNSPolicy)
+	}
+}
+
+func TestEndPodDnsFailure_MissingActionMarkerIsSafeNoOp(t *testing.T) {
+	// A workload that carries the experiment annotation but no DNS-failure
+	// action marker may have been touched by a different chaosblade action
+	// sharing the same experiment id, or already half-restored. Either way,
+	// the pod-DNS-failure restore must not touch it.
+	annotations := map[string]string{
+		ChaosBladeExperimentAnnotation:        "exp-1",
+		ChaosBladeOriginalDnsPolicyAnnotation: `"ClusterFirst"`,
+		ChaosBladeOriginalDnsConfigAnnotation: "",
+	}
+	podSpec := &v1.PodSpec{DNSPolicy: v1.DNSNone}
+
+	mutated, err := endPodDnsFailure(annotations, podSpec, "exp-1")
+	if err != nil {
+		t.Errorf("missing action marker must not surface as an error, got: %v", err)
+	}
+	if mutated {
+		t.Error("endPodDnsFailure must report no mutation when the action marker is absent")
+	}
+	if _, exists := annotations[ChaosBladeExperimentAnnotation]; !exists {
+		t.Error("experiment annotation must remain in place when action marker is absent")
+	}
+}
+
+// TestEndPodDnsFailure_StrictOnInvalidBackup is the regression test for the
+// high-severity code review finding: when the backed-up DNSPolicy/DNSConfig
+// cannot be decoded, the action MUST refuse to restore AND MUST keep the
+// chaosblade annotations in place so the workload can still be identified
+// and recovered (manually or via a retry after the annotation is repaired).
+//
+// The previous behaviour swallowed JSON errors and still deleted the
+// chaosblade.io/experiment annotation, which left the pod stranded with the
+// injected unreachable nameserver and no metadata to find it again.
+func TestEndPodDnsFailure_StrictOnInvalidBackup(t *testing.T) {
+	cases := []struct {
+		name        string
+		annotations map[string]string
+		wantErrFrag string
+	}{
+		{
+			name: "invalid policy JSON",
+			annotations: map[string]string{
+				ChaosBladeExperimentAnnotation:        "exp-1",
+				ChaosBladePodDnsFailureAnnotation:     ChaosBladePodDnsFailureAction,
+				ChaosBladeOriginalDnsPolicyAnnotation: `not-json`,
+				ChaosBladeOriginalDnsConfigAnnotation: "",
+			},
+			wantErrFrag: ChaosBladeOriginalDnsPolicyAnnotation,
+		},
+		{
+			name: "invalid config JSON",
+			annotations: map[string]string{
+				ChaosBladeExperimentAnnotation:        "exp-1",
+				ChaosBladePodDnsFailureAnnotation:     ChaosBladePodDnsFailureAction,
+				ChaosBladeOriginalDnsPolicyAnnotation: `"ClusterFirst"`,
+				ChaosBladeOriginalDnsConfigAnnotation: `not-json-either`,
+			},
+			wantErrFrag: ChaosBladeOriginalDnsConfigAnnotation,
+		},
+		{
+			name: "missing policy annotation",
+			annotations: map[string]string{
+				ChaosBladeExperimentAnnotation:        "exp-1",
+				ChaosBladePodDnsFailureAnnotation:     ChaosBladePodDnsFailureAction,
+				ChaosBladeOriginalDnsConfigAnnotation: "",
+			},
+			wantErrFrag: ChaosBladeOriginalDnsPolicyAnnotation,
+		},
+		{
+			name: "missing config annotation",
+			annotations: map[string]string{
+				ChaosBladeExperimentAnnotation:        "exp-1",
+				ChaosBladePodDnsFailureAnnotation:     ChaosBladePodDnsFailureAction,
+				ChaosBladeOriginalDnsPolicyAnnotation: `"ClusterFirst"`,
+			},
+			wantErrFrag: ChaosBladeOriginalDnsConfigAnnotation,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			// Snapshot the annotations so we can prove they are not mutated.
+			original := copyMap(tt.annotations)
+			podSpec := &v1.PodSpec{
+				DNSPolicy: v1.DNSNone,
+				DNSConfig: &v1.PodDNSConfig{Nameservers: []string{UnreachableDnsNameserver}},
+			}
+
+			mutated, err := endPodDnsFailure(tt.annotations, podSpec, "exp-1")
+			if err == nil {
+				t.Fatal("expected error, got nil — corruption must not be silently accepted")
+			}
+			if mutated {
+				t.Error("endPodDnsFailure must NOT report a mutation when the backup is corrupted")
+			}
+			if !strings.Contains(err.Error(), tt.wantErrFrag) {
+				t.Errorf("error %q must name the offending annotation %q", err.Error(), tt.wantErrFrag)
+			}
+
+			// Critical safety property: annotations MUST be left intact so a
+			// later destroy (after the operator repairs the value) can still
+			// identify and restore the workload.
+			for k, v := range original {
+				if got, ok := tt.annotations[k]; !ok || got != v {
+					t.Errorf("annotation %q was modified or removed on error path: got %q, want %q", k, got, v)
+				}
+			}
+			// And the podSpec MUST remain at the injected state so the
+			// workload is still in a known, identifiable configuration.
+			if podSpec.DNSPolicy != v1.DNSNone {
+				t.Errorf("podSpec.DNSPolicy was mutated on error path: %v", podSpec.DNSPolicy)
+			}
+			if podSpec.DNSConfig == nil ||
+				len(podSpec.DNSConfig.Nameservers) != 1 ||
+				podSpec.DNSConfig.Nameservers[0] != UnreachableDnsNameserver {
+				t.Errorf("podSpec.DNSConfig was mutated on error path: %+v", podSpec.DNSConfig)
+			}
+		})
+	}
+}
+
+// TestEndPodDnsFailure_AtomicityOnPartialCorruption locks in the "all-or-
+// nothing" invariant: even when ONE backup is valid and the OTHER is not,
+// neither half of the podSpec may be restored. This prevents a half-restored
+// workload that the next destroy attempt cannot fully recover.
+func TestEndPodDnsFailure_AtomicityOnPartialCorruption(t *testing.T) {
+	annotations := map[string]string{
+		ChaosBladeExperimentAnnotation:        "exp-1",
+		ChaosBladePodDnsFailureAnnotation:     ChaosBladePodDnsFailureAction,
+		ChaosBladeOriginalDnsPolicyAnnotation: `"ClusterFirst"`, // valid
+		ChaosBladeOriginalDnsConfigAnnotation: `not-json`,       // corrupted
+	}
+	podSpec := &v1.PodSpec{
+		DNSPolicy: v1.DNSNone,
+		DNSConfig: &v1.PodDNSConfig{Nameservers: []string{UnreachableDnsNameserver}},
+	}
+
+	mutated, err := endPodDnsFailure(annotations, podSpec, "exp-1")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if mutated {
+		t.Fatal("partial corruption must not yield a mutation")
+	}
+	// DNSPolicy was perfectly decodable, but the function must NOT have
+	// applied it because DNSConfig failed to decode.
+	if podSpec.DNSPolicy != v1.DNSNone {
+		t.Errorf("DNSPolicy was applied even though DNSConfig decode failed: %v", podSpec.DNSPolicy)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// resolveTopLevelWorkload (fake client)
+// ---------------------------------------------------------------------------
+
+func TestResolveTopLevelWorkload(t *testing.T) {
+	const ns = "default"
+	ctx := context.Background()
+
+	t.Run("pod owned by ReplicaSet which is owned by Deployment", func(t *testing.T) {
+		rs := newReplicaSet("nginx-7b8d", ns, controllerRef("Deployment", "nginx"))
+		c := newDnsTestClient(t, rs)
+		pod := newPod("nginx-7b8d-abc", ns, controllerRef("ReplicaSet", "nginx-7b8d"))
+
+		kind, name, err := resolveTopLevelWorkload(ctx, c, pod)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if kind != "Deployment" || name != "nginx" {
+			t.Errorf("got (%s, %s), want (Deployment, nginx)", kind, name)
+		}
+	})
+
+	t.Run("pod owned directly by DaemonSet", func(t *testing.T) {
+		c := newDnsTestClient(t)
+		pod := newPod("fluentd-x", ns, controllerRef("DaemonSet", "fluentd"))
+
+		kind, name, err := resolveTopLevelWorkload(ctx, c, pod)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if kind != "DaemonSet" || name != "fluentd" {
+			t.Errorf("got (%s, %s), want (DaemonSet, fluentd)", kind, name)
+		}
+	})
+
+	t.Run("pod owned directly by StatefulSet", func(t *testing.T) {
+		c := newDnsTestClient(t)
+		pod := newPod("redis-0", ns, controllerRef("StatefulSet", "redis"))
+
+		kind, name, err := resolveTopLevelWorkload(ctx, c, pod)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if kind != "StatefulSet" || name != "redis" {
+			t.Errorf("got (%s, %s), want (StatefulSet, redis)", kind, name)
+		}
+	})
+
+	t.Run("naked pod with no controller owner", func(t *testing.T) {
+		c := newDnsTestClient(t)
+		pod := newPod("loose-pod", ns)
+
+		_, _, err := resolveTopLevelWorkload(ctx, c, pod)
+		if err == nil || !strings.Contains(err.Error(), "no controller owner") {
+			t.Fatalf("expected no-controller-owner error, got: %v", err)
+		}
+	})
+
+	t.Run("pod owned by Job — unsupported", func(t *testing.T) {
+		c := newDnsTestClient(t)
+		pod := newPod("batch-pod", ns, controllerRef("Job", "batch-job"))
+
+		_, _, err := resolveTopLevelWorkload(ctx, c, pod)
+		if err == nil || !strings.Contains(err.Error(), "unsupported pod owner kind Job") {
+			t.Fatalf("expected unsupported-kind error for Job, got: %v", err)
+		}
+	})
+
+	t.Run("ReplicaSet not owned by a Deployment is rejected", func(t *testing.T) {
+		// Bare ReplicaSet (or owned by something other than Deployment) — the
+		// supported workload set requires the top-level controller to be a
+		// Deployment so it can be re-injected by name.
+		rs := newReplicaSet("bare-rs", ns)
+		c := newDnsTestClient(t, rs)
+		pod := newPod("bare-rs-x", ns, controllerRef("ReplicaSet", "bare-rs"))
+
+		_, _, err := resolveTopLevelWorkload(ctx, c, pod)
+		if err == nil || !strings.Contains(err.Error(), "not owned by a Deployment") {
+			t.Fatalf("expected not-owned-by-deployment error, got: %v", err)
+		}
+	})
+
+	t.Run("missing ReplicaSet surfaces the lookup error", func(t *testing.T) {
+		c := newDnsTestClient(t)
+		pod := newPod("orphan-x", ns, controllerRef("ReplicaSet", "missing-rs"))
+
+		_, _, err := resolveTopLevelWorkload(ctx, c, pod)
+		if err == nil || !strings.Contains(err.Error(), "get replicaset") {
+			t.Fatalf("expected replicaset lookup error, got: %v", err)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// injectWorkloadDnsFailure / restoreWorkloadDnsFailure (fake client)
+// ---------------------------------------------------------------------------
+
+func TestInjectAndRestoreWorkloadDnsFailure_Deployment(t *testing.T) {
+	const ns = "default"
+	original := v1.PodSpec{
+		DNSPolicy: v1.DNSClusterFirst,
+		DNSConfig: &v1.PodDNSConfig{Nameservers: []string{"10.96.0.10"}},
+	}
+	dep := newDeployment("nginx", ns, original, nil)
+	c := newDnsTestClient(t, dep)
+	executor := &PodDnsFailureActionExecutor{client: c}
+
+	if err := executor.injectWorkloadDnsFailure(context.Background(), ns, "Deployment", "nginx", "exp-1"); err != nil {
+		t.Fatalf("inject failed: %v", err)
+	}
+
+	mid := &appsv1.Deployment{}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "nginx"}, mid); err != nil {
+		t.Fatalf("get mid-state failed: %v", err)
+	}
+	if mid.Spec.Template.Spec.DNSPolicy != v1.DNSNone {
+		t.Errorf("post-inject DNSPolicy = %v, want DNSNone", mid.Spec.Template.Spec.DNSPolicy)
+	}
+	if mid.Spec.Template.Spec.DNSConfig == nil ||
+		mid.Spec.Template.Spec.DNSConfig.Nameservers[0] != UnreachableDnsNameserver {
+		t.Errorf("post-inject DNSConfig = %+v, want unreachable nameserver",
+			mid.Spec.Template.Spec.DNSConfig)
+	}
+	if mid.Annotations[ChaosBladeExperimentAnnotation] != "exp-1" {
+		t.Errorf("post-inject experiment annotation = %q, want exp-1",
+			mid.Annotations[ChaosBladeExperimentAnnotation])
+	}
+
+	if err := executor.restoreWorkloadDnsFailure(context.Background(), ns, "Deployment", "nginx", "exp-1"); err != nil {
+		t.Fatalf("restore failed: %v", err)
+	}
+
+	post := &appsv1.Deployment{}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "nginx"}, post); err != nil {
+		t.Fatalf("get post-state failed: %v", err)
+	}
+	if post.Spec.Template.Spec.DNSPolicy != v1.DNSClusterFirst {
+		t.Errorf("post-restore DNSPolicy = %v, want ClusterFirst", post.Spec.Template.Spec.DNSPolicy)
+	}
+	if post.Spec.Template.Spec.DNSConfig == nil ||
+		post.Spec.Template.Spec.DNSConfig.Nameservers[0] != "10.96.0.10" {
+		t.Errorf("post-restore DNSConfig = %+v, want nameserver 10.96.0.10",
+			post.Spec.Template.Spec.DNSConfig)
+	}
+	for _, k := range []string{
+		ChaosBladeExperimentAnnotation,
+		ChaosBladePodDnsFailureAnnotation,
+		ChaosBladeOriginalDnsPolicyAnnotation,
+		ChaosBladeOriginalDnsConfigAnnotation,
+	} {
+		if _, exists := post.Annotations[k]; exists {
+			t.Errorf("annotation %q must be cleared post-restore", k)
+		}
+	}
+}
+
+func TestInjectAndRestoreWorkloadDnsFailure_DaemonSet(t *testing.T) {
+	const ns = "default"
+	ds := newDaemonSet("fluentd", ns, v1.PodSpec{DNSPolicy: v1.DNSClusterFirstWithHostNet}, nil)
+	c := newDnsTestClient(t, ds)
+	executor := &PodDnsFailureActionExecutor{client: c}
+
+	if err := executor.injectWorkloadDnsFailure(context.Background(), ns, "DaemonSet", "fluentd", "exp-1"); err != nil {
+		t.Fatalf("inject failed: %v", err)
+	}
+	mid := &appsv1.DaemonSet{}
+	_ = c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "fluentd"}, mid)
+	if mid.Spec.Template.Spec.DNSPolicy != v1.DNSNone {
+		t.Errorf("DaemonSet DNSPolicy after inject = %v, want DNSNone", mid.Spec.Template.Spec.DNSPolicy)
+	}
+
+	if err := executor.restoreWorkloadDnsFailure(context.Background(), ns, "DaemonSet", "fluentd", "exp-1"); err != nil {
+		t.Fatalf("restore failed: %v", err)
+	}
+	post := &appsv1.DaemonSet{}
+	_ = c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "fluentd"}, post)
+	if post.Spec.Template.Spec.DNSPolicy != v1.DNSClusterFirstWithHostNet {
+		t.Errorf("DaemonSet DNSPolicy after restore = %v, want ClusterFirstWithHostNet",
+			post.Spec.Template.Spec.DNSPolicy)
+	}
+}
+
+func TestInjectAndRestoreWorkloadDnsFailure_StatefulSet(t *testing.T) {
+	const ns = "default"
+	sts := newStatefulSet("redis", ns, v1.PodSpec{DNSPolicy: v1.DNSDefault}, nil)
+	c := newDnsTestClient(t, sts)
+	executor := &PodDnsFailureActionExecutor{client: c}
+
+	if err := executor.injectWorkloadDnsFailure(context.Background(), ns, "StatefulSet", "redis", "exp-1"); err != nil {
+		t.Fatalf("inject failed: %v", err)
+	}
+	if err := executor.restoreWorkloadDnsFailure(context.Background(), ns, "StatefulSet", "redis", "exp-1"); err != nil {
+		t.Fatalf("restore failed: %v", err)
+	}
+	post := &appsv1.StatefulSet{}
+	_ = c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "redis"}, post)
+	if post.Spec.Template.Spec.DNSPolicy != v1.DNSDefault {
+		t.Errorf("StatefulSet DNSPolicy after restore = %v, want Default", post.Spec.Template.Spec.DNSPolicy)
+	}
+}
+
+func TestInjectWorkloadDnsFailure_UnsupportedKindFailsFast(t *testing.T) {
+	c := newDnsTestClient(t)
+	executor := &PodDnsFailureActionExecutor{client: c}
+
+	err := executor.injectWorkloadDnsFailure(context.Background(), "default", "Job", "batch", "exp-1")
+	if err == nil || !strings.Contains(err.Error(), "unsupported owner kind Job") {
+		t.Fatalf("expected unsupported-kind error, got: %v", err)
+	}
+}
+
+func TestRestoreWorkloadDnsFailure_MissingWorkloadIsNoOp(t *testing.T) {
+	c := newDnsTestClient(t) // no objects
+	executor := &PodDnsFailureActionExecutor{client: c}
+
+	if err := executor.restoreWorkloadDnsFailure(
+		context.Background(), "default", "Deployment", "ghost", "exp-1"); err != nil {
+		t.Errorf("restore of missing workload should be a no-op, got: %v", err)
+	}
+}
+
+func TestRestoreWorkloadDnsFailure_ForeignExperimentIsNoOp(t *testing.T) {
+	const ns = "default"
+	dep := newDeployment("nginx", ns,
+		v1.PodSpec{
+			DNSPolicy: v1.DNSNone,
+			DNSConfig: &v1.PodDNSConfig{Nameservers: []string{UnreachableDnsNameserver}},
+		},
+		map[string]string{
+			ChaosBladeExperimentAnnotation:        "exp-other",
+			ChaosBladePodDnsFailureAnnotation:     ChaosBladePodDnsFailureAction,
+			ChaosBladeOriginalDnsPolicyAnnotation: `"ClusterFirst"`,
+		},
+	)
+	c := newDnsTestClient(t, dep)
+	executor := &PodDnsFailureActionExecutor{client: c}
+
+	if err := executor.restoreWorkloadDnsFailure(context.Background(), ns, "Deployment", "nginx", "exp-1"); err != nil {
+		t.Fatalf("unexpected error on foreign restore: %v", err)
+	}
+	post := &appsv1.Deployment{}
+	_ = c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "nginx"}, post)
+	if post.Annotations[ChaosBladeExperimentAnnotation] != "exp-other" {
+		t.Errorf("foreign restore mutated experiment owner: %q",
+			post.Annotations[ChaosBladeExperimentAnnotation])
+	}
+	if post.Spec.Template.Spec.DNSPolicy != v1.DNSNone {
+		t.Errorf("foreign restore mutated DNSPolicy: %v", post.Spec.Template.Spec.DNSPolicy)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// restoreNamespaceWorkloads (fallback path)
+// ---------------------------------------------------------------------------
+
+func TestRestoreNamespaceWorkloads(t *testing.T) {
+	const ns = "default"
+	const expId = "exp-1"
+
+	injectedPodSpec := v1.PodSpec{
+		DNSPolicy: v1.DNSNone,
+		DNSConfig: &v1.PodDNSConfig{Nameservers: []string{UnreachableDnsNameserver}},
+	}
+	ownAnnotations := map[string]string{
+		ChaosBladeExperimentAnnotation:        expId,
+		ChaosBladePodDnsFailureAnnotation:     ChaosBladePodDnsFailureAction,
+		ChaosBladeOriginalDnsPolicyAnnotation: `"ClusterFirst"`,
+		ChaosBladeOriginalDnsConfigAnnotation: "",
+	}
+
+	// Owned by our experiment — should be restored.
+	depOwn := newDeployment("nginx", ns, injectedPodSpec, copyMap(ownAnnotations))
+	dsOwn := newDaemonSet("fluentd", ns, injectedPodSpec, copyMap(ownAnnotations))
+	stsOwn := newStatefulSet("redis", ns, injectedPodSpec, copyMap(ownAnnotations))
+
+	// Owned by a different experiment — must be left alone.
+	depForeign := newDeployment("nginx-foreign", ns, injectedPodSpec, map[string]string{
+		ChaosBladeExperimentAnnotation:        "exp-other",
+		ChaosBladePodDnsFailureAnnotation:     ChaosBladePodDnsFailureAction,
+		ChaosBladeOriginalDnsPolicyAnnotation: `"ClusterFirst"`,
+		ChaosBladeOriginalDnsConfigAnnotation: "",
+	})
+
+	// Carries our experiment annotation but is owned by another chaosblade
+	// *action* (e.g. taint, badresource). The DNS failure restore must not
+	// touch workloads it did not inject.
+	depWrongAction := newDeployment("nginx-wrong-action", ns, v1.PodSpec{DNSPolicy: v1.DNSClusterFirst},
+		map[string]string{
+			ChaosBladeExperimentAnnotation: expId,
+			// Note: no ChaosBladePodDnsFailureAnnotation marker.
+			"chaosblade.io/some-other-action": "true",
+		},
+	)
+
+	// No annotations — must be ignored.
+	depPlain := newDeployment("nginx-plain", ns,
+		v1.PodSpec{DNSPolicy: v1.DNSClusterFirst}, nil)
+
+	c := newDnsTestClient(t, depOwn, dsOwn, stsOwn, depForeign, depWrongAction, depPlain)
+	executor := &PodDnsFailureActionExecutor{client: c}
+
+	processed := map[string]bool{}
+	if err := executor.restoreNamespaceWorkloads(context.Background(), ns, expId, processed); err != nil {
+		t.Fatalf("restoreNamespaceWorkloads failed: %v", err)
+	}
+
+	// Owned workloads restored.
+	verifyDeploymentRestored(t, c, ns, "nginx")
+	verifyDaemonSetRestored(t, c, ns, "fluentd")
+	verifyStatefulSetRestored(t, c, ns, "redis")
+
+	// Foreign workload untouched.
+	gotForeign := &appsv1.Deployment{}
+	_ = c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "nginx-foreign"}, gotForeign)
+	if gotForeign.Annotations[ChaosBladeExperimentAnnotation] != "exp-other" {
+		t.Errorf("foreign-experiment workload was modified: annotation=%q",
+			gotForeign.Annotations[ChaosBladeExperimentAnnotation])
+	}
+	if gotForeign.Spec.Template.Spec.DNSPolicy != v1.DNSNone {
+		t.Errorf("foreign-experiment workload DNSPolicy was restored: %v",
+			gotForeign.Spec.Template.Spec.DNSPolicy)
+	}
+
+	// Wrong-action workload untouched (our annotation present but no DNS
+	// failure marker).
+	gotWrongAction := &appsv1.Deployment{}
+	_ = c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "nginx-wrong-action"}, gotWrongAction)
+	if gotWrongAction.Annotations[ChaosBladeExperimentAnnotation] != expId {
+		t.Errorf("wrong-action workload annotation was cleared by DNS restore: %q",
+			gotWrongAction.Annotations[ChaosBladeExperimentAnnotation])
+	}
+
+	// Verify processed map is populated so a second invocation is a no-op.
+	wantKeys := []string{
+		ns + "/Deployment/nginx",
+		ns + "/DaemonSet/fluentd",
+		ns + "/StatefulSet/redis",
+	}
+	for _, k := range wantKeys {
+		if !processed[k] {
+			t.Errorf("processed map missing key %q", k)
+		}
+	}
+}
+
+func TestRestoreNamespaceWorkloads_RespectsAlreadyProcessed(t *testing.T) {
+	const ns = "default"
+	const expId = "exp-1"
+
+	dep := newDeployment("nginx", ns,
+		v1.PodSpec{
+			DNSPolicy: v1.DNSNone,
+			DNSConfig: &v1.PodDNSConfig{Nameservers: []string{UnreachableDnsNameserver}},
+		},
+		map[string]string{
+			ChaosBladeExperimentAnnotation:        expId,
+			ChaosBladePodDnsFailureAnnotation:     ChaosBladePodDnsFailureAction,
+			ChaosBladeOriginalDnsPolicyAnnotation: `"ClusterFirst"`,
+			ChaosBladeOriginalDnsConfigAnnotation: "",
+		},
+	)
+	c := newDnsTestClient(t, dep)
+	executor := &PodDnsFailureActionExecutor{client: c}
+
+	// Pre-mark the workload as already processed; the namespace fallback must
+	// honor it and skip the Update entirely.
+	processed := map[string]bool{ns + "/Deployment/nginx": true}
+	if err := executor.restoreNamespaceWorkloads(context.Background(), ns, expId, processed); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	post := &appsv1.Deployment{}
+	_ = c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "nginx"}, post)
+	if post.Spec.Template.Spec.DNSPolicy != v1.DNSNone {
+		t.Errorf("workload was unexpectedly restored despite being pre-processed: %v",
+			post.Spec.Template.Spec.DNSPolicy)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end: Exec create → destroy round-trip
+// ---------------------------------------------------------------------------
+
+// TestExec_CreateThenDestroy_RoundTrip is the safety net the code review
+// asked for: it stitches together container context, owner resolution,
+// annotation backup, injection, and the namespace-wide restore fallback.
+func TestExec_CreateThenDestroy_RoundTrip(t *testing.T) {
+	const ns = "default"
+	originalSpec := v1.PodSpec{
+		DNSPolicy: v1.DNSClusterFirst,
+		DNSConfig: &v1.PodDNSConfig{Nameservers: []string{"10.96.0.10"}},
+	}
+
+	dep := newDeployment("nginx", ns, originalSpec, nil)
+	rs := newReplicaSet("nginx-7b8d", ns, controllerRef("Deployment", "nginx"))
+	pod := newPod("nginx-7b8d-abc", ns, controllerRef("ReplicaSet", "nginx-7b8d"))
+	pod.Spec = originalSpec
+
+	c := newDnsTestClient(t, dep, rs, pod)
+	executor := &PodDnsFailureActionExecutor{client: c}
+
+	containerMetas := model.ContainerMatchedList{
+		model.ContainerObjectMeta{
+			Id:        "container-1",
+			PodName:   "nginx-7b8d-abc",
+			Namespace: ns,
+		},
+	}
+	ctx := model.SetExperimentIdToContext(context.Background(), "exp-roundtrip")
+	ctx = model.SetContainerObjectMetaListToContext(ctx, containerMetas)
+
+	expModel := &spec.ExpModel{ActionFlags: map[string]string{}}
+
+	// Phase 1: create.
+	createResp := executor.Exec("uid-1", ctx, expModel)
+	if createResp == nil {
+		t.Fatal("create response is nil")
+	}
+	if status, ok := createResp.Result.(v1alpha1.ExperimentStatus); ok && !status.Success {
+		t.Fatalf("create failed: %s", status.Error)
+	}
+
+	mid := &appsv1.Deployment{}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "nginx"}, mid); err != nil {
+		t.Fatalf("get mid-state deployment failed: %v", err)
+	}
+	if mid.Spec.Template.Spec.DNSPolicy != v1.DNSNone {
+		t.Errorf("mid-state DNSPolicy = %v, want DNSNone", mid.Spec.Template.Spec.DNSPolicy)
+	}
+	if mid.Annotations[ChaosBladeExperimentAnnotation] != "exp-roundtrip" {
+		t.Errorf("mid-state experiment annotation = %q, want exp-roundtrip",
+			mid.Annotations[ChaosBladeExperimentAnnotation])
+	}
+	// The pod should have been deleted as part of injection so the controller
+	// recreates it with the faulty DNS config.
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "nginx-7b8d-abc"}, &v1.Pod{}); err == nil {
+		t.Error("expected the originally matched pod to be deleted after create")
+	}
+
+	// Phase 2: destroy. The original pod is gone, so the destroy path takes
+	// the namespace-wide fallback. This must still restore the workload.
+	destroyCtx := spec.SetDestroyFlag(ctx, "uid-1")
+	destroyResp := executor.Exec("uid-1", destroyCtx, expModel)
+	if destroyResp == nil {
+		t.Fatal("destroy response is nil")
+	}
+
+	verifyDeploymentRestored(t, c, ns, "nginx")
+}
+
+func TestExec_CreateFailsNameserverPrecondition(t *testing.T) {
+	const ns = "default"
+	dep := newDeployment("nginx", ns,
+		v1.PodSpec{
+			DNSPolicy: v1.DNSNone,
+			DNSConfig: &v1.PodDNSConfig{Nameservers: []string{"8.8.8.8"}},
+		}, nil)
+	rs := newReplicaSet("nginx-7b8d", ns, controllerRef("Deployment", "nginx"))
+	pod := newPod("nginx-7b8d-abc", ns, controllerRef("ReplicaSet", "nginx-7b8d"))
+	pod.Spec = v1.PodSpec{
+		DNSPolicy: v1.DNSNone,
+		DNSConfig: &v1.PodDNSConfig{Nameservers: []string{"8.8.8.8"}},
+	}
+
+	c := newDnsTestClient(t, dep, rs, pod)
+	executor := &PodDnsFailureActionExecutor{client: c}
+
+	containerMetas := model.ContainerMatchedList{
+		model.ContainerObjectMeta{
+			Id:        "container-1",
+			PodName:   "nginx-7b8d-abc",
+			Namespace: ns,
+		},
+	}
+	ctx := model.SetExperimentIdToContext(context.Background(), "exp-precondition")
+	ctx = model.SetContainerObjectMetaListToContext(ctx, containerMetas)
+
+	expModel := &spec.ExpModel{
+		ActionFlags: map[string]string{DnsFailureNameserverFlag: "10.96.0.10"},
+	}
+
+	resp := executor.Exec("uid-1", ctx, expModel)
+	if resp == nil {
+		t.Fatal("response is nil")
+	}
+	// The Deployment must NOT have been modified, because the strict-mode
+	// nameserver precondition was not satisfied.
+	post := &appsv1.Deployment{}
+	_ = c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "nginx"}, post)
+	if post.Spec.Template.Spec.DNSPolicy != v1.DNSNone {
+		t.Errorf("workload DNSPolicy after failed precondition = %v, want unchanged DNSNone",
+			post.Spec.Template.Spec.DNSPolicy)
+	}
+	if _, ok := post.Annotations[ChaosBladeExperimentAnnotation]; ok {
+		t.Errorf("workload was annotated even though precondition failed: %v",
+			post.Annotations)
+	}
+	// Pod was not deleted.
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "nginx-7b8d-abc"}, &v1.Pod{}); err != nil {
+		t.Errorf("pod must not be deleted when precondition fails: %v", err)
+	}
+
+	// The error reported back to ChaosBlade must explain exactly why the
+	// strict-mode precondition kicked in. Locking this string in prevents
+	// future refactors from silently regressing the message back to the
+	// vague "does not reference nameserver" wording that the code review
+	// found misleading.
+	status, ok := resp.Result.(v1alpha1.ExperimentStatus)
+	if !ok {
+		t.Fatalf("resp.Result is %T, want v1alpha1.ExperimentStatus", resp.Result)
+	}
+	if len(status.ResStatuses) != 1 {
+		t.Fatalf("got %d resource statuses, want 1", len(status.ResStatuses))
+	}
+	gotErr := status.ResStatuses[0].Error
+	for _, want := range []string{
+		"DNSPolicy=None",
+		"DNSConfig.Nameservers does not contain 10.96.0.10",
+		"PodSpec is authoritative",
+	} {
+		if !strings.Contains(gotErr, want) {
+			t.Errorf("precondition error %q must explain %q", gotErr, want)
+		}
+	}
+}
+
+// TestExec_CreateProceedsWhenPodSpecCannotDisprovePrecondition locks in the
+// other half of the documented contract: when the pod's PodSpec cannot prove
+// or disprove the requested nameserver (DNSConfig is nil, or DNSPolicy is
+// ClusterFirst with extra nameservers), the action treats the flag as a hint
+// and proceeds with injection. This is the half that the code review pointed
+// out is easy to miss when reading the (previously misleading) docs.
+func TestExec_CreateProceedsWhenPodSpecCannotDisprovePrecondition(t *testing.T) {
+	const ns = "default"
+
+	cases := []struct {
+		name    string
+		podSpec v1.PodSpec
+	}{
+		{
+			name:    "DNSConfig nil with ClusterFirst",
+			podSpec: v1.PodSpec{DNSPolicy: v1.DNSClusterFirst},
+		},
+		{
+			name: "DNSConfig set with extra nameservers under ClusterFirst",
+			podSpec: v1.PodSpec{
+				DNSPolicy: v1.DNSClusterFirst,
+				DNSConfig: &v1.PodDNSConfig{Nameservers: []string{"8.8.8.8"}},
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			dep := newDeployment("nginx", ns, tt.podSpec, nil)
+			rs := newReplicaSet("nginx-7b8d", ns, controllerRef("Deployment", "nginx"))
+			pod := newPod("nginx-7b8d-abc", ns, controllerRef("ReplicaSet", "nginx-7b8d"))
+			pod.Spec = tt.podSpec
+
+			c := newDnsTestClient(t, dep, rs, pod)
+			executor := &PodDnsFailureActionExecutor{client: c}
+
+			containerMetas := model.ContainerMatchedList{
+				model.ContainerObjectMeta{
+					Id:        "container-1",
+					PodName:   "nginx-7b8d-abc",
+					Namespace: ns,
+				},
+			}
+			ctx := model.SetExperimentIdToContext(context.Background(), "exp-hint")
+			ctx = model.SetContainerObjectMetaListToContext(ctx, containerMetas)
+
+			expModel := &spec.ExpModel{
+				ActionFlags: map[string]string{DnsFailureNameserverFlag: "10.96.0.10"},
+			}
+
+			if resp := executor.Exec("uid-1", ctx, expModel); resp == nil {
+				t.Fatal("response is nil")
+			}
+
+			// The Deployment WAS modified because the hint-mode precondition
+			// accepts what it cannot verify.
+			post := &appsv1.Deployment{}
+			_ = c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "nginx"}, post)
+			if post.Spec.Template.Spec.DNSPolicy != v1.DNSNone {
+				t.Errorf("hint-mode precondition must allow injection, but DNSPolicy = %v",
+					post.Spec.Template.Spec.DNSPolicy)
+			}
+			if post.Annotations[ChaosBladeExperimentAnnotation] != "exp-hint" {
+				t.Errorf("workload was not marked with experiment annotation: %v",
+					post.Annotations)
+			}
+		})
+	}
+}
+
+// TestExec_DestroyWithCorruptedAnnotationSurfacesFailureAndAllowsRetry is the
+// end-to-end regression test for the high-severity code review finding. It
+// proves three properties at the same time:
+//
+//  1. A destroy that hits a corrupted backup annotation reports a FAILURE
+//     status (not a misleading success).
+//  2. Every chaosblade.io annotation is preserved on the failure path so the
+//     workload is still identifiable for a retry.
+//  3. After the operator repairs the annotation, a follow-up destroy
+//     completes the restore — the workload does NOT get stranded.
+//
+// The previous lenient implementation silently swallowed the JSON error,
+// deleted chaosblade.io/experiment, and reported success — which left the
+// pod with the unreachable nameserver permanently and no way to identify it
+// for cleanup.
+func TestExec_DestroyWithCorruptedAnnotationSurfacesFailureAndAllowsRetry(t *testing.T) {
+	const ns = "default"
+
+	injectedSpec := v1.PodSpec{
+		DNSPolicy: v1.DNSNone,
+		DNSConfig: &v1.PodDNSConfig{Nameservers: []string{UnreachableDnsNameserver}},
+	}
+	// The deployment is in the "injected and corrupted" state: the marker
+	// and experiment annotations are correct, but the DNSPolicy backup is
+	// not parseable JSON (simulating an out-of-band edit or a serializer
+	// bug).
+	corruptedAnnotations := map[string]string{
+		ChaosBladeExperimentAnnotation:        "exp-retry",
+		ChaosBladePodDnsFailureAnnotation:     ChaosBladePodDnsFailureAction,
+		ChaosBladeOriginalDnsPolicyAnnotation: `corrupt-not-json`,
+		ChaosBladeOriginalDnsConfigAnnotation: "",
+	}
+
+	dep := newDeployment("nginx", ns, injectedSpec, corruptedAnnotations)
+	rs := newReplicaSet("nginx-7b8d", ns, controllerRef("Deployment", "nginx"))
+	pod := newPod("nginx-7b8d-abc", ns, controllerRef("ReplicaSet", "nginx-7b8d"))
+	pod.Spec = injectedSpec
+
+	c := newDnsTestClient(t, dep, rs, pod)
+	executor := &PodDnsFailureActionExecutor{client: c}
+
+	containerMetas := model.ContainerMatchedList{
+		model.ContainerObjectMeta{
+			Id:        "container-1",
+			PodName:   "nginx-7b8d-abc",
+			Namespace: ns,
+		},
+	}
+	ctx := model.SetExperimentIdToContext(context.Background(), "exp-retry")
+	ctx = model.SetContainerObjectMetaListToContext(ctx, containerMetas)
+	destroyCtx := spec.SetDestroyFlag(ctx, "uid-1")
+	expModel := &spec.ExpModel{ActionFlags: map[string]string{}}
+
+	// ----- First destroy: must surface a failure.
+	resp := executor.Exec("uid-1", destroyCtx, expModel)
+	if resp == nil {
+		t.Fatal("response is nil")
+	}
+	status, ok := resp.Result.(v1alpha1.ExperimentStatus)
+	if !ok {
+		t.Fatalf("unexpected result type %T", resp.Result)
+	}
+	if status.Success {
+		t.Fatalf("destroy with corrupted annotation must NOT report success, got: %+v", status)
+	}
+	if len(status.ResStatuses) == 0 {
+		t.Fatal("expected at least one resource status describing the failure")
+	}
+	gotErr := status.ResStatuses[0].Error
+	for _, want := range []string{"decode backed-up", ChaosBladeOriginalDnsPolicyAnnotation, "can be retried"} {
+		if !strings.Contains(gotErr, want) {
+			t.Errorf("failure status error %q must mention %q", gotErr, want)
+		}
+	}
+
+	// ----- The workload MUST be untouched: annotations preserved + podSpec
+	// still at the injected state. This is exactly the property the fix
+	// guarantees.
+	midDep := &appsv1.Deployment{}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "nginx"}, midDep); err != nil {
+		t.Fatalf("get mid-state deployment failed: %v", err)
+	}
+	for k, want := range corruptedAnnotations {
+		if got := midDep.Annotations[k]; got != want {
+			t.Errorf("annotation %q was modified on the failure path: got %q, want %q", k, got, want)
+		}
+	}
+	if midDep.Spec.Template.Spec.DNSPolicy != v1.DNSNone {
+		t.Errorf("podSpec.DNSPolicy was mutated on the failure path: %v",
+			midDep.Spec.Template.Spec.DNSPolicy)
+	}
+	if midDep.Spec.Template.Spec.DNSConfig == nil ||
+		midDep.Spec.Template.Spec.DNSConfig.Nameservers[0] != UnreachableDnsNameserver {
+		t.Errorf("podSpec.DNSConfig was mutated on the failure path: %+v",
+			midDep.Spec.Template.Spec.DNSConfig)
+	}
+
+	// ----- Operator repairs the annotation out-of-band. The remaining
+	// chaosblade metadata is still in place, so a follow-up destroy can
+	// pick up where the first one left off.
+	midDep.Annotations[ChaosBladeOriginalDnsPolicyAnnotation] = `"ClusterFirst"`
+	if err := c.Update(context.Background(), midDep); err != nil {
+		t.Fatalf("manual annotation repair failed: %v", err)
+	}
+
+	// ----- Second destroy: must complete the restore.
+	resp2 := executor.Exec("uid-1", destroyCtx, expModel)
+	if resp2 == nil {
+		t.Fatal("retry response is nil")
+	}
+	status2, ok := resp2.Result.(v1alpha1.ExperimentStatus)
+	if !ok {
+		t.Fatalf("unexpected retry result type %T", resp2.Result)
+	}
+	if !status2.Success {
+		t.Fatalf("retry destroy must succeed after repair, got: %+v", status2)
+	}
+
+	postDep := &appsv1.Deployment{}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: "nginx"}, postDep); err != nil {
+		t.Fatalf("get post-state deployment failed: %v", err)
+	}
+	if postDep.Spec.Template.Spec.DNSPolicy != v1.DNSClusterFirst {
+		t.Errorf("retry destroy must restore DNSPolicy, got %v", postDep.Spec.Template.Spec.DNSPolicy)
+	}
+	if postDep.Spec.Template.Spec.DNSConfig != nil {
+		t.Errorf("retry destroy must restore DNSConfig to nil (empty-string sentinel), got %+v",
+			postDep.Spec.Template.Spec.DNSConfig)
+	}
+	for _, k := range []string{
+		ChaosBladeExperimentAnnotation,
+		ChaosBladePodDnsFailureAnnotation,
+		ChaosBladeOriginalDnsPolicyAnnotation,
+		ChaosBladeOriginalDnsConfigAnnotation,
+	} {
+		if _, exists := postDep.Annotations[k]; exists {
+			t.Errorf("retry destroy must clear annotation %q after successful restore", k)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Shared assertion helpers
+// ---------------------------------------------------------------------------
+
+func verifyDeploymentRestored(t *testing.T, c *channel.Client, ns, name string) {
+	t.Helper()
+	got := &appsv1.Deployment{}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: name}, got); err != nil {
+		t.Fatalf("get %s/%s failed: %v", ns, name, err)
+	}
+	if got.Spec.Template.Spec.DNSPolicy != v1.DNSClusterFirst {
+		t.Errorf("%s DNSPolicy after restore = %v, want ClusterFirst",
+			name, got.Spec.Template.Spec.DNSPolicy)
+	}
+	for _, k := range []string{
+		ChaosBladeExperimentAnnotation,
+		ChaosBladePodDnsFailureAnnotation,
+		ChaosBladeOriginalDnsPolicyAnnotation,
+		ChaosBladeOriginalDnsConfigAnnotation,
+	} {
+		if _, exists := got.Annotations[k]; exists {
+			t.Errorf("%s annotation %q must be cleared after restore", name, k)
+		}
+	}
+}
+
+func verifyDaemonSetRestored(t *testing.T, c *channel.Client, ns, name string) {
+	t.Helper()
+	got := &appsv1.DaemonSet{}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: name}, got); err != nil {
+		t.Fatalf("get %s/%s failed: %v", ns, name, err)
+	}
+	if got.Spec.Template.Spec.DNSPolicy != v1.DNSClusterFirst {
+		t.Errorf("%s DNSPolicy after restore = %v, want ClusterFirst",
+			name, got.Spec.Template.Spec.DNSPolicy)
+	}
+}
+
+func verifyStatefulSetRestored(t *testing.T, c *channel.Client, ns, name string) {
+	t.Helper()
+	got := &appsv1.StatefulSet{}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: name}, got); err != nil {
+		t.Fatalf("get %s/%s failed: %v", ns, name, err)
+	}
+	if got.Spec.Template.Spec.DNSPolicy != v1.DNSClusterFirst {
+		t.Errorf("%s DNSPolicy after restore = %v, want ClusterFirst",
+			name, got.Spec.Template.Spec.DNSPolicy)
+	}
+}
+
+func copyMap(m map[string]string) map[string]string {
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}

--- a/exec/pod/pod.go
+++ b/exec/pod/pod.go
@@ -311,6 +311,18 @@ blade create k8s pod-pod failedmount --namespace default --workload-type deploym
 # Mount a non-existent pvc volume to a statefulset
 blade create k8s pod-pod failedmount --namespace default --workload-type statefulset --workload-name redis-app --volume-type pvc --kubeconfig ~/.kube/config`,
 				)
+			case *PodDnsFailureActionSpec:
+				action.SetLongDesc("Resolve the target pod's DNS configuration, then inject a complete DNS unavailability fault by overriding the owning workload's PodSpec to use an unreachable nameserver. The original DNSPolicy/DNSConfig is backed up to workload annotations and restored when the experiment is destroyed. The pod is deleted after injection so the controller recreates it with the faulty DNS configuration.")
+				action.SetExample(
+					`# Make all DNS queries from a pod fail by injecting an unreachable nameserver to its workload
+blade create k8s pod-pod dnsfailure --names nginx-app-xxx --namespace default --kubeconfig ~/.kube/config
+
+# Same as above but require that the pod is currently configured to use 10.96.0.10 as a nameserver
+blade create k8s pod-pod dnsfailure --names nginx-app-xxx --namespace default --nameserver 10.96.0.10 --kubeconfig ~/.kube/config
+
+# Inject DNS failure for pods selected by labels
+blade create k8s pod-pod dnsfailure --labels app=nginx --namespace default --kubeconfig ~/.kube/config`,
+				)
 			default:
 				action.SetExample(strings.Replace(
 					action.Example(),
@@ -359,6 +371,7 @@ func NewSelfExpModelCommandSpec(client *channel.Client) spec.ExpModelCommandSpec
 				NewPodTaintNodeActionSpec(client),
 				NewBadResourceSizeActionSpec(client),
 				NewFailedMountActionSpec(client),
+				NewPodDnsFailureActionSpec(client),
 			},
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -122,6 +122,7 @@ require (
 	google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a // indirect
 	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/hack/init.sh
+++ b/hack/init.sh
@@ -14,6 +14,30 @@
 # limitations under the License.
 
 
+# Ensure Go-installed tool binaries (goimports, gofumpt, ...) are reachable.
+#
+# The update-/verify- hack scripts run `go install <tool>@<version>` and then
+# invoke the binary by its bare name. `go install` writes to $GOBIN if set,
+# otherwise to $(go env GOPATH)/bin. On many developer machines that
+# directory is NOT on $PATH by default (notably default macOS shells with
+# Homebrew Go), which makes `make format` / `make verify` fail with
+#   "<tool>: command not found".
+#
+# Prepending the install dir here means every script that sources init.sh
+# picks up freshly installed tools without requiring developers to fiddle
+# with their shell rc files.
+__chaosblade_go_tool_dir="$(go env GOBIN 2>/dev/null || true)"
+if [[ -z "${__chaosblade_go_tool_dir}" ]]; then
+    __chaosblade_go_tool_dir="$(go env GOPATH 2>/dev/null || true)/bin"
+fi
+if [[ -n "${__chaosblade_go_tool_dir}" && "${__chaosblade_go_tool_dir}" != "/bin" ]]; then
+    case ":${PATH:-}:" in
+        *":${__chaosblade_go_tool_dir}:"*) ;;
+        *) export PATH="${__chaosblade_go_tool_dir}:${PATH:-}" ;;
+    esac
+fi
+unset __chaosblade_go_tool_dir
+
 function git_find() {
     # Similar to find but faster and easier to understand.  We want to include
     # modified and untracked files because this might be running against code


### PR DESCRIPTION
### Describe what this PR does / why we need it

在 chaosblade-operator 中新增两个 DNS Server 故障注入场景，分别覆盖 Cluster 与 Pod 两个维度，并在销毁实验时自动恢复原状：

1. **Cluster 级 DNS Server 故障**：根据 K8s 集群 DNS Service 地址（默认 `kube-dns` / `kube-system`，兼容 CoreDNS）反推出 DNS Server 工作负载，将其副本数缩容至 0，使整个集群的 DNS 解析完全不可用。
2. **Pod 级 DNS Server 故障**：根据指定的 Pod 名称（以及可选的 nameserver IP）查找该 Pod 的 DNS 配置，通过覆写其所属工作负载（Deployment/DaemonSet/StatefulSet）的 PodSpec，注入不可达的 nameserver `127.0.0.255`，使该 Pod 视角下的 DNS 解析完全不可用。

同步更新中英文 README 的 `Supported experiments` / `支持的场景` 章节，并提供示例 CR YAML。

### Does this pull request fix one issue?

NONE

### Describe how you did it

#### 1. 新增 `cluster` Scope（`exec/cluster/`）

- `cluster.go`：注册 `cluster` Scope 下的 `dns` 目标。
- `controller.go`：实现 `ExpController`，与现有 `pod` / `node` / `container` / `service` 的风格一致。
- `dnsfailure.go`：实现 `dnsfailure` Action：
  - 通过 `--dns-service` / `--dns-service-namespace` 找到集群 DNS Service。
  - 读取 `Service.Spec.Selector`，与同命名空间下的 Deployment 的 PodTemplate Labels 进行匹配，**反推出 DNS Server 工作负载**。
  - 使用 `RetryOnConflict` 包裹更新；将原始 `replicas` 序列化后存入 annotation，并将 `replicas` 缩容为 0。
  - 销毁时按实验 ID 校验 annotation，恢复原始副本数并清理 annotation。
- 在 `exec/controller.go` 中通过 `cluster.NewExpController(client)` 注册到分发器。

#### 2. 新增 Pod 级 `dnsfailure` Action（`exec/pod/dnsfailureexp.go`）

- 复用 Pod scope 既有的 `--names` / `--labels` / `--namespace` 选择能力，并附加可选的 `--nameserver` IP 校验。
- 沿 `OwnerReferences` 向上解析（`ReplicaSet → Deployment` / `DaemonSet` / `StatefulSet`）找到顶层工作负载。
- 备份 `PodTemplate.Spec.DNSPolicy` 与 `DNSConfig`（JSON 编码）至工作负载 annotation；将 `DNSPolicy` 改为 `None`，`DNSConfig.Nameservers` 设为不可路由的回环 `127.0.0.255`。
- 删除 Pod 触发控制器重建；多 Pod 共享同一 workload 时通过 `processedWorkloads` 去重。
- 销毁时优先按 Pod 反查 owner 走精确恢复路径；当 Pod 已不存在时回退按 namespace + 实验 ID annotation 枚举三类工作负载（Deployment/DaemonSet/StatefulSet）全量恢复。
- 在 `exec/pod/pod.go` 的 `NewSelfExpModelCommandSpec` 中注册，并补充 LongDesc 与 Example。

#### 3. 文档与示例

- `README.md` / `README_CN.md` 在 `Supported experiments` 章节：
  - Pod 类追加 DNS 项；
  - 末尾新增 `Cluster` 大类与 `DNS` 项。
- 新增 `examples/cluster-dns-failure.yaml`、`examples/pod-dns-failure.yaml`，可直接 `kubectl apply` 验证。

### Describe how to verify it

#### 本地构建 / 检查

```bash
go build ./...
go vet ./...
go test ./exec/pod/... ./exec/cluster/...
```

#### 集群 E2E（建议在测试集群执行）

1. 部署本变更后的 chaosblade-operator。
2. **Cluster 级 DNS 故障**：

```bash
kubectl apply -f examples/cluster-dns-failure.yaml
# 预期：kube-system/coredns（或 kube-dns）Deployment 副本数被缩为 0，
# 在任意 Pod 中 nslookup kubernetes.default 应失败。
kubectl delete -f examples/cluster-dns-failure.yaml
# 预期：Deployment 副本数恢复，集群 DNS 解析恢复正常。
```

3. **Pod 级 DNS 故障**：

```bash
kubectl apply -f examples/pod-dns-failure.yaml
# 预期：目标 Pod 重建后，进入新 Pod 执行 nslookup 失败；
# 工作负载 PodSpec 上可见 chaosblade.io/* 相关 annotation。
kubectl delete -f examples/pod-dns-failure.yaml
# 预期：工作负载 DNSPolicy/DNSConfig 恢复，重建后的 Pod DNS 解析正常。
```

#### chaosblade CLI

```bash
# Cluster
blade create k8s cluster-dns dnsfailure --kubeconfig ~/.kube/config

# Pod
blade create k8s pod-pod dnsfailure --names nginx-app-xxx --namespace default --kubeconfig ~/.kube/config
```

### Special notes for reviews

- 故障的恢复语义遵循现有 ChaosBlade Operator 的 reconciliation 模型，通过 `kubectl delete blade <name>` 触发 destroy 实现恢复，与 `schedulingfailure`、`badresourcesize` 等 Action 保持一致。
- Cluster Scope 为新增的顶层 Scope（与 `pod` / `node` / `container` / `service` 并列），后续可承接更多集群级故障（如 etcd、kube-proxy 等）。
- 所有写操作使用 `RetryOnConflict` 包裹，并通过 `chaosblade.io/experiment` annotation 防止跨实验冲突；幂等：相同实验 ID 二次注入无副作用。
- RBAC：当前 `deploy/helm/chaosblade-operator/templates/rbac.yaml` 已对 `services`、`deployments`、`daemonsets`、`statefulsets`、`pods` 授予 `*` 权限，本次实现未引入新的 API 资源，无需调整 RBAC。
- 注入 Cluster 级 DNS 故障会影响整个集群的服务发现（包括 operator 自身可能依赖的 DNS 解析），请仅在测试环境使用。

Signed-off-by: tdy218 <tdy218@gmail.com>
