### PR TITLE
fix(webhook): explicitly inject admission decoder to avoid nil panic

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ helm install chaosblade chaosblade-operator-arm64-${version}.tgz --namespace cha
 ```
 
 ## Install and uninstall
-The lowest version of kubernetes supported is 1.12. Chaosblade operator can be installed through kubectl or helm, the installation method is as follows:
+The lowest version of kubernetes supported is 1.22. Chaosblade operator can be installed through kubectl or helm, the installation method is as follows:
 
 Note: For the following `VERSION`, please use the latest version number instead
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -58,7 +58,7 @@ helm install chaosblade chaosblade-operator-arm64-${version}.tgz --namespace cha
 ```
 
 ## 安装&卸载
-支持的 Kubernetes 最小版本是 v1.12，chaosblade operator 可通过 kubectl 或者 helm 进行安装，安装方式如下：
+支持的 Kubernetes 最小版本是 v1.22，chaosblade operator 可通过 kubectl 或者 helm 进行安装，安装方式如下：
 注意：以下的 `VERSION` 请使用最新的版本号替代
 ### Helm v2
 * 在 [Release](https://github.com/chaosblade-io/chaosblade-operator/releases) 地址下载最新的 `chaosblade-operator-VERSION-v2.tgz` 包

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -48,8 +48,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/chaosblade-io/chaosblade-operator/channel"
 	"github.com/chaosblade-io/chaosblade-operator/pkg/apis"
+	"github.com/chaosblade-io/chaosblade-operator/pkg/apis/chaosblade/v1alpha1"
 	"github.com/chaosblade-io/chaosblade-operator/pkg/controller"
 	operator "github.com/chaosblade-io/chaosblade-operator/pkg/runtime"
 	"github.com/chaosblade-io/chaosblade-operator/pkg/runtime/chaosblade"
@@ -169,28 +172,27 @@ func createManager(cfg *rest.Config) (manager.Manager, error) {
 		return nil, err
 	}
 	logrus.Infof("Get watch namespace is %s", watchNamespace)
+	// Restrict only the ChaosBlade CR watch to watchNamespace. Other types
+	// (Pods/Nodes/etc.) must remain cluster-scoped because the operator
+	// reads pods in arbitrary namespaces (e.g. the chaosblade-tool DaemonSet
+	// namespace, or user-targeted pod namespaces). Using DefaultNamespaces
+	// would reject those reads with "unknown namespace for the cache".
+	bladeNamespaces := map[string]cache.Config{}
 	if strings.Contains(watchNamespace, ",") {
-		defaultNsps := make(map[string]cache.Config)
 		for _, nsp := range strings.Split(watchNamespace, ",") {
-			defaultNsps[nsp] = cache.Config{}
+			bladeNamespaces[nsp] = cache.Config{}
 		}
-		return manager.New(cfg, manager.Options{
-			Cache: cache.Options{
-				Scheme:            scheme,
-				DefaultNamespaces: defaultNsps,
-			},
-			Scheme: scheme,
-			MapperProvider: func(c *rest.Config, httpClient *http.Client) (meta.RESTMapper, error) {
-				return apiutil.NewDynamicRESTMapper(c, httpClient)
-			},
-			NewClient: channel.NewClientFunc(),
-		})
+	} else if watchNamespace != "" {
+		bladeNamespaces[watchNamespace] = cache.Config{}
+	}
+	cacheOpts := cache.Options{Scheme: scheme}
+	if len(bladeNamespaces) > 0 {
+		cacheOpts.ByObject = map[ctrlclient.Object]cache.ByObject{
+			&v1alpha1.ChaosBlade{}: {Namespaces: bladeNamespaces},
+		}
 	}
 	return manager.New(cfg, manager.Options{
-		Cache: cache.Options{
-			Scheme:            scheme,
-			DefaultNamespaces: map[string]cache.Config{watchNamespace: {}},
-		},
+		Cache:  cacheOpts,
 		Scheme: scheme,
 		MapperProvider: func(c *rest.Config, httpClient *http.Client) (meta.RESTMapper, error) {
 			return apiutil.NewDynamicRESTMapper(c, httpClient)

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -35,6 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtimeutil "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -146,7 +147,13 @@ func addWebhook(m manager.Manager) error {
 		return err
 	}
 	logrus.Infof("registering %s to the webhook server", "mutating-pods")
-	server.Register("/mutating-pods", &webhook.Admission{Handler: &mutator.Mutator{}})
+	// controller-runtime v0.15+ removed DecoderInjector; build the decoder
+	// from the manager's scheme and inject it explicitly to avoid a nil
+	// dereference inside Mutator.Handle.
+	decoder := admission.NewDecoder(m.GetScheme())
+	server.Register("/mutating-pods", &webhook.Admission{
+		Handler: mutator.NewMutator(m.GetClient(), decoder),
+	})
 	return nil
 }
 

--- a/pkg/controller/chaosblade/daemonset.go
+++ b/pkg/controller/chaosblade/daemonset.go
@@ -117,11 +117,11 @@ func createPodSpec() corev1.PodSpec {
 	pathType := corev1.HostPathFileOrCreate
 	periodSeconds := int64(30)
 	return corev1.PodSpec{
-		Containers:                    []corev1.Container{createContainer()},
-		Affinity:                      createAffinity(),
-		DNSPolicy:                     corev1.DNSClusterFirstWithHostNet,
-		HostNetwork:                   true,
-		HostPID:                       true,
+		Containers:  []corev1.Container{createContainer()},
+		Affinity:    createAffinity(),
+		DNSPolicy:   corev1.DNSClusterFirstWithHostNet,
+		HostNetwork: true,
+		HostPID:     true,
 		Tolerations: []corev1.Toleration{
 			{Effect: corev1.TaintEffectNoSchedule, Operator: corev1.TolerationOpExists},
 			{Effect: corev1.TaintEffectNoExecute, Operator: corev1.TolerationOpExists},

--- a/pkg/webhook/pod/mutator.go
+++ b/pkg/webhook/pod/mutator.go
@@ -49,7 +49,19 @@ type Mutator struct {
 	decoder admission.Decoder
 }
 
+// NewMutator constructs a Mutator with required dependencies.
+// In controller-runtime v0.15+ the DecoderInjector interface was removed,
+// so the decoder must be injected explicitly at registration time;
+// otherwise v.decoder will be nil and Handle() will panic.
+func NewMutator(c client.Client, d admission.Decoder) *Mutator {
+	return &Mutator{client: c, decoder: d}
+}
+
 func (v *Mutator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	if v.decoder == nil {
+		return admission.Errored(http.StatusInternalServerError,
+			fmt.Errorf("admission decoder is not initialized; use NewMutator to construct the handler"))
+	}
 	pod := &corev1.Pod{}
 	err := v.decoder.Decode(req, pod)
 	if err != nil {
@@ -173,13 +185,15 @@ func (v *Mutator) mutatePodsFn(pod *corev1.Pod) error {
 	return nil
 }
 
-// InjectClient injects the client.
+// InjectClient is kept for backward compatibility but is NOT called by
+// controller-runtime v0.15+ anymore. Prefer NewMutator for fresh wiring.
 func (v *Mutator) InjectClient(c client.Client) error {
 	v.client = c
 	return nil
 }
 
-// InjectDecoder injects the decoder.
+// InjectDecoder is kept for backward compatibility but is NOT called by
+// controller-runtime v0.15+ anymore. Prefer NewMutator for fresh wiring.
 func (v *Mutator) InjectDecoder(d admission.Decoder) error {
 	v.decoder = d
 	return nil


### PR DESCRIPTION
### Describe what this PR does / why we need it

Since controller-runtime v0.15, the `admission.DecoderInjector` interface has been removed and decoders are no longer injected into webhook handlers automatically. The pod mutating webhook was registered with a zero-value `Mutator`, so `Mutator.decoder` stayed nil and every pod creation matching the webhook rules panicked with `runtime error: invalid memory address or nil pointer dereference` in `Mutator.Handle`, which blocked business application deployment.

### Does this pull request fix one issue?

Fixes chaosblade-io/chaosblade#1342

### Describe how you did it

- Add a `NewMutator(c client.Client, d admission.Decoder)` constructor that wires the client and decoder explicitly
- Build the decoder from the manager scheme at registration time: `admission.NewDecoder(m.GetScheme())`
- Guard `Handle` with a nil-decoder check that returns HTTP 500 instead of panicking
- Keep `InjectClient`/`InjectDecoder` for backward compatibility, documented as no longer invoked by controller-runtime v0.15+
- Scope the informer cache namespace restriction to the ChaosBlade CR only (separate commit): `DefaultNamespaces` limited every resource type to `WATCH_NAMESPACE`, which made the operator fail reading pods in other namespaces with "unknown namespace for the cache"
- Update README to state the minimum supported Kubernetes version (1.22), since the legacy "1.12" claim predates the k8s.io v0.31 / controller-runtime v0.19 dependency stack

### Describe how to verify it

1. Deploy the operator built from this branch with `webhook-enable=true`
2. Create any Deployment whose pods match the webhook rules — pods should be created successfully and the operator log should no longer show "Observed a panic"
3. Deploy a pod annotated with `chaosblade/inject-volume` + `chaosblade/inject-volume-subpath` and confirm the `chaosblade-fuse` sidecar is injected

### Special notes for reviews

- Both fix commits are signed off (DCO)
- A linux/amd64 image was built from this branch and verified locally
- **Note**: this PR also carries `style: fix gofumpt alignment in daemonset.go`, fixing a formatting violation introduced by #306 (bd51c8f). That violation breaks `make verify` on **every** PR based on current master, so fixing it here is required for CI to pass. Please merge this PR (or the style fix) before other pending PRs.

Signed-off-by: tdy218 <tdy218@gmail.com>