### PR TITLE
fix: preserve status-identifier order in concurrent execution (#1279)

### DIFF
--- a/exec/model/executor_copy.go
+++ b/exec/model/executor_copy.go
@@ -149,7 +149,7 @@ func (e *ExecCommandInPodExecutor) Exec(uid string, ctx context.Context, expMode
 			experimentStatus.Error = "see resStatus for the error details"
 		}
 	}
-	experimentStatus.Success = success
+	experimentStatus.Success = finalSuccess
 	experimentStatus.ResStatuses = statuses
 
 	checkExperimentStatus(ctx, expModel, statuses, experimentIdentifiers, e.Client)

--- a/exec/model/executor_copy.go
+++ b/exec/model/executor_copy.go
@@ -73,7 +73,7 @@ func (e *ExecCommandInPodExecutor) Exec(uid string, ctx context.Context, expMode
 	}
 	logrusField.Infof("experiment identifiers: %v", experimentIdentifiers)
 
-	statuses := experimentStatus.ResStatuses
+	statuses := make([]v1alpha1.ResourceStatus, len(experimentIdentifiers))
 	success := true
 	_, isDestroy := spec.IsDestroy(ctx)
 	updateResultLock := &sync.Mutex{}
@@ -106,7 +106,6 @@ func (e *ExecCommandInPodExecutor) Exec(uid string, ctx context.Context, expMode
 					logrusField.Warningln(msg)
 					rsStatus.CreateSuccessResourceStatus()
 					rsStatus.Error = msg
-					success = true
 				} else {
 					// if get pod error, the execution is considered failure
 					msg := fmt.Sprintf("get pod: %s in %s error",
@@ -120,28 +119,38 @@ func (e *ExecCommandInPodExecutor) Exec(uid string, ctx context.Context, expMode
 			logrusField.Infof("execute identifier: %+v", identifier)
 			execSuccess, rsStatus = execCommands(isDestroy, rsStatus, identifier, e.Client)
 		}
-		updateResultLock.Lock()
-		statuses = append(statuses, rsStatus)
+		// Use direct index assignment to preserve order correspondence with experimentIdentifiers.
+		// No lock needed for slice write since each goroutine writes to its own index.
+		statuses[i] = rsStatus
 		// If false occurs once, the result is fails
-		success = success && execSuccess
-		updateResultLock.Unlock()
+		if !execSuccess {
+			updateResultLock.Lock()
+			success = false
+			updateResultLock.Unlock()
+		}
 	}
 
 	ParallelizeExec(len(experimentIdentifiers), execCommandInPod)
 
-	logrusField.Infof("success: %t, statuses: %+v", success, statuses)
-	if success {
+	// Read success under lock for defensive synchronization,
+	// although wg.Wait() in ParallelizeExec already provides happens-before.
+	updateResultLock.Lock()
+	finalSuccess := success
+	updateResultLock.Unlock()
+
+	logrusField.Infof("success: %t, statuses: %+v", finalSuccess, statuses)
+	if finalSuccess {
 		experimentStatus.State = v1alpha1.SuccessState
 	} else {
 		experimentStatus.State = v1alpha1.ErrorState
-		if len(statuses) == 0 {
+		if len(experimentIdentifiers) == 0 {
 			experimentStatus.Error = "the resources not found"
 		} else {
 			experimentStatus.Error = "see resStatus for the error details"
 		}
 	}
 	experimentStatus.Success = success
-	experimentStatus.ResStatuses = append(experimentStatus.ResStatuses, statuses...)
+	experimentStatus.ResStatuses = statuses
 
 	checkExperimentStatus(ctx, expModel, statuses, experimentIdentifiers, e.Client)
 	return spec.ReturnResultIgnoreCode(experimentStatus)

--- a/exec/model/executor_nsexec.go
+++ b/exec/model/executor_nsexec.go
@@ -135,7 +135,7 @@ func (e *CommonExecutor) Exec(uid string, ctx context.Context, expModel *spec.Ex
 			experimentStatus.Error = "see resStatus for the error details"
 		}
 	}
-	experimentStatus.Success = success
+	experimentStatus.Success = finalSuccess
 	experimentStatus.ResStatuses = statuses
 
 	checkExperimentStatus(ctx, expModel, statuses, experimentIdentifiers, e.Client)

--- a/exec/model/executor_nsexec.go
+++ b/exec/model/executor_nsexec.go
@@ -59,7 +59,7 @@ func (e *CommonExecutor) Exec(uid string, ctx context.Context, expModel *spec.Ex
 	}
 	logrusField.Infof("experiment identifiers: %v", experimentIdentifiers)
 
-	statuses := experimentStatus.ResStatuses
+	statuses := make([]v1alpha1.ResourceStatus, len(experimentIdentifiers))
 	success := true
 	_, isDestroy := spec.IsDestroy(ctx)
 	updateResultLock := &sync.Mutex{}
@@ -92,7 +92,6 @@ func (e *CommonExecutor) Exec(uid string, ctx context.Context, expModel *spec.Ex
 					logrusField.Warningln(msg)
 					rsStatus.CreateSuccessResourceStatus()
 					rsStatus.Error = msg
-					success = true
 				} else {
 					// if get pod error, the execution is considered failure
 					msg := fmt.Sprintf("get pod: %s in %s error",
@@ -106,28 +105,38 @@ func (e *CommonExecutor) Exec(uid string, ctx context.Context, expModel *spec.Ex
 			logrusField.Infof("execute identifier: %+v", identifier)
 			execSuccess, rsStatus = execCommands(isDestroy, rsStatus, identifier, e.Client)
 		}
-		updateResultLock.Lock()
-		statuses = append(statuses, rsStatus)
+		// Use direct index assignment to preserve order correspondence with experimentIdentifiers.
+		// No lock needed for slice write since each goroutine writes to its own index.
+		statuses[i] = rsStatus
 		// If false occurs once, the result is fails
-		success = success && execSuccess
-		updateResultLock.Unlock()
+		if !execSuccess {
+			updateResultLock.Lock()
+			success = false
+			updateResultLock.Unlock()
+		}
 	}
 
 	ParallelizeExec(len(experimentIdentifiers), execCommandInPod)
 
-	logrusField.Infof("success: %t, statuses: %+v", success, statuses)
-	if success {
+	// Read success under lock for defensive synchronization,
+	// although wg.Wait() in ParallelizeExec already provides happens-before.
+	updateResultLock.Lock()
+	finalSuccess := success
+	updateResultLock.Unlock()
+
+	logrusField.Infof("success: %t, statuses: %+v", finalSuccess, statuses)
+	if finalSuccess {
 		experimentStatus.State = v1alpha1.SuccessState
 	} else {
 		experimentStatus.State = v1alpha1.ErrorState
-		if len(statuses) == 0 {
+		if len(experimentIdentifiers) == 0 {
 			experimentStatus.Error = "the resources not found"
 		} else {
 			experimentStatus.Error = "see resStatus for the error details"
 		}
 	}
 	experimentStatus.Success = success
-	experimentStatus.ResStatuses = append(experimentStatus.ResStatuses, statuses...)
+	experimentStatus.ResStatuses = statuses
 
 	checkExperimentStatus(ctx, expModel, statuses, experimentIdentifiers, e.Client)
 	return spec.ReturnResultIgnoreCode(experimentStatus)


### PR DESCRIPTION
## Problem

When injecting faults into a large number of pods (e.g., 500 pods across 10 nodes), the `ParallelizeExec` function executes concurrently with up to 64 workers. The `statuses` slice was built using `append()` inside a mutex, resulting in **non-deterministic ordering**.

Later, `checkExperimentStatus()` iterates with:
```go
for i, status := range statuses {
    identifier := identifiers[i]  // ← WRONG INDEX
    podName := identifier.ChaosBladePodName
    response := client.Exec(..., "blade", "status", status.Id)
}
```

The index mismatch causes it to check experiment status on the **wrong chaosblade-tool pod**, leading to "not found" errors and inability to destroy experiments.

Fixes: https://github.com/chaosblade-io/chaosblade/issues/1279

## Root Cause

In `executor_nsexec.go` and `executor_copy.go`:
```go
statuses := experimentStatus.ResStatuses  // empty slice
execCommandInPod := func(i int) {
    // ...
    updateResultLock.Lock()
    statuses = append(statuses, rsStatus)  // ← ORDER IS NON-DETERMINISTIC
    success = success && execSuccess
    updateResultLock.Unlock()
}
ParallelizeExec(len(experimentIdentifiers), execCommandInPod)
```

Goroutines finish in arbitrary order, so `statuses[0]` might correspond to `identifiers[5]`, `statuses[1]` to `identifiers[2]`, etc.

## Fix

Pre-allocate the `statuses` slice and use **direct index assignment**:
```go
statuses := make([]v1alpha1.ResourceStatus, len(experimentIdentifiers))
execCommandInPod := func(i int) {
    // ...
    statuses[i] = rsStatus  // ← ORDER PRESERVED
    if !execSuccess {
        updateResultLock.Lock()
        success = false
        updateResultLock.Unlock()
    }
}
```

This ensures `statuses[i]` always corresponds to `experimentIdentifiers[i]`, regardless of goroutine completion order. The lock is only needed for the `success` boolean, not for the slice write (each goroutine writes to its own index).

## Changes

- `exec/model/executor_nsexec.go`: Pre-allocate statuses, use index assignment
- `exec/model/executor_copy.go`: Same fix applied

## Why It Only Manifests at Scale

With a small number of pods (< 10), goroutines often finish in order by chance. With 500 pods across 10 nodes, the variance in execution time across nodes makes the ordering mismatch almost certain.